### PR TITLE
Path memoization is now done only on pandora index

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,9 +69,8 @@ vm-build/
 Singularity_debug.pandora
 debug_with_singularity.sh
 pandora_debug.img
-build_debug/
+build_debug*
 build/
 data_issue*
-build_release/
-build_release_with_debug/
-build_profiling/
+build_release*
+build_profiling*

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -72,23 +72,24 @@ target_link_libraries(${PROJECT_NAME}
 
 
 
-#Uncomment the following if you wish to build the compare_indexes binary
-#Build compare_indexes
-#set(SRC_FILES_COMPARE_INDEXES ${SRC_FILES})
-#list(REMOVE_ITEM SRC_FILES_COMPARE_INDEXES ${PROJECT_SOURCE_DIR}/src/main.cpp)
-#add_executable(compare_indexes ${PROJECT_SOURCE_DIR}/scripts/compare_indexes/compare_indexes.cpp ${SRC_FILES_COMPARE_INDEXES})
-#add_dependencies(compare_indexes gatb)
-#set_target_properties(compare_indexes PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/bin/)
-#target_link_libraries(compare_indexes
-#        ${CMAKE_THREAD_LIBS_INIT}
-#        ${Boost_IOSTREAMS_LIBRARY}
-#        ${Boost_FILESYSTEM_LIBRARY}
-#        ${Boost_SYSTEM_LIBRARY}
-#        ${Boost_LOG_LIBRARY}
-#        ${Boost_THREAD_LIBRARY}
-#        ${EXTERNAL_LIBS}
-#        ${CMAKE_DL_LIBS}
-#        ${ZLIB_LIBRARY})
+if(BUILD_COMPARE_INDEXES)
+    #Build compare_indexes
+    set(SRC_FILES_COMPARE_INDEXES ${SRC_FILES})
+    list(REMOVE_ITEM SRC_FILES_COMPARE_INDEXES ${PROJECT_SOURCE_DIR}/src/main.cpp)
+    add_executable(compare_indexes ${PROJECT_SOURCE_DIR}/scripts/compare_indexes/compare_indexes.cpp ${SRC_FILES_COMPARE_INDEXES})
+    add_dependencies(compare_indexes gatb)
+    set_target_properties(compare_indexes PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/bin/)
+    target_link_libraries(compare_indexes
+            ${CMAKE_THREAD_LIBS_INIT}
+            ${Boost_IOSTREAMS_LIBRARY}
+            ${Boost_FILESYSTEM_LIBRARY}
+            ${Boost_SYSTEM_LIBRARY}
+            ${Boost_LOG_LIBRARY}
+            ${Boost_THREAD_LIBRARY}
+            ${EXTERNAL_LIBS}
+            ${CMAKE_DL_LIBS}
+            ${ZLIB_LIBRARY})
+endif(BUILD_COMPARE_INDEXES)
 
 
 enable_testing()

--- a/include/localPRG.h
+++ b/include/localPRG.h
@@ -39,6 +39,8 @@ public:
     //VCF vcf;
     std::vector<uint32_t> num_hits;
 
+    static bool path_memoization_in_nodes_along_path_method; //flag to turn on or off path memoization in nodes_along_path method
+
     LocalPRG(uint32_t id, const std::string &name, const std::string &seq);
 
     // functions used to create LocalGraph from PRG string, and to sketch graph

--- a/include/localPRG.h
+++ b/include/localPRG.h
@@ -39,7 +39,7 @@ public:
     //VCF vcf;
     std::vector<uint32_t> num_hits;
 
-    static bool path_memoization_in_nodes_along_path_method; //flag to turn on or off path memoization in nodes_along_path method
+    static bool do_path_memoization_in_nodes_along_path_method;
 
     LocalPRG(uint32_t id, const std::string &name, const std::string &seq);
 

--- a/src/index_main.cpp
+++ b/src/index_main.cpp
@@ -95,10 +95,14 @@ int pandora_index(int argc, char *argv[]) // the "pandora index" command
         }
     }
 
