### PR TITLE
WIP: enhancement #23: interval end memorized instead of recalculated

### DIFF
--- a/include/interval.h
+++ b/include/interval.h
@@ -8,7 +8,8 @@
 struct Interval {
     uint32_t start;
     uint32_t length;
-    //in pilot, longest prg was 208,562 characters long
+    uint32_t end;
+    // in pilot, longest prg was 208,562 characters long
 
     Interval(uint32_t= 0, uint32_t= 0);
 

--- a/src/interval.cpp
+++ b/src/interval.cpp
@@ -6,15 +6,16 @@
 #define assert_msg(x) !(std::cerr << "Assertion failed: " << x << std::endl)
 
 
-Interval::Interval(uint32_t s, uint32_t e) : start(s) {
-    assert(e >= start); // not a real interval ;
-    assert (e - start < std::numeric_limits<uint32_t>::max() or
-            assert_msg("Interval [" << s << "," << e << ") was too long"));
-    length = e - start; // intervals need to be exclusive of end point so that empty strings can be represented
+Interval::Interval(uint32_t s, uint32_t e) : start(s), end(e) {
+    assert(this->end >= this->start);
+    assert(this->end - this->start <= std::numeric_limits<uint32_t>::max());
+
+    // intervals must be end exclusive so that empty strings can be represented
+    this->length = this->end - this->start;
 }
 
 uint32_t Interval::get_end() const {
-    return start + (uint32_t) length;
+    return start + length;
 }
 
 std::ostream &operator<<(std::ostream &out, Interval const &i) {
@@ -27,12 +28,10 @@ std::istream &operator>>(std::istream &in, Interval &i) {
     in.ignore(1, '[');
     in >> i.start;
     in.ignore(2, ' ');
-    in >> end;
+    in >> i.end;
     in.ignore(1, ')');
-    assert(end >= i.start);
-    assert (end - i.start < std::numeric_limits<uint32_t>::max() or
-            assert_msg("Interval [" << i.start << "," << end << ") was too long"));
-    i.length = end - i.start;
+
+    i.length = i.end - i.start;
     return in;
 }
 

--- a/src/localPRG.cpp
+++ b/src/localPRG.cpp
@@ -68,16 +68,15 @@ std::vector<LocalNodePtr> LocalPRG::nodes_along_path(const Path &p) const {
 
     for (auto it = p.path.begin(); it != p.path.end(); ++it) {
         const auto &interval = *it;
-        uint32_t interval_end = it->get_end();
 
         // find the appropriate node of the prg
         for (auto n = prg.nodes.begin(); n != prg.nodes.end(); ++n) {
-            auto node_ptr = n->second;
-            uint32_t node_start = node_ptr->pos.start;
-            uint32_t node_end = node_ptr->pos.get_end();
+            auto local_node = (LocalNode) *(n->second);
+            uint32_t node_start = local_node.pos.start;
+            uint32_t node_end = local_node.pos.end;
 
-            bool is_overlapping_node = interval_end > node_start and interval.start < node_end;
-            bool is_equal_node = interval.start == node_start and interval_end == node_end;
+            bool is_overlapping_node = interval.end > node_start and interval.start < node_end;
+            bool is_equal_node = interval.start == node_start and interval.end == node_end;
             bool is_null_node = (
                     interval.start == node_start
                     and interval.length == 0
@@ -87,7 +86,7 @@ std::vector<LocalNodePtr> LocalPRG::nodes_along_path(const Path &p) const {
 
             if (is_overlapping_node or is_equal_node or is_null_node) {
                 path_nodes.push_back(n->second);
-            } else if (interval_end < node_start) {
+            } else if (interval.end < node_start) {
                 // local nodes are labelled in order of occurance in the linear prg string, no need to search further
                 break;
             }

--- a/src/prg/path.cpp
+++ b/src/prg/path.cpp
@@ -226,10 +226,9 @@ bool Path::operator!=(const Path &y) const {
 }
 
 std::ostream &prg::operator<<(std::ostream &out, Path const &p) {
-    uint32_t num_intervals = p.path.size();
-    out << num_intervals << "{";
-    for (auto it = p.path.begin(); it != p.path.end(); ++it) {
-        out << *it;
+    out << p.path.size() << "{";
+    for (const auto &interval: p.path) {
+        out << interval;
     }
     out << "}";
     return out;


### PR DESCRIPTION
Please don't merge. Looking for feedback.

Is there a reason why we cant just memorize the value of `get_end` for an interval? Is `Interval.start` ever changed after construction?