### PR TITLE
Remove all uses of make_dir function

### DIFF
--- a/include/denovo_discovery/local_assembly.h
+++ b/include/denovo_discovery/local_assembly.h
@@ -29,6 +29,7 @@ const uint32_t g_local_assembly_kmer_size{11};
 const auto g_log_level{logging::trivial::debug};
 const float g_covg_scaling_factor{0.1};
 const uint32_t g_kmer_attempts_count{10};
+const uint32_t g_max_num_paths{500};
 
 std::pair<Node, bool> get_node(const std::string &kmer, const Graph &graph);
 

--- a/include/estimate_parameters.h
+++ b/include/estimate_parameters.h
@@ -3,6 +3,9 @@
 
 #include <cstring>
 #include <cstdint>
+#include <boost/filesystem.hpp>
+
+namespace fs = boost::filesystem;
 
 
 uint32_t find_mean_covg(std::vector<uint32_t> &);

--- a/include/utils.h
+++ b/include/utils.h
@@ -43,8 +43,6 @@ struct spointer_values_equal {
 // utility functions
 std::string now();
 
-void make_dir(const std::string &);
-
 std::string int_to_string(const int number);
 
 std::vector<std::string> split(const std::string &, const std::string &);

--- a/src/compare_main.cpp
+++ b/src/compare_main.cpp
@@ -245,7 +245,7 @@ int pandora_compare(int argc, char *argv[]) {
 
         // make output dir for this sample
         string sample_outdir = outdir + "/" + sample->first;
-        make_dir(sample_outdir + "/kmer_prgs");
+        fs::create_directories(sample_outdir + "/kmer_prgs");
 
         // construct the pangraph for this sample
         cout << now() << "Constructing pangenome::Graph from read file " << sample->second
@@ -313,7 +313,7 @@ int pandora_compare(int argc, char *argv[]) {
         }
 
         string node_outdir = outdir + "/" + c.second->get_name();
-        make_dir(node_outdir);
+        fs::create_directories(node_outdir);
 
         c.second->output_samples(prgs[c.first], node_outdir, w, vcf_ref);
     }

--- a/src/denovo_discovery/denovo_discovery.cpp
+++ b/src/denovo_discovery/denovo_discovery.cpp
@@ -36,7 +36,7 @@ void denovo_discovery::find_candidates(
                                    local_assembly_kmer_size,
                                    kmer_attempts_count)
         };
-
+        // todo: create directory to put paths into i.e denovo/
         auto fname = get_discovered_paths_fname(info, local_assembly_kmer_size);
         auto discovered_paths_fpath = output_directory / fname;
 

--- a/src/denovo_discovery/local_assembly.cpp
+++ b/src/denovo_discovery/local_assembly.cpp
@@ -204,9 +204,19 @@ void local_assembly(const std::vector<std::string> &sequences, const std::vector
                 auto tree = DFS(start_node, graph);
                 auto result = get_paths_between(s_kmer, e_kmer, tree, graph, max_path_length, expected_coverage);
 
-                if (not result.empty()) {
+                if (not result.empty() and result.size() < g_max_num_paths) {
                     write_paths_to_fasta(out_path, result);
+                } else {
+                    if (result.empty()) {
+                        BOOST_LOG_TRIVIAL(debug) << "No paths found.";
+                    }
+                    else if (result.size() >= g_max_num_paths)
+                    {
+                        BOOST_LOG_TRIVIAL(debug) << "Too many paths found " << std::to_string(result.size())
+                                                 << ". Skipping slice.";
+                    }
                 }
+
                 remove_graph_file();
                 return;
             }

--- a/src/estimate_parameters.cpp
+++ b/src/estimate_parameters.cpp
@@ -206,7 +206,7 @@ void estimate_parameters(pangenome::Graph *pangraph, const string &outdir, const
 
     // save coverage distribution
     cout << now() << "Writing kmer coverage distribution to " << outdir << "/kmer_covgs.txt" << endl;
-    make_dir(outdir);
+    fs::create_directories(outdir);
     ofstream handle;
     handle.open(outdir + "/kmer_covgs.txt");
     assert(!handle.fail() or assert_msg("Could not open file " << outdir + "/kmer_covgs.txt"));

--- a/src/index_main.cpp
+++ b/src/index_main.cpp
@@ -27,7 +27,7 @@ void index_prgs(std::vector<std::shared_ptr<LocalPRG>> &prgs, Index *idx, const 
     auto dir_num = 0;
     for (uint32_t i = 0; i != prgs.size(); ++i) {
         if (i % 4000 == 0) {
-            make_dir(outdir + "/" + int_to_string(dir_num + 1));
+            fs::create_directories(outdir + "/" + int_to_string(dir_num + 1));
             dir_num++;
         }
         prgs[i]->minimizer_sketch(idx, w, k);

--- a/src/map_main.cpp
+++ b/src/map_main.cpp
@@ -220,9 +220,9 @@ int pandora_map(int argc, char *argv[]) {
     cout << "\tsnps_only\t" << snps_only << endl;
     cout << "\tdiscover\t" << discover_denovo << endl << endl;
 
-    make_dir(outdir);
+    fs::create_directories(outdir);
     if (output_kg)
-        make_dir(outdir + "/kmer_graphs");
+        fs::create_directories(outdir + "/kmer_graphs");
 
     cout << now() << "Loading Index and LocalPRGs from file" << endl;
     Index *idx;

--- a/src/pangenome/pangraph.cpp
+++ b/src/pangenome/pangraph.cpp
@@ -439,7 +439,7 @@ void Graph::save_mapped_read_strings(const string &readfilepath, const string &o
         cout << "Find coordinates for node " << node_ptr.second->name;
         node_ptr.second->get_read_overlap_coordinates(read_overlap_coordinates);
         cout << "." << endl;
-        make_dir(outdir + "/" + node_ptr.second->get_name());
+        fs::create_directories(outdir + "/" + node_ptr.second->get_name());
         outhandle.open(outdir + "/" + node_ptr.second->get_name() + "/" + node_ptr.second->get_name() + ".reads.fa");
         for (const auto &coord : read_overlap_coordinates) {
             readfile.get_id(coord[0]);
@@ -467,7 +467,7 @@ void Graph::save_mapped_read_strings(const string &readfilepath, const string &o
 
 void Graph::save_kmergraph_coverages(const string &outdir, const string &sample_name) {
     BOOST_LOG_TRIVIAL(debug) << "Save kmergraph coverages for sample " << sample_name;
-    make_dir(outdir + "/coverages");
+    fs::create_directories(outdir + "/coverages");
     for (const auto &n : nodes) {
         string node_file = outdir + "/coverages/" + n.second->name + ".csv";
         if (!boost::filesystem::exists(node_file)) {

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -37,18 +37,6 @@ string now() {
     return dt.substr(0, dt.length() - 1) + " ";
 }
 
-void make_dir(const string &dirpath) {
-    if (dirpath == ".")
-        return;
-
-    const boost::filesystem::path dir(dirpath);
-    if (boost::filesystem::exists(dir)) {
-        return;
-    }
-
-    assert(boost::filesystem::create_directories(dir) || assert_msg("Failed to make directories " << dir));
-}
-
 string int_to_string(const int number) {
     stringstream ss;
     ss << setw(2) << setfill('0') << number;


### PR DESCRIPTION
This PR closes #96 by replacing all uses of `make_dir` with `boost::filesystem::create_directories`. This replacement function does all the same checks as the original `make_dir` function.  This also addresses #69 in standardising the use of `boost::filesystem`.  

There is also a first pass at limiting the number of paths generated during local assembly #95 .