### PR TITLE
fix: wrong boost libraries found at runtime; use static boost libraries

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,8 @@ project(${PROJECT_NAME_STR} C CXX)
 
 find_package(Threads REQUIRED)
 find_package(ZLIB REQUIRED)
+
+set(Boost_USE_STATIC_LIBS ON)
 find_package(Boost 1.62.0 COMPONENTS system filesystem iostreams REQUIRED)
 
 # C++11 required


### PR DESCRIPTION
I tested this on d80db6dd534ee4b48626e0b336a4eee9df1607ad which is a little while back. But I'm feeling confident that it will work with the latest dev branch commits.

When I tested it, all unit tests pass on Yoda passed. Seg fault during tests was fixed. The wrong boost shared libraries were used at runtime. I avoided that problem by linking against boost static libraries.

@mbhall88 please remove `/nfs/leia/research/iqbal/software/boost_1_62_0`. I think that source/build files should be here: `/nfs/leia/research/iqbal/software/tmp`.
