### PR TITLE
CLI parsing improvements and gatb compiler instructions

### DIFF
--- a/Singularity.pandora
+++ b/Singularity.pandora
@@ -51,3 +51,6 @@ MirrorURL: http://us.archive.ubuntu.com/ubuntu/
     make
     ctest -VV
     echo "export PATH=$(pwd):$PATH" >> $SINGULARITY_ENVIRONMENT
+
+
+

--- a/ext/gatb.cmake
+++ b/ext/gatb.cmake
@@ -13,7 +13,7 @@ ExternalProject_Add(gatb
         DOWNLOAD_COMMAND  wget https://github.com/GATB/gatb-core/archive/v1.4.1.tar.gz --timestamping -O gatb.tar.gz
         DOWNLOAD_DIR      "${CMAKE_BINARY_DIR}/ext"
         CONFIGURE_COMMAND ""
-        BUILD_COMMAND     bash -c "cd ${GATB_BUILD_DIR} && cmake ${GATB_DIR} && make"
+        BUILD_COMMAND     bash -c "cd ${GATB_BUILD_DIR} && cmake -D CMAKE_C_COMPILER=${CMAKE_C_COMPILER} -D CMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER} ${GATB_DIR} && make"
         INSTALL_COMMAND   ""
         TEST_COMMAND      "")
 