+    //configure logging
     auto g_log_level{boost::log::trivial::info};
     if (log_level == "debug")
         g_log_level = boost::log::trivial::debug;
     boost::log::core::get()->set_filter(boost::log::trivial::severity >= g_log_level);
+
+    //configure path memoization to be done
+    LocalPRG::path_memoization_in_nodes_along_path_method = true;
 
     // load PRGs from file
     std::vector<std::shared_ptr<LocalPRG>> prgs;

--- a/src/index_main.cpp
+++ b/src/index_main.cpp
@@ -95,14 +95,12 @@ int pandora_index(int argc, char *argv[]) // the "pandora index" command
         }
     }
 
-    //configure logging
     auto g_log_level{boost::log::trivial::info};
     if (log_level == "debug")
         g_log_level = boost::log::trivial::debug;
     boost::log::core::get()->set_filter(boost::log::trivial::severity >= g_log_level);
 
-    //configure path memoization to be done
-    LocalPRG::path_memoization_in_nodes_along_path_method = true;
+    LocalPRG::do_path_memoization_in_nodes_along_path_method = true;
 
     // load PRGs from file
     std::vector<std::shared_ptr<LocalPRG>> prgs;

--- a/src/localPRG.cpp
+++ b/src/localPRG.cpp
@@ -18,6 +18,9 @@
 #define assert_msg(x) !(std::cerr << "Assertion failed: " << x << std::endl)
 
 
