### PR TITLE
Fix off-by-one error in fastq_handler

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,3 +63,6 @@ EcoliK12_pandora*
 
 #internal scripts
 scripts/*
+
+# local directory - michael
+vm-build/

--- a/include/denovo_discovery/extract_reads.h
+++ b/include/denovo_discovery/extract_reads.h
@@ -59,7 +59,7 @@ namespace denovo_discovery {
     std::map<GeneIntervalInfo, ReadPileup>
     collect_read_pileups(const std::set<std::pair<ReadCoordinate, GeneIntervalInfo>> &,
                          const boost::filesystem::path &,
-                         const uint32_t &padding_size = g_local_assembly_kmer_size);
+                         const uint32_t &padding_size = g_local_assembly_kmer_size * 2);
 }
 
 

--- a/src/denovo_discovery/local_assembly.cpp
+++ b/src/denovo_discovery/local_assembly.cpp
@@ -246,9 +246,6 @@ void local_assembly(const std::vector<std::string> &sequences,
         if (not start_found) {
             continue;
         }
-
-        BOOST_LOG_TRIVIAL(debug) << "Found start kmer: " << graph.toString(start_node);
-
         for (const auto &e_kmer: end_kmers) {
             // make sure end kmer doesnt exist in the set of start kmers
             if (start_kmers.find(e_kmer) != start_kmers.end()) {

--- a/src/fastaq_handler.cpp
+++ b/src/fastaq_handler.cpp
@@ -124,9 +124,10 @@ void print(istream &infile) {
 }
 
 void FastaqHandler::get_id(const uint32_t &id) {
-    //cout << "get id " << id << endl;
-    if (id < num_reads_parsed) {
-        //cout << "restart buffer as have id " << num_reads_parsed << " and want id " << id << endl;
+    const uint32_t one_based_id = id + 1;
+    if (one_based_id < num_reads_parsed) {
+        BOOST_LOG_TRIVIAL(warning) << "restart buffer as have id " << num_reads_parsed << " and want id "
+                                   << one_based_id << " (" << id << ") with 0-based indexing.";
         num_reads_parsed = 0;
         name.clear();
         read.clear();
@@ -146,9 +147,6 @@ void FastaqHandler::get_id(const uint32_t &id) {
         inbuf.push(fastaq_file);
     }
 
-    BOOST_LOG_TRIVIAL(trace) << "now have name " << name << " read " << read << " num_reads_parsed " << num_reads_parsed
-                             << " and line " << line << endl;
-
     while (id > 1 and num_reads_parsed < id) {
         skip_next();
         if (eof()) {
@@ -156,17 +154,12 @@ void FastaqHandler::get_id(const uint32_t &id) {
         }
     }
 
-    BOOST_LOG_TRIVIAL(trace) << "now have name " << name << " read " << read << " num_reads_parsed " << num_reads_parsed
-                             << " and line " << line << endl;
-
     while (num_reads_parsed <= id) {
         get_next();
         if (eof()) {
             break;
         }
     }
-    BOOST_LOG_TRIVIAL(trace) << "now have name " << name << " read " << read << " num_reads_parsed " << num_reads_parsed
-                             << " and line " << line << endl;
 }
 
 void FastaqHandler::close() {

--- a/src/localPRG.cpp
+++ b/src/localPRG.cpp
@@ -1204,7 +1204,7 @@ uint32_t median(std::vector<uint32_t> v) {
     } else {
         int n1 = (v.size() + 2) / 2;
         int n2 = (v.size() - 2) / 2;
-        return (v[n1 - 1] + v[n2 - 1]) / 2;
+            return (v[n1 - 1] + v[n2 - 1]) / 2;
     }
 }
 


### PR DESCRIPTION
This PR fixes a bug where for every read we were effectively iterating through the fastq file once, due to an off-by-one error in the comparison of `id` and `num_reads_parsed`. Previously this process was consuming ~99% of CPU time, after these changes, it only consumes ~12%. #74 