--- a/src/compare_main.cpp
+++ b/src/compare_main.cpp
@@ -131,35 +131,35 @@ int pandora_compare(int argc, char *argv[]) {
             }
         } else if (arg == "-w") {
             if (i + 1 < argc) { // Make sure we aren't at the end of argv!
-                w = (unsigned) atoi(argv[++i]); // Increment 'i' so we don't get the argument as the next argv[i].
+                w = strtoul(argv[++i], nullptr, 10); // Increment 'i' so we don't get the argument as the next argv[i].
             } else { // Uh-oh, there was no argument to the destination option.
                 std::cerr << "-w option requires one argument." << std::endl;
                 return 1;
             }
         } else if (arg == "-k") {
             if (i + 1 < argc) { // Make sure we aren't at the end of argv!
-                k = (unsigned) atoi(argv[++i]); // Increment 'i' so we don't get the argument as the next argv[i].
+                k = strtoul(argv[++i], nullptr, 10); // Increment 'i' so we don't get the argument as the next argv[i].
             } else { // Uh-oh, there was no argument to the destination option.
                 std::cerr << "-k option requires one argument." << std::endl;
                 return 1;
             }
         } else if ((arg == "-m") || (arg == "--max_diff")) {
             if (i + 1 < argc) { // Make sure we aren't at the end of argv!
-                max_diff = atoi(argv[++i]); // Increment 'i' so we don't get the argument as the next argv[i].
+                max_diff = strtol(argv[++i], nullptr, 10); // Increment 'i' so we don't get the argument as the next argv[i].
             } else { // Uh-oh, there was no argument to the destination option.
                 std::cerr << "--max_diff option requires one argument." << std::endl;
                 return 1;
             }
         } else if ((arg == "-c") || (arg == "--min_cluster_size")) {
             if (i + 1 < argc) { // Make sure we aren't at the end of argv!
-                min_cluster_size = atoi(argv[++i]); // Increment 'i' so we don't get the argument as the next argv[i].
+                min_cluster_size = strtoul(argv[++i], nullptr, 10); // Increment 'i' so we don't get the argument as the next argv[i].
             } else { // Uh-oh, there was no argument to the destination option.
                 std::cerr << "--min_cluster_size option requires one argument." << std::endl;
                 return 1;
             }
         } else if ((arg == "-e") || (arg == "--error_rate")) {
             if (i + 1 < argc) { // Make sure we aren't at the end of argv!
-                e_rate = atof(argv[++i]); // Increment 'i' so we don't get the argument as the next argv[i].
+                e_rate = strtof(argv[++i], nullptr); // Increment 'i' so we don't get the argument as the next argv[i].
                 if (e_rate < 0.01) {
                     illumina = true;
                 }
@@ -169,7 +169,7 @@ int pandora_compare(int argc, char *argv[]) {
             }
         } else if ((arg == "--genome_size")) {
             if (i + 1 < argc) { // Make sure we aren't at the end of argv!
-                genome_size = atoi(argv[++i]); // Increment 'i' so we don't get the argument as the next argv[i].
+                genome_size = strtoul(argv[++i], nullptr, 10); // Increment 'i' so we don't get the argument as the next argv[i].
             } else { // Uh-oh, there was no argument to the destination option.
                 std::cerr << "--genome_size option requires one argument." << std::endl;
                 return 1;
@@ -189,49 +189,49 @@ int pandora_compare(int argc, char *argv[]) {
             bin = true;
         } else if ((arg == "--max_covg")) {
             if (i + 1 < argc) { // Make sure we aren't at the end of argv!
-                max_covg = atoi(argv[++i]); // Increment 'i' so we don't get the argument as the next argv[i].
+                max_covg = strtoul(argv[++i], nullptr, 10); // Increment 'i' so we don't get the argument as the next argv[i].
             } else { // Uh-oh, there was no argument to the destination option.
                 std::cerr << "--max_covg option requires one argument." << std::endl;
                 return 1;
             }
         } else if ((arg == "--min_allele_covg_gt")) {
             if (i + 1 < argc) { // Make sure we aren't at the end of argv!
-                min_allele_covg_gt = atoi(argv[++i]); // Increment 'i' so we don't get the argument as the next argv[i].
+                min_allele_covg_gt = strtoul(argv[++i], nullptr, 10); // Increment 'i' so we don't get the argument as the next argv[i].
             } else { // Uh-oh, there was no argument to the destination option.
                 std::cerr << "--min_allele_covg_gt option requires one argument." << std::endl;
                 return 1;
             }
         } else if ((arg == "--min_total_covg_gt")) {
             if (i + 1 < argc) { // Make sure we aren't at the end of argv!
-                min_total_covg_gt = atoi(argv[++i]); // Increment 'i' so we don't get the argument as the next argv[i].
+                min_total_covg_gt = strtoul(argv[++i], nullptr, 10); // Increment 'i' so we don't get the argument as the next argv[i].
             } else { // Uh-oh, there was no argument to the destination option.
                 std::cerr << "--min_total_covg_gt option requires one argument." << std::endl;
                 return 1;
             }
         } else if ((arg == "--min_diff_covg_gt")) {
             if (i + 1 < argc) { // Make sure we aren't at the end of argv!
-                min_diff_covg_gt = atoi(argv[++i]); // Increment 'i' so we don't get the argument as the next argv[i].
+                min_diff_covg_gt = strtoul(argv[++i], nullptr, 10); // Increment 'i' so we don't get the argument as the next argv[i].
             } else { // Uh-oh, there was no argument to the destination option.
                 std::cerr << "--min_diff_covg_gt option requires one argument." << std::endl;
                 return 1;
             }
         } else if ((arg == "--min_allele_fraction_covg_gt")) {
             if (i + 1 < argc) { // Make sure we aren't at the end of argv!
-                min_allele_fraction_covg_gt = static_cast<float>(atof(argv[++i])); // Increment 'i' so we don't get the argument as the next argv[i].
+                min_allele_fraction_covg_gt = strtof(argv[++i], nullptr); // Increment 'i' so we don't get the argument as the next argv[i].
             } else { // Uh-oh, there was no argument to the destination option.
                 std::cerr << "--min_allele_fraction_covg_gt option requires one argument." << std::endl;
                 return 1;
             }
         } else if ((arg == "--genotyping_error_rate")) {
             if (i + 1 < argc) { // Make sure we aren't at the end of argv!
-                genotyping_error_rate = static_cast<float>(atof(argv[++i])); // Increment 'i' so we don't get the argument as the next argv[i].
+                genotyping_error_rate = strtof(argv[++i], nullptr); // Increment 'i' so we don't get the argument as the next argv[i].
             } else { // Uh-oh, there was no argument to the destination option.
                 std::cerr << "--genotyping_error_rate option requires one argument." << std::endl;
                 return 1;
             }
         } else if ((arg == "--confidence_threshold")) {
             if (i + 1 < argc) { // Make sure we aren't at the end of argv!
-                confidence_threshold = atoi(argv[++i]); // Increment 'i' so we don't get the argument as the next argv[i].
+                confidence_threshold = (uint16_t)strtoul(argv[++i], nullptr, 10); // Increment 'i' so we don't get the argument as the next argv[i].
             } else { // Uh-oh, there was no argument to the destination option.
                 std::cerr << "--confidence_threshold option requires one argument." << std::endl;
                 return 1;
@@ -315,7 +315,7 @@ int pandora_compare(int argc, char *argv[]) {
         const auto &sample_fpath = sample.second;
 
         // make output dir for this sample
-        auto sample_outdir = outdir + "/" + sample_name;
+        auto sample_outdir = outdir.append("/").append(sample_name);
         fs::create_directories(sample_outdir);
 
         // construct the pangraph for this sample

--- a/src/denovo_discovery/candidate_region.cpp
+++ b/src/denovo_discovery/candidate_region.cpp
@@ -150,6 +150,8 @@ void CandidateRegion::generate_read_pileup(const fs::path &reads_filepath) {
 
 
 void CandidateRegion::write_denovo_paths_to_file(const fs::path &output_directory) {
+    fs::create_directories(output_directory);
+
     if (denovo_paths.empty()) {
         BOOST_LOG_TRIVIAL(debug) << "No denovo paths for " << filename;
         return;
@@ -157,7 +159,6 @@ void CandidateRegion::write_denovo_paths_to_file(const fs::path &output_director
 
     auto fasta { generate_fasta_for_denovo_paths() };
 
-    fs::create_directories(output_directory);
     const auto discovered_paths_filepath { output_directory / filename };
 
     fasta.save(discovered_paths_filepath.string());

--- a/src/estimate_parameters.cpp
+++ b/src/estimate_parameters.cpp
@@ -235,7 +235,8 @@ uint32_t estimate_parameters(std::shared_ptr<pangenome::Graph> pangraph,
         or (not bin and abs(var - mean) < 2 and mean > 10 and num_reads > 30 and covg > 2) ){
         bin = true;
         mean_covg = find_mean_covg(kmer_covg_dist);
-        exp_depth_covg = mean_covg;
+        if (exp_depth_covg < 1)
+            exp_depth_covg = mean;
         std::cout << "found mean kmer covg " << mean_covg << " and mean global covg " << covg
                   << " with avg num reads covering node " << num_reads << std::endl;
         if (mean_covg > 0 and mean_covg < covg) {

--- a/src/index_main.cpp
+++ b/src/index_main.cpp
@@ -23,7 +23,7 @@ static void show_index_usage() {
               << std::endl;
 }
 
-int pandora_index(int argc, char *argv[]) // the "pandora index" comand
+int pandora_index(int argc, char *argv[]) // the "pandora index" command
 {
     // if not enough arguments, print usage
     if (argc < 2) {
@@ -32,7 +32,7 @@ int pandora_index(int argc, char *argv[]) // the "pandora index" comand
     }
 
     // otherwise, parse the parameters from the command line
-    std::string prgfile, index_outfile = "", log_level="info";
+    std::string prgfile, index_outfile, log_level = "info";
     bool update = false;
     uint32_t w = 14, k = 15, id=0; // default parameters
     for (int i = 1; i < argc; ++i) {
@@ -44,21 +44,21 @@ int pandora_index(int argc, char *argv[]) // the "pandora index" comand
             update = true;
         } else if (arg == "-w") {
             if (i + 1 < argc) { // Make sure we aren't at the end of argv!
-                w = (unsigned) atoi(argv[++i]); // Increment 'i' so we don't get the argument as the next argv[i].
+                w = strtoul(argv[++i], nullptr, 10); // Increment 'i' so we don't get the argument as the next argv[i].
             } else { // Uh-oh, there was no argument to the destination option.
                 std::cerr << "-w option requires one argument." << std::endl;
                 return 1;
             }
         } else if (arg == "-k") {
             if (i + 1 < argc) { // Make sure we aren't at the end of argv!
-                k = (unsigned) atoi(argv[++i]); // Increment 'i' so we don't get the argument as the next argv[i].
+                k = strtoul(argv[++i], nullptr, 10); // Increment 'i' so we don't get the argument as the next argv[i].
             } else { // Uh-oh, there was no argument to the destination option.
                 std::cerr << "-k option requires one argument." << std::endl;
                 return 1;
             }
         } else if (arg == "--offset") {
             if (i + 1 < argc) { // Make sure we aren't at the end of argv!
-                id = (unsigned) atoi(argv[++i]); // Increment 'i' so we don't get the argument as the next argv[i].
+                id = strtoul(argv[++i], nullptr, 10); // Increment 'i' so we don't get the argument as the next argv[i].
             } else { // Uh-oh, there was no argument to the destination option.
                 std::cerr << "--offset option requires one argument." << std::endl;
                 return 1;
@@ -107,7 +107,7 @@ int pandora_index(int argc, char *argv[]) // the "pandora index" comand
     index_prgs(prgs, index, w, k, outdir);
 
     // save index
-    if (index_outfile != "")
+    if (not index_outfile.empty())
         index->save(index_outfile);
     else if (id > 0)
         index->save(prgfile+"."+std::to_string(id), w, k);

--- a/src/localPRG.cpp
+++ b/src/localPRG.cpp
@@ -205,8 +205,9 @@ LocalPRG::build_graph(const Interval &i, const std::vector<uint32_t> &from_ids, 
         if (v.size() < (uint32_t) 4) {
             BOOST_LOG_TRIVIAL(warning) << "In conversion from linear localPRG string to graph, splitting the string by "
                                           "the next var site resulted in the wrong number of intervals. Please check that site numbers "
-                                          "are flanked by a space on either side. Or perhaps ordering of numbers in GFA is irregular?!"
-                                          "Size of partition based on site " << next_site << " is " << v.size();
+                                          "are flanked by a space on either side. Or perhaps ordering of numbers in GFA is irregular?! "
+                                          "Size of partition based on site " << next_site << " is " << v.size()
+                                          << "\nLocalPRG name: " << name;
             std::exit(-1);
         }
         next_site += 2;

--- a/src/map_main.cpp
+++ b/src/map_main.cpp
@@ -114,36 +114,35 @@ int pandora_map(int argc, char *argv[]) {
             }
         } else if (arg == "-w") {
             if (i + 1 < argc) { // Make sure we aren't at the end of argv!
-                w = (unsigned) atoi(argv[++i]); // Increment 'i' so we don't get the argument as the next argv[i].
+                w = strtoul(argv[++i], nullptr, 10); // Increment 'i' so we don't get the argument as the next argv[i].
             } else { // Uh-oh, there was no argument to the destination option.
                 std::cerr << "-w option requires one argument." << std::endl;
                 return 1;
             }
         } else if (arg == "-k") {
             if (i + 1 < argc) { // Make sure we aren't at the end of argv!
-                k = (unsigned) atoi(argv[++i]); // Increment 'i' so we don't get the argument as the next argv[i].
+                k = strtoul(argv[++i], nullptr, 10); // Increment 'i' so we don't get the argument as the next argv[i].
             } else { // Uh-oh, there was no argument to the destination option.
                 std::cerr << "-k option requires one argument." << std::endl;
                 return 1;
             }
         } else if ((arg == "-m") || (arg == "--max_diff")) {
             if (i + 1 < argc) { // Make sure we aren't at the end of argv!
-                max_diff = atoi(argv[++i]); // Increment 'i' so we don't get the argument as the next argv[i].
+                max_diff = strtol(argv[++i], nullptr, 10); // Increment 'i' so we don't get the argument as the next argv[i].
             } else { // Uh-oh, there was no argument to the destination option.
                 std::cerr << "--max_diff option requires one argument." << std::endl;
                 return 1;
             }
         } else if ((arg == "-c") || (arg == "--min_cluster_size")) {
             if (i + 1 < argc) { // Make sure we aren't at the end of argv!
-                min_cluster_size = atoi(argv[++i]); // Increment 'i' so we don't get the argument as the next argv[i].
+                min_cluster_size = strtoul(argv[++i], nullptr, 10); // Increment 'i' so we don't get the argument as the next argv[i].
             } else { // Uh-oh, there was no argument to the destination option.
                 std::cerr << "--min_cluster_size option requires one argument." << std::endl;
                 return 1;
             }
         } else if ((arg == "-e") || (arg == "--error_rate")) {
             if (i + 1 < argc) { // Make sure we aren't at the end of argv!
-                e_rate = static_cast<float>(atof(
-                        argv[++i])); // Increment 'i' so we don't get the argument as the next argv[i].
+                e_rate = strtof(argv[++i], nullptr); // Increment 'i' so we don't get the argument as the next argv[i].
                 if (e_rate < 0.01) {
                     illumina = true;
                 }
@@ -153,7 +152,7 @@ int pandora_map(int argc, char *argv[]) {
             }
         } else if ((arg == "--genome_size")) {
             if (i + 1 < argc) { // Make sure we aren't at the end of argv!
-                genome_size = atoi(argv[++i]); // Increment 'i' so we don't get the argument as the next argv[i].
+                genome_size = strtoul(argv[++i], nullptr, 10); // Increment 'i' so we don't get the argument as the next argv[i].
             } else { // Uh-oh, there was no argument to the destination option.
                 std::cerr << "--genome_size option requires one argument." << std::endl;
                 return 1;
@@ -186,56 +185,56 @@ int pandora_map(int argc, char *argv[]) {
             bin = true;
         } else if ((arg == "--max_covg")) {
             if (i + 1 < argc) { // Make sure we aren't at the end of argv!
-                max_covg = atoi(argv[++i]); // Increment 'i' so we don't get the argument as the next argv[i].
+                max_covg = strtoul(argv[++i], nullptr, 10); // Increment 'i' so we don't get the argument as the next argv[i].
             } else { // Uh-oh, there was no argument to the destination option.
                 std::cerr << "--max_covg option requires one argument." << std::endl;
                 return 1;
             }
         } else if ((arg == "--min_allele_covg_gt")) {
             if (i + 1 < argc) { // Make sure we aren't at the end of argv!
-                min_allele_covg_gt = atoi(argv[++i]); // Increment 'i' so we don't get the argument as the next argv[i].
+                min_allele_covg_gt = strtoul(argv[++i], nullptr, 10); // Increment 'i' so we don't get the argument as the next argv[i].
             } else { // Uh-oh, there was no argument to the destination option.
                 std::cerr << "--min_allele_covg_gt option requires one argument." << std::endl;
                 return 1;
             }
         } else if ((arg == "--min_total_covg_gt")) {
             if (i + 1 < argc) { // Make sure we aren't at the end of argv!
-                min_total_covg_gt = atoi(argv[++i]); // Increment 'i' so we don't get the argument as the next argv[i].
+                min_total_covg_gt = strtoul(argv[++i], nullptr, 10); // Increment 'i' so we don't get the argument as the next argv[i].
             } else { // Uh-oh, there was no argument to the destination option.
                 std::cerr << "--min_total_covg_gt option requires one argument." << std::endl;
                 return 1;
             }
         } else if ((arg == "--min_diff_covg_gt")) {
             if (i + 1 < argc) { // Make sure we aren't at the end of argv!
-                min_diff_covg_gt = atoi(argv[++i]); // Increment 'i' so we don't get the argument as the next argv[i].
+                min_diff_covg_gt = strtoul(argv[++i], nullptr, 10); // Increment 'i' so we don't get the argument as the next argv[i].
             } else { // Uh-oh, there was no argument to the destination option.
                 std::cerr << "--min_diff_covg_gt option requires one argument." << std::endl;
                 return 1;
             }
         } else if ((arg == "--min_allele_fraction_covg_gt")) {
             if (i + 1 < argc) { // Make sure we aren't at the end of argv!
-                min_allele_fraction_covg_gt = static_cast<float>(atof(argv[++i])); // Increment 'i' so we don't get the argument as the next argv[i].
+                min_allele_fraction_covg_gt = strtof(argv[++i], nullptr); // Increment 'i' so we don't get the argument as the next argv[i].
             } else { // Uh-oh, there was no argument to the destination option.
                 std::cerr << "--min_allele_fraction_covg_gt option requires one argument." << std::endl;
                 return 1;
             }
         } else if ((arg == "--genotyping_error_rate")) {
             if (i + 1 < argc) { // Make sure we aren't at the end of argv!
-                genotyping_error_rate = static_cast<float>(atof(argv[++i])); // Increment 'i' so we don't get the argument as the next argv[i].
+                genotyping_error_rate = strtof(argv[++i], nullptr); // Increment 'i' so we don't get the argument as the next argv[i].
             } else { // Uh-oh, there was no argument to the destination option.
                 std::cerr << "--genotyping_error_rate option requires one argument." << std::endl;
                 return 1;
             }
         } else if ((arg == "--confidence_threshold")) {
             if (i + 1 < argc) { // Make sure we aren't at the end of argv!
-                confidence_threshold = atoi(argv[++i]); // Increment 'i' so we don't get the argument as the next argv[i].
+                confidence_threshold = (uint16_t)strtoul(argv[++i], nullptr, 10); // Increment 'i' so we don't get the argument as the next argv[i].
             } else { // Uh-oh, there was no argument to the destination option.
                 std::cerr << "--confidence_threshold option requires one argument." << std::endl;
                 return 1;
             }
         } else if ((arg == "--denovo_kmer_size")) {
             if (i + 1 < argc) { // Make sure we aren't at the end of argv!
-                denovo_kmer_size = atoi(argv[++i]); // Increment 'i' so we don't get the argument as the next argv[i].
+                denovo_kmer_size = (uint_least8_t)strtoul(argv[++i], nullptr, 10); // Increment 'i' so we don't get the argument as the next argv[i].
             } else { // Uh-oh, there was no argument to the destination option.
                 std::cerr << "--denovo_kmer_size option requires one argument." << std::endl;
                 return 1;

--- a/src/random_path_main.cpp
+++ b/src/random_path_main.cpp
@@ -27,7 +27,7 @@ int pandora_random_path(int argc, char *argv[]) // the "pandora walk" comand
 
     uint32_t num_paths = 1;
     if (argc == 3) {
-        num_paths = atoi(argv[2]);
+        num_paths = strtoul(argv[2], nullptr, 10);
     }
 
     for (const auto &prg_ptr: prgs) {


### PR DESCRIPTION
* Replace unsafe CLI parsing which fixes #124 
* Tell GATB to use the same compiler as the rest of the `cmake` project (it was just using the system default previously)
* Create a _de novo_ paths directory even if we don't generate any paths.