### PR TITLE
Remove possibility of duplicate coordinates

### DIFF
--- a/include/extract_reads.h
+++ b/include/extract_reads.h
@@ -20,7 +20,7 @@ find_interval_in_localpath(const Interval &, const vector<LocalNodePtr> &, const
 std::set<MinimizerHitPtr, pComp_path> hits_along_path(const std::set<MinimizerHitPtr, pComp_path>&,
                                                        const std::vector<LocalNodePtr>&);
 
-void get_read_overlap_coordinates(PanNodePtr, std::vector<std::vector<uint32_t>>&, std::vector<LocalNodePtr>&);
+void get_read_overlap_coordinates(PanNodePtr, set<uint32_t> &, std::vector<LocalNodePtr> &);
 
 void save_read_strings_to_denovo_assemble(const std::string&,
                                           const std::string&,

--- a/include/extract_reads.h
+++ b/include/extract_reads.h
@@ -12,25 +12,26 @@
 
 typedef std::shared_ptr<pangenome::Node> PanNodePtr;
 
-std::vector<Interval> identify_regions(const std::vector<uint32_t>&, const uint32_t& threshold=0, const uint32_t& min_length=0);
+std::vector<Interval>
+identify_regions(const std::vector<uint32_t> &, const uint32_t &threshold = 0, const uint32_t &min_length = 0);
 
 vector<LocalNodePtr>
 find_interval_in_localpath(const Interval &, const vector<LocalNodePtr> &, const unsigned int &buff);
 
-std::set<MinimizerHitPtr, pComp_path> hits_along_path(const std::set<MinimizerHitPtr, pComp_path>&,
-                                                       const std::vector<LocalNodePtr>&);
+std::set<MinimizerHitPtr, pComp_path> hits_along_path(const std::set<MinimizerHitPtr, pComp_path> &,
+                                                      const std::vector<LocalNodePtr> &);
 
-void get_read_overlap_coordinates(PanNodePtr, set<uint32_t> &, std::vector<LocalNodePtr> &);
+void get_read_overlap_coordinates(PanNodePtr, std::set<std::vector<uint32_t>> &, std::vector<LocalNodePtr> &);
 
-void save_read_strings_to_denovo_assemble(const std::string&,
-                                          const std::string&,
+void save_read_strings_to_denovo_assemble(const std::string &,
+                                          const std::string &,
                                           const PanNodePtr,
-                                          const std::vector<LocalNodePtr>&,
-                                          const std::vector<KmerNodePtr>&,
-                                          const unsigned int &buff=0,
-                                          const uint32_t& threshold = 2,
-                                          const uint32_t& min_length = 5
-                                          );
+                                          const std::vector<LocalNodePtr> &,
+                                          const std::vector<KmerNodePtr> &,
+                                          const unsigned int &buff = 0,
+                                          const uint32_t &threshold = 2,
+                                          const uint32_t &min_length = 5
+);
 
 
 Interval apply_buffer_to_interval(const Interval &interval, const int32_t &buff);

--- a/src/extract_reads.cpp
+++ b/src/extract_reads.cpp
@@ -154,7 +154,7 @@ set<MinimizerHitPtr, pComp_path> hits_along_path(const set<MinimizerHitPtr, pCom
     return subset;
 }
 
-void get_read_overlap_coordinates(PanNodePtr pnode, vector<vector<uint32_t>> &read_overlap_coordinates,
+void get_read_overlap_coordinates(PanNodePtr pnode, set<uint32_t> &read_overlap_coordinates,
                                   vector<LocalNodePtr> &lmp) {
     read_overlap_coordinates.clear();
     read_overlap_coordinates.reserve(pnode->reads.size());
@@ -184,7 +184,7 @@ void get_read_overlap_coordinates(PanNodePtr pnode, vector<vector<uint32_t>> &re
                                                                                  << "Found end " << end
                                                                                  << " after found start " << start));
         coordinate = {read_ptr->id, start, end, (*hit_ptr_iter)->strand};
-        read_overlap_coordinates.push_back(coordinate);
+        read_overlap_coordinates.insert(coordinate);
     }
 
     if (read_overlap_coordinates.size() > 0) {
@@ -225,8 +225,8 @@ void save_read_strings_to_denovo_assemble(const string &readfilepath,
     FastaqHandler readfile(readfilepath);
     Fastaq fa;
     uint32_t start, end;
-    vector <vector<uint32_t>> read_overlap_coordinates;
-    vector <LocalNodePtr> sub_lmp;
+    std::set <std::vector<uint32_t>> read_overlap_coordinates;
+    std::vector <LocalNodePtr> sub_lmp;
 
     for (auto interval : intervals) {
 

--- a/src/extract_reads.cpp
+++ b/src/extract_reads.cpp
@@ -157,7 +157,6 @@ set<MinimizerHitPtr, pComp_path> hits_along_path(const set<MinimizerHitPtr, pCom
 void get_read_overlap_coordinates(PanNodePtr pnode, set<uint32_t> &read_overlap_coordinates,
                                   vector<LocalNodePtr> &lmp) {
     read_overlap_coordinates.clear();
-    read_overlap_coordinates.reserve(pnode->reads.size());
     vector <uint32_t> coordinate;
 
     auto read_count = 0;
@@ -187,7 +186,7 @@ void get_read_overlap_coordinates(PanNodePtr pnode, set<uint32_t> &read_overlap_
         read_overlap_coordinates.insert(coordinate);
     }
 
-    if (read_overlap_coordinates.size() > 0) {
+    if (not read_overlap_coordinates.empty()) {
         sort(read_overlap_coordinates.begin(), read_overlap_coordinates.end(),
              [](const vector <uint32_t> &a, const vector <uint32_t> &b) {
                  for (uint32_t i = 0; i < a.size(); ++i) {

--- a/src/extract_reads.cpp
+++ b/src/extract_reads.cpp
@@ -224,7 +224,7 @@ void save_read_strings_to_denovo_assemble(const string &readfilepath,
         get_read_overlap_coordinates(pnode, read_overlap_coordinates, sub_lmp);
 
         uint16_t j = 0;
-        for (auto coord : read_overlap_coordinates) {
+        for (const auto &coord : read_overlap_coordinates) {
             BOOST_LOG_TRIVIAL(debug) << "\nLooking at coordinate j = " << +j << " {" << coord[0] << "," << coord[1]
                                      << "," << coord[2] << "," << coord[3] << "}";
             j++;

--- a/src/extract_reads.cpp
+++ b/src/extract_reads.cpp
@@ -185,17 +185,6 @@ void get_read_overlap_coordinates(PanNodePtr pnode, set<uint32_t> &read_overlap_
         coordinate = {read_ptr->id, start, end, (*hit_ptr_iter)->strand};
         read_overlap_coordinates.insert(coordinate);
     }
-
-    if (not read_overlap_coordinates.empty()) {
-        sort(read_overlap_coordinates.begin(), read_overlap_coordinates.end(),
-             [](const vector <uint32_t> &a, const vector <uint32_t> &b) {
-                 for (uint32_t i = 0; i < a.size(); ++i) {
-                     if (a[i] != b[i]) { return a[i] < b[i]; }
-                 }
-                 return false;
-             });
-    }
-
 }
 
 void save_read_strings_to_denovo_assemble(const string &readfilepath,

--- a/src/extract_reads.cpp
+++ b/src/extract_reads.cpp
@@ -154,13 +154,13 @@ set<MinimizerHitPtr, pComp_path> hits_along_path(const set<MinimizerHitPtr, pCom
     return subset;
 }
 
-void get_read_overlap_coordinates(PanNodePtr pnode, set<uint32_t> &read_overlap_coordinates,
+void get_read_overlap_coordinates(PanNodePtr pnode, std::set<std::vector<uint32_t>> &read_overlap_coordinates,
                                   vector<LocalNodePtr> &lmp) {
     read_overlap_coordinates.clear();
-    std::vector <uint32_t> coordinate;
+    std::vector<uint32_t> coordinate;
 
     auto read_count = 0;
-    for (const auto read_ptr : pnode->reads) {
+    for (const auto &read_ptr : pnode->reads) {
         read_count++;
         auto read_hits_along_path = hits_along_path(read_ptr->hits.at(pnode->prg_id), lmp);
         if (read_hits_along_path.size() < 2) {
@@ -170,7 +170,7 @@ void get_read_overlap_coordinates(PanNodePtr pnode, set<uint32_t> &read_overlap_
         auto hit_ptr_iter = read_hits_along_path.begin();
         uint32_t start = (*hit_ptr_iter)->read_start_position;
         uint32_t end = 0;
-        for (const auto hit_ptr : read_hits_along_path) {
+        for (const auto &hit_ptr : read_hits_along_path) {
             start = min(start, hit_ptr->read_start_position);
             end = max(end, hit_ptr->read_start_position + hit_ptr->prg_path.length());
         }
@@ -200,8 +200,8 @@ void save_read_strings_to_denovo_assemble(const string &readfilepath,
     // level for boost logging
     logging::core::get()->set_filter(logging::trivial::severity >= g_log_level);
 
-    vector <uint32_t> covgs = get_covgs_along_localnode_path(pnode, lmp, kmp);
-    vector <Interval> intervals = identify_regions(covgs, threshold, min_length);
+    vector<uint32_t> covgs = get_covgs_along_localnode_path(pnode, lmp, kmp);
+    vector<Interval> intervals = identify_regions(covgs, threshold, min_length);
 
     if (intervals.empty()) {
         return;
@@ -213,8 +213,8 @@ void save_read_strings_to_denovo_assemble(const string &readfilepath,
     FastaqHandler readfile(readfilepath);
     Fastaq fa;
     uint32_t start, end;
-    std::set <std::vector<uint32_t>> read_overlap_coordinates;
-    std::vector <LocalNodePtr> sub_lmp;
+    std::set<std::vector<uint32_t>> read_overlap_coordinates;
+    std::vector<LocalNodePtr> sub_lmp;
 
     for (auto interval : intervals) {
 
@@ -342,7 +342,7 @@ void save_read_strings_to_denovo_assemble(const string &readfilepath,
                 }
 
                 local_assembly(sequences, start_kmers, end_kmers, out_path, g_local_assembly_kmer_size, max_path_length,
-                slice_coverage);
+                               slice_coverage);
 
                 BOOST_LOG_TRIVIAL(info) << " Finished local assembly for "
                                         << pnode->get_name() + "." + to_string(interval.start) + "-" +

--- a/src/extract_reads.cpp
+++ b/src/extract_reads.cpp
@@ -157,7 +157,7 @@ set<MinimizerHitPtr, pComp_path> hits_along_path(const set<MinimizerHitPtr, pCom
 void get_read_overlap_coordinates(PanNodePtr pnode, set<uint32_t> &read_overlap_coordinates,
                                   vector<LocalNodePtr> &lmp) {
     read_overlap_coordinates.clear();
-    vector <uint32_t> coordinate;
+    std::vector <uint32_t> coordinate;
 
     auto read_count = 0;
     for (const auto read_ptr : pnode->reads) {

--- a/test/extract_reads_test.cpp
+++ b/test/extract_reads_test.cpp
@@ -534,7 +534,6 @@ TEST(ExtractReadsTest, get_read_overlap_coordinates) {
 
     get_read_overlap_coordinates(pn, overlaps, lmp);
 
-
     EXPECT_ITERABLE_EQ(std::set<std::vector<uint32_t>>, expected_overlaps, overlaps);
 }
 

--- a/test/extract_reads_test.cpp
+++ b/test/extract_reads_test.cpp
@@ -545,6 +545,324 @@ TEST(ExtractReadsTest, get_read_overlap_coordinates) {
 }
 
 
+TEST(ExtractReadsTest, get_read_overlap_coordinates_no_duplicates) {
+    //
+    //  Read 0 has prg 3 sequence in interval (2,12] only
+    //  Read 1 has prg 3 sequence in interval (6,16] as well as noise
+    //  Read 2 has prg 3 sequence in interval (4,20] stretched out
+    //  Read 3 has prg 3 sequence in interval (4,14] but is missing bits
+    //  Read 4 doesn't have prg 3 sequence - on all hits are noise
+    //  Read 5 is a duplicate of Read 0
+    //
+    uint32_t pnode_id=3, prg_id=3, read_id = 0, knode_id = 0;
+    string pnode_name = "three";
+    bool orientation(true);
+    deque<Interval> d;
+    prg::Path prg_path;
+    MinimizerHitPtr mh;
+
+    PanNodePtr pn= make_shared<pangenome::Node>(pnode_id, prg_id, pnode_name);
+    PanReadPtr pr = make_shared<pangenome::Read>(read_id);
+
+    set<MinimizerHitPtr, pComp> hits;
+
+
+    // READ 0
+    // hits overlapping edges of path
+    d = {Interval(0,1), Interval(4,5), Interval(8,9)};
+    prg_path.initialize(d);
+    mh = make_shared<MinimizerHit>(read_id, Interval(2,5), prg_id, prg_path, knode_id, orientation);
+    hits.insert(mh);
+    d = {Interval(29,30), Interval(33,33), Interval(40,42)};
+    prg_path.initialize(d);
+    mh = make_shared<MinimizerHit>(read_id, Interval(8,11), prg_id, prg_path, knode_id, orientation);
+    hits.insert(mh);
+    d = {Interval(28,30), Interval(33,33), Interval(40,41)};
+    prg_path.initialize(d);
+    mh = make_shared<MinimizerHit>(read_id, Interval(7,10), prg_id, prg_path, knode_id, orientation);
+    hits.insert(mh);
+
+    // hits on path
+    d = {Interval(4,5), Interval(8,9), Interval(16,17)};
+    prg_path.initialize(d);
+    mh = make_shared<MinimizerHit>(read_id, Interval(3,6), prg_id, prg_path, knode_id, orientation);
+    hits.insert(mh);
+    d = {Interval(8,9), Interval(16,17), Interval(27,28)};
+    prg_path.initialize(d);
+    mh = make_shared<MinimizerHit>(read_id, Interval(4,7), prg_id, prg_path, knode_id, orientation);
+    hits.insert(mh);
+    d = {Interval(16,17), Interval(27,29)};
+    prg_path.initialize(d);
+    mh = make_shared<MinimizerHit>(read_id, Interval(5,8), prg_id, prg_path, knode_id, orientation);
+    hits.insert(mh);
+    d = {Interval(27,30)};
+    prg_path.initialize(d);
+    mh = make_shared<MinimizerHit>(read_id, Interval(6,9), prg_id, prg_path, knode_id, orientation);
+    hits.insert(mh);
+
+    pr->add_hits(prg_id,hits);
+    pn->reads.insert(pr);
+    hits.clear();
+
+    // READ 1
+    read_id = 1;
+    pr = make_shared<pangenome::Read>(read_id);
+
+    // hits overlapping edges of path
+    d = {Interval(0,1), Interval(4,5), Interval(8,9)};
+    prg_path.initialize(d);
+    mh = make_shared<MinimizerHit>(read_id, Interval(6,9), prg_id, prg_path, knode_id, orientation);
+    hits.insert(mh);
+    d = {Interval(29,30), Interval(33,33), Interval(40,42)};
+    prg_path.initialize(d);
+    mh = make_shared<MinimizerHit>(read_id, Interval(12,15), prg_id, prg_path, knode_id, orientation);
+    hits.insert(mh);
+    d = {Interval(28,30), Interval(33,33), Interval(40,41)};
+    prg_path.initialize(d);
+    mh = make_shared<MinimizerHit>(read_id, Interval(11,14), prg_id, prg_path, knode_id, orientation);
+    hits.insert(mh);
+
+    // hits on path
+    d = {Interval(4,5), Interval(8,9), Interval(16,17)};
+    prg_path.initialize(d);
+    mh = make_shared<MinimizerHit>(read_id, Interval(7,10), prg_id, prg_path, knode_id, orientation);
+    hits.insert(mh);
+    d = {Interval(8,9), Interval(16,17), Interval(27,28)};
+    prg_path.initialize(d);
+    mh = make_shared<MinimizerHit>(read_id, Interval(8,11), prg_id, prg_path, knode_id, orientation);
+    hits.insert(mh);
+    d = {Interval(16,17), Interval(27,29)};
+    prg_path.initialize(d);
+    mh = make_shared<MinimizerHit>(read_id, Interval(9,12), prg_id, prg_path, knode_id, orientation);
+    hits.insert(mh);
+    d = {Interval(27,30)};
+    prg_path.initialize(d);
+    mh = make_shared<MinimizerHit>(read_id, Interval(10,13), prg_id, prg_path, knode_id, orientation);
+    hits.insert(mh);
+
+    // noise
+    d = {Interval(7,8), Interval(16, 17), Interval(27,28)};
+    prg_path.initialize(d);
+    mh = make_shared<MinimizerHit>(read_id, Interval(1,4), prg_id, prg_path, knode_id, orientation);
+    hits.insert(mh);
+    mh = make_shared<MinimizerHit>(read_id, Interval(8,11), prg_id, prg_path, knode_id, orientation);
+    hits.insert(mh);
+    d = {Interval(29, 30), Interval(31,33)};
+    prg_path.initialize(d);
+    mh = make_shared<MinimizerHit>(read_id, Interval(9,12), prg_id, prg_path, knode_id, orientation);
+    hits.insert(mh);
+    d = {Interval(78,81)};
+    prg_path.initialize(d);
+    mh = make_shared<MinimizerHit>(read_id, Interval(13,16), prg_id, prg_path, knode_id, orientation);
+    hits.insert(mh);
+
+    pr->add_hits(prg_id,hits);
+    pn->reads.insert(pr);
+    hits.clear();
+
+    // READ 2
+    read_id = 2;
+    pr = make_shared<pangenome::Read>(read_id);
+
+    // hits overlapping edges of path
+    d = {Interval(0,1), Interval(4,5), Interval(8,9)};
+    prg_path.initialize(d);
+    mh = make_shared<MinimizerHit>(read_id, Interval(4,7), prg_id, prg_path, knode_id, orientation);
+    hits.insert(mh);
+    d = {Interval(29,30), Interval(33,33), Interval(40,42)};
+    prg_path.initialize(d);
+    mh = make_shared<MinimizerHit>(read_id, Interval(17,20), prg_id, prg_path, knode_id, orientation);
+    hits.insert(mh);
+    d = {Interval(28,30), Interval(33,33), Interval(40,41)};
+    prg_path.initialize(d);
+    mh = make_shared<MinimizerHit>(read_id, Interval(15,18), prg_id, prg_path, knode_id, orientation);
+    hits.insert(mh);
+
+    // hits on path
+    d = {Interval(4,5), Interval(8,9), Interval(16,17)};
+    prg_path.initialize(d);
+    mh = make_shared<MinimizerHit>(read_id, Interval(5,8), prg_id, prg_path, knode_id, orientation);
+    hits.insert(mh);
+    d = {Interval(8,9), Interval(16,17), Interval(27,28)};
+    prg_path.initialize(d);
+    mh = make_shared<MinimizerHit>(read_id, Interval(8,11), prg_id, prg_path, knode_id, orientation);
+    hits.insert(mh);
+    d = {Interval(16,17), Interval(27,29)};
+    prg_path.initialize(d);
+    mh = make_shared<MinimizerHit>(read_id, Interval(9,12), prg_id, prg_path, knode_id, orientation);
+    hits.insert(mh);
+    d = {Interval(27,30)};
+    prg_path.initialize(d);
+    mh = make_shared<MinimizerHit>(read_id, Interval(10,13), prg_id, prg_path, knode_id, orientation);
+    hits.insert(mh);
+
+    // noise
+    d = {Interval(7,8), Interval(16, 17), Interval(27,28)};
+    prg_path.initialize(d);
+    mh = make_shared<MinimizerHit>(read_id, Interval(1,4), prg_id, prg_path, knode_id, orientation);
+    hits.insert(mh);
+    mh = make_shared<MinimizerHit>(read_id, Interval(8,11), prg_id, prg_path, knode_id, orientation);
+    hits.insert(mh);
+    d = {Interval(29, 30), Interval(31,33)};
+    prg_path.initialize(d);
+    mh = make_shared<MinimizerHit>(read_id, Interval(9,12), prg_id, prg_path, knode_id, orientation);
+    hits.insert(mh);
+    d = {Interval(78,81)};
+    prg_path.initialize(d);
+    mh = make_shared<MinimizerHit>(read_id, Interval(13,16), prg_id, prg_path, knode_id, orientation);
+    hits.insert(mh);
+
+    pr->add_hits(prg_id,hits);
+    pn->reads.insert(pr);
+    hits.clear();
+
+    // READ 3
+    read_id = 3;
+    pr = make_shared<pangenome::Read>(read_id);
+
+    // hits overlapping edges of path
+    d = {Interval(0,1), Interval(4,5), Interval(8,9)};
+    prg_path.initialize(d);
+    mh = make_shared<MinimizerHit>(read_id, Interval(4,7), prg_id, prg_path, knode_id, orientation);
+    hits.insert(mh);
+    d = {Interval(29,30), Interval(33,33), Interval(40,42)};
+    prg_path.initialize(d);
+    mh = make_shared<MinimizerHit>(read_id, Interval(10,13), prg_id, prg_path, knode_id, orientation);
+    hits.insert(mh);
+    d = {Interval(28,30), Interval(33,33), Interval(40,41)};
+    prg_path.initialize(d);
+    mh = make_shared<MinimizerHit>(read_id, Interval(9,12), prg_id, prg_path, knode_id, orientation);
+    hits.insert(mh);
+
+    // hits on path
+    d = {Interval(8,9), Interval(16,17), Interval(27,28)};
+    prg_path.initialize(d);
+    mh = make_shared<MinimizerHit>(read_id, Interval(6,9), prg_id, prg_path, knode_id, orientation);
+    hits.insert(mh);
+    d = {Interval(16,17), Interval(27,29)};
+    prg_path.initialize(d);
+    mh = make_shared<MinimizerHit>(read_id, Interval(7,10), prg_id, prg_path, knode_id, orientation);
+    hits.insert(mh);
+
+
+    // noise
+    d = {Interval(7,8), Interval(16, 17), Interval(27,28)};
+    prg_path.initialize(d);
+    mh = make_shared<MinimizerHit>(read_id, Interval(1,4), prg_id, prg_path, knode_id, orientation);
+    hits.insert(mh);
+    mh = make_shared<MinimizerHit>(read_id, Interval(7,10), prg_id, prg_path, knode_id, orientation);
+    hits.insert(mh);
+
+    pr->add_hits(prg_id,hits);
+    pn->reads.insert(pr);
+    hits.clear();
+
+    // READ 4
+    read_id = 4;
+    pr = make_shared<pangenome::Read>(read_id);
+
+    // hits overlapping edges of path
+    d = {Interval(0,1), Interval(4,5), Interval(8,9)};
+    prg_path.initialize(d);
+    mh = make_shared<MinimizerHit>(read_id, Interval(4,7), prg_id, prg_path, knode_id, orientation);
+    hits.insert(mh);
+    d = {Interval(29,30), Interval(33,33), Interval(40,42)};
+    prg_path.initialize(d);
+    mh = make_shared<MinimizerHit>(read_id, Interval(17,20), prg_id, prg_path, knode_id, orientation);
+    hits.insert(mh);
+
+    // noise
+    d = {Interval(7,8), Interval(16, 17), Interval(27,28)};
+    prg_path.initialize(d);
+    mh = make_shared<MinimizerHit>(read_id, Interval(1,4), prg_id, prg_path, knode_id, orientation);
+    hits.insert(mh);
+    mh = make_shared<MinimizerHit>(read_id, Interval(8,11), prg_id, prg_path, knode_id, orientation);
+    hits.insert(mh);
+    d = {Interval(29, 30), Interval(31,33)};
+    prg_path.initialize(d);
+    mh = make_shared<MinimizerHit>(read_id, Interval(9,12), prg_id, prg_path, knode_id, orientation);
+    hits.insert(mh);
+    d = {Interval(78,81)};
+    prg_path.initialize(d);
+    mh = make_shared<MinimizerHit>(read_id, Interval(13,16), prg_id, prg_path, knode_id, orientation);
+    hits.insert(mh);
+
+    pr->add_hits(prg_id,hits);
+    pn->reads.insert(pr);
+    hits.clear();
+
+    // READ 5
+    read_id = 0;
+    pr = make_shared<pangenome::Read>(read_id);
+
+    // hits overlapping edges of path
+    d = {Interval(0,1), Interval(4,5), Interval(8,9)};
+    prg_path.initialize(d);
+    mh = make_shared<MinimizerHit>(read_id, Interval(2,5), prg_id, prg_path, knode_id, orientation);
+    hits.insert(mh);
+    d = {Interval(29,30), Interval(33,33), Interval(40,42)};
+    prg_path.initialize(d);
+    mh = make_shared<MinimizerHit>(read_id, Interval(8,11), prg_id, prg_path, knode_id, orientation);
+    hits.insert(mh);
+    d = {Interval(28,30), Interval(33,33), Interval(40,41)};
+    prg_path.initialize(d);
+    mh = make_shared<MinimizerHit>(read_id, Interval(7,10), prg_id, prg_path, knode_id, orientation);
+    hits.insert(mh);
+
+    // hits on path
+    d = {Interval(4,5), Interval(8,9), Interval(16,17)};
+    prg_path.initialize(d);
+    mh = make_shared<MinimizerHit>(read_id, Interval(3,6), prg_id, prg_path, knode_id, orientation);
+    hits.insert(mh);
+    d = {Interval(8,9), Interval(16,17), Interval(27,28)};
+    prg_path.initialize(d);
+    mh = make_shared<MinimizerHit>(read_id, Interval(4,7), prg_id, prg_path, knode_id, orientation);
+    hits.insert(mh);
+    d = {Interval(16,17), Interval(27,29)};
+    prg_path.initialize(d);
+    mh = make_shared<MinimizerHit>(read_id, Interval(5,8), prg_id, prg_path, knode_id, orientation);
+    hits.insert(mh);
+    d = {Interval(27,30)};
+    prg_path.initialize(d);
+    mh = make_shared<MinimizerHit>(read_id, Interval(6,9), prg_id, prg_path, knode_id, orientation);
+    hits.insert(mh);
+
+    pr->add_hits(prg_id,hits);
+    pn->reads.insert(pr);
+    hits.clear();
+
+    // RUN GET_READ_OVERLAPS
+    LocalPRG l3(3,"nested varsite", "A 5 G 7 C 8 T 7 T 9 CCG 10 CGG 9  6 G 5 TAT");
+    vector<LocalNodePtr> lmp = {//l3.prg.nodes[0],
+            l3.prg.nodes[1], l3.prg.nodes[2], l3.prg.nodes[4],
+            l3.prg.nodes[6], l3.prg.nodes[7]//, l3.prg.nodes[9]
+    };
+    // A G C T CGG  TAT
+
+    vector<vector<uint32_t>> overlaps;
+    vector<vector<uint32_t>> expected_overlaps = {{0, 3, 9, 1}, {1, 7, 13, 1}, {2, 5, 13, 1}, {3, 6, 10, 1}};
+
+    get_read_overlap_coordinates(pn, overlaps, lmp);
+
+    for (auto &coord: overlaps) {
+        for (auto &c: coord) {
+            std::cout << c << " ";
+        }
+        std::cout << "\n";
+    }
+
+    EXPECT_EQ(expected_overlaps.size(), overlaps.size());
+
+    uint j = 0;
+    for (auto coord : overlaps)
+    {
+        EXPECT_ITERABLE_EQ(vector<uint32_t>, expected_overlaps[j], coord);
+        j++;
+    }
+}
+
+
+
 TEST(ApplyBufferToIntervalTest, buffZero_returnSameInterval) {
     const Interval interval {2, 2};
     const int buff {0};

--- a/test/extract_reads_test.cpp
+++ b/test/extract_reads_test.cpp
@@ -837,13 +837,6 @@ TEST(ExtractReadsTest, get_read_overlap_coordinates_no_duplicates) {
 
     get_read_overlap_coordinates(pn, overlaps, lmp);
 
-    for (const auto &coord: overlaps) {
-        for (const auto &c: coord) {
-            std::cout << c << " ";
-        }
-        std::cout << "\n";
-    }
-
     EXPECT_ITERABLE_EQ(std::set<std::vector<uint32_t>>, expected_overlaps, overlaps);
 }
 

--- a/test/extract_reads_test.cpp
+++ b/test/extract_reads_test.cpp
@@ -529,19 +529,13 @@ TEST(ExtractReadsTest, get_read_overlap_coordinates) {
                                 };
     // A G C T CGG  TAT
 
-    vector<vector<uint32_t>> overlaps;
-    vector<vector<uint32_t>> expected_overlaps = {{0, 3, 9, 1}, {1, 7, 13, 1}, {2, 5, 13, 1}, {3, 6, 10, 1}};
+    std::set<vector<uint32_t>> overlaps;
+    std::set<vector<uint32_t>> expected_overlaps = {{0, 3, 9, 1}, {1, 7, 13, 1}, {2, 5, 13, 1}, {3, 6, 10, 1}};
 
     get_read_overlap_coordinates(pn, overlaps, lmp);
 
-    EXPECT_EQ(expected_overlaps.size(), overlaps.size());
 
-    uint j = 0;
-    for (auto coord : overlaps)
-    {
-        EXPECT_ITERABLE_EQ(vector<uint32_t>, expected_overlaps[j], coord);
-        j++;
-    }
+    EXPECT_ITERABLE_EQ(std::set<std::vector<uint32_t>>, expected_overlaps, overlaps);
 }
 
 
@@ -839,26 +833,19 @@ TEST(ExtractReadsTest, get_read_overlap_coordinates_no_duplicates) {
     };
     // A G C T CGG  TAT
 
-    vector<vector<uint32_t>> overlaps;
-    vector<vector<uint32_t>> expected_overlaps = {{0, 3, 9, 1}, {1, 7, 13, 1}, {2, 5, 13, 1}, {3, 6, 10, 1}};
+    std::set<vector<uint32_t>> overlaps;
+    std::set<vector<uint32_t>> expected_overlaps = {{0, 3, 9, 1}, {1, 7, 13, 1}, {2, 5, 13, 1}, {3, 6, 10, 1}};
 
     get_read_overlap_coordinates(pn, overlaps, lmp);
 
-    for (auto &coord: overlaps) {
-        for (auto &c: coord) {
+    for (const auto &coord: overlaps) {
+        for (const auto &c: coord) {
             std::cout << c << " ";
         }
         std::cout << "\n";
     }
 
-    EXPECT_EQ(expected_overlaps.size(), overlaps.size());
-
-    uint j = 0;
-    for (auto coord : overlaps)
-    {
-        EXPECT_ITERABLE_EQ(vector<uint32_t>, expected_overlaps[j], coord);
-        j++;
-    }
+    EXPECT_ITERABLE_EQ(std::set<std::vector<uint32_t>>, expected_overlaps, overlaps);
 }
 
 


### PR DESCRIPTION
This pull request closes #38 and uses a `std::set` instead of a `std::vector` to keep coordinates.  
Also added a test for this.