+//memoization is always disabled by default
+bool LocalPRG::path_memoization_in_nodes_along_path_method = false;
+
 LocalPRG::LocalPRG(uint32_t id, const std::string &name, const std::string &seq)
         : next_id(0), buff(" "), next_site(5), id(id), name(name), seq(seq), num_hits(2, 0) {
     std::vector<uint32_t> v; //TODO: v is not used - safe to delete - but is passed as a parameter...
@@ -68,7 +71,10 @@ std::string LocalPRG::string_along_path(const std::vector<LocalNodePtr> &p) {
 }
 
 std::vector<LocalNodePtr> LocalPRG::nodes_along_path(prg::Path &p) const {
-    return p.nodes_along_path(*this);
+    if (path_memoization_in_nodes_along_path_method)
+        return p.nodes_along_path(*this); //memoized version
+    else
+        return nodes_along_path_core(p); //non-memoized version
 }
 
 

--- a/src/localPRG.cpp
+++ b/src/localPRG.cpp
@@ -17,9 +17,7 @@
 
 #define assert_msg(x) !(std::cerr << "Assertion failed: " << x << std::endl)
 
-
-//memoization is always disabled by default
-bool LocalPRG::path_memoization_in_nodes_along_path_method = false;
+bool LocalPRG::do_path_memoization_in_nodes_along_path_method = false;
 
 LocalPRG::LocalPRG(uint32_t id, const std::string &name, const std::string &seq)
         : next_id(0), buff(" "), next_site(5), id(id), name(name), seq(seq), num_hits(2, 0) {
@@ -71,7 +69,7 @@ std::string LocalPRG::string_along_path(const std::vector<LocalNodePtr> &p) {
 }
 
 std::vector<LocalNodePtr> LocalPRG::nodes_along_path(prg::Path &p) const {
-    if (path_memoization_in_nodes_along_path_method)
+    if (do_path_memoization_in_nodes_along_path_method)
         return p.nodes_along_path(*this); //memoized version
     else
         return nodes_along_path_core(p); //non-memoized version

--- a/test/localPRG_test.cpp
+++ b/test/localPRG_test.cpp
@@ -276,14 +276,14 @@ void nodes_along_path_core_test() {
 }
 
 TEST(LocalPRGTest, nodes_along_path_without_memoization) {
-    assert(LocalPRG::path_memoization_in_nodes_along_path_method == false);
+    LocalPRG::do_path_memoization_in_nodes_along_path_method = false;
     nodes_along_path_core_test();
 }
 
 TEST(LocalPRGTest, nodes_along_path_with_memoization) {
-    LocalPRG::path_memoization_in_nodes_along_path_method=true;
+    LocalPRG::do_path_memoization_in_nodes_along_path_method = true;
     nodes_along_path_core_test();
-    LocalPRG::path_memoization_in_nodes_along_path_method=false;
+    LocalPRG::do_path_memoization_in_nodes_along_path_method = false;
 }
 
 TEST(LocalPRGTest, split_by_siteNoSites) {

--- a/test/localPRG_test.cpp
+++ b/test/localPRG_test.cpp
@@ -157,7 +157,10 @@ TEST(LocalPRGTest, string_along_localpath) {
     EXPECT_EQ("AGT", l2.string_along_path(p));
 }
 
-TEST(LocalPRGTest, nodes_along_path) {
+//core function called to test the LocalPRG::nodes_along_path() method in both tests that follow:
+//TEST(LocalPRGTest, nodes_along_path_without_memoization) and
+//TEST(LocalPRGTest, nodes_along_path_with_memoization)
+void nodes_along_path_core_test() {
     LocalPRG l0(0, "empty", "");
     LocalPRG l1(1, "simple", "AGCT");
     LocalPRG l2(2, "varsite", "A 5 GC 6 G 5 T");
@@ -270,6 +273,17 @@ TEST(LocalPRGTest, nodes_along_path) {
     EXPECT_EQ(j, l3.nodes_along_path(p3)[0]->id);
     j = 5;
     EXPECT_EQ(j, l3.nodes_along_path(p3)[1]->id);
+}
+
+TEST(LocalPRGTest, nodes_along_path_without_memoization) {
+    assert(LocalPRG::path_memoization_in_nodes_along_path_method == false);
+    nodes_along_path_core_test();
+}
+
+TEST(LocalPRGTest, nodes_along_path_with_memoization) {
+    LocalPRG::path_memoization_in_nodes_along_path_method=true;
+    nodes_along_path_core_test();
+    LocalPRG::path_memoization_in_nodes_along_path_method=false;
 }
 
 TEST(LocalPRGTest, split_by_siteNoSites) {

--- a/test/pangraph_test.cpp
+++ b/test/pangraph_test.cpp
@@ -1080,7 +1080,7 @@ TEST(PangenomeGraphTest, save_mapped_read_strings) {
     MiniRecord mr3(0, p, 0, 0);
     mhits.add_hit(1, m3, mr3);
 
-    auto l0 = std::make_shared<LocalPRG>(LocalPRG(0, "0", ""));
+    auto l0 = std::make_shared<LocalPRG>(LocalPRG(0, "zero", ""));
     pg.add_node(l0);
     pg.add_hits_between_PRG_and_read(l0, 1, mhits.hits);
     mhits.clear();


### PR DESCRIPTION
Path memoization in `LocalPRG::nodes_along_path` method speeds up `pandora index` a lot at the cost of using more memory. `pandora map` and `pandora compare` are mostly limited by RAM usage than speed though.

This PR disables path memoization in all modules but `pandora index`.

This modification brings the RAM usage of `pandora compare` on the klebs PRG with 151 samples down to 17.1GB:

* Runtime:
  * 5h08min with memoization
  * 5h21min without memoization
* RAM usage:
  * 24.5GB with memoization
  * 17.1 GB without memoization

The path memoization speed-up in `pandora compare` is small (13 minutes faster in this example), while the RAM required for the memoization is ~7.5 GB. So, in `pandora map` and `pandora compare` it seems that it is better to disable path memoization.

Added unit tests to test both memoized and non-memoized versions of this method, and assured that `pandora compare` and `pandora index` are producing the same results as before in a real dataset. No real dataset tests were done with `pandora map` though...