### PR TITLE
Closes #151

### DIFF
--- a/include/kmergraphwithcoverage.h
+++ b/include/kmergraphwithcoverage.h
@@ -22,7 +22,7 @@ class KmerGraphWithCoverage {
 private:
     //each coverage is represented as a std::vector, each position of the vector representing the coverage of a sample
     //each coverage of a sample is represented by a std::pair, for the forward and reverse reads coverage of that sample
-    std::vector<std::vector<std::pair<uint32_t, uint32_t>>> nodeIndex2SampleCoverage;
+    std::vector<std::vector<std::pair<uint16_t, uint16_t>>> nodeIndex2SampleCoverage;
     uint32_t exp_depth_covg;
     float binomial_parameter_p;
     float negative_binomial_parameter_p;
@@ -48,13 +48,18 @@ public:
     virtual ~KmerGraphWithCoverage() = default;
 
     //getter
+    //TODO: we should return a uint16_t instead of a uint32_t, but I did not want to change the interface
+    //TODO: converting uint16_t to uint32_t is safe anyway
+    //TODO: some parts of the code accumulates under the type of this variable, so it might be dangerous to change to uint16_t wihtout careful analysis
+    //TODO: leaving to uint32_t to be safe
     uint32_t get_covg(uint32_t node_id, bool strand, uint32_t sample_id) const;
+
     uint32_t get_num_reads() const { return num_reads; }
     uint32_t get_total_number_samples() const {return total_number_samples; }
 
     //setters
     void increment_covg(uint32_t node_id, bool strand, uint32_t sample_id);
-    void set_covg(uint32_t node_id, uint32_t value, bool strand, uint32_t sample_id);
+    void set_covg(uint32_t node_id, uint16_t value, bool strand, uint32_t sample_id);
     void set_exp_depth_covg(const uint32_t);
     void set_binomial_parameter_p(const float);
     void set_negative_binomial_parameters(const float &, const float &);
@@ -62,8 +67,11 @@ public:
     void set_num_reads(uint32_t num_reads) { this->num_reads = num_reads; }
 
     void zeroCoverages() {
-        for (auto &sampleCoverage: nodeIndex2SampleCoverage)
-            sampleCoverage = std::vector<std::pair<uint32_t, uint32_t>>(total_number_samples);
+        for (auto &sampleCoverage: nodeIndex2SampleCoverage) {
+            sampleCoverage = std::vector<std::pair<uint16_t, uint16_t>>(total_number_samples);
+            sampleCoverage.shrink_to_fit(); //tries to make this information as compact as possible (TODO: use sdsl?)
+        }
+
     }
 
     float nbin_prob(uint32_t, const uint32_t &sample_id);

--- a/include/kmergraphwithcoverage.h
+++ b/include/kmergraphwithcoverage.h
@@ -22,7 +22,7 @@ class KmerGraphWithCoverage {
 private:
     //each coverage is represented as a std::vector, each position of the vector representing the coverage of a sample
     //each coverage of a sample is represented by a std::pair, for the forward and reverse reads coverage of that sample
-    std::vector<std::vector<std::pair<uint16_t, uint16_t>>> nodeIndex2SampleCoverage;
+    std::vector<std::vector<std::pair<uint16_t, uint16_t>>> node_index_to_sample_coverage;
     uint32_t exp_depth_covg;
     float binomial_parameter_p;
     float negative_binomial_parameter_p;
@@ -36,7 +36,7 @@ public:
 
     //constructor, destructors, etc
     KmerGraphWithCoverage(KmerGraph * kmer_prg, uint32_t total_number_samples=1) :
-            nodeIndex2SampleCoverage(kmer_prg->nodes.size()),
+            node_index_to_sample_coverage(kmer_prg->nodes.size()),
             exp_depth_covg{0}, binomial_parameter_p{1}, negative_binomial_parameter_p{0.015}, negative_binomial_parameter_r{2}, thresh{-25}, total_number_samples{total_number_samples}, num_reads{0}, kmer_prg{kmer_prg} {
         assert(kmer_prg != nullptr);
         zeroCoverages();
@@ -59,13 +59,13 @@ public:
              worth the risk now
     TODO: leaving return type as uint32_t to be safe for now, need a recheck later
      */
-    uint32_t get_covg(uint32_t node_id, bool strand, uint32_t sample_id) const;
+    uint32_t get_covg(uint32_t node_id, bool is_forward, uint32_t sample_id) const;
     uint32_t get_num_reads() const { return num_reads; }
     uint32_t get_total_number_samples() const {return total_number_samples; }
 
     //setters
-    void increment_covg(uint32_t node_id, bool strand, uint32_t sample_id);
-    void set_covg(uint32_t node_id, uint16_t value, bool strand, uint32_t sample_id);
+    void increment_covg(uint32_t node_id, bool is_forward, uint32_t sample_id);
+    void set_covg(uint32_t node_id, uint16_t value, bool is_forward, uint32_t sample_id);
     void set_exp_depth_covg(const uint32_t);
     void set_binomial_parameter_p(const float);
     void set_negative_binomial_parameters(const float &, const float &);
@@ -73,7 +73,7 @@ public:
     void set_num_reads(uint32_t num_reads) { this->num_reads = num_reads; }
 
     void zeroCoverages() {
-        for (auto &sampleCoverage: nodeIndex2SampleCoverage) {
+        for (auto &sampleCoverage: node_index_to_sample_coverage) {
             sampleCoverage = std::vector<std::pair<uint16_t, uint16_t>>(total_number_samples);
             sampleCoverage.shrink_to_fit(); //tries to make this information as compact as possible (TODO: use sdsl?)
         }

--- a/include/kmergraphwithcoverage.h
+++ b/include/kmergraphwithcoverage.h
@@ -47,13 +47,19 @@ public:
     KmerGraphWithCoverage& operator=(KmerGraphWithCoverage&& other) = default; //move assignment operator
     virtual ~KmerGraphWithCoverage() = default;
 
-    //getter
-    //TODO: we should return a uint16_t instead of a uint32_t, but I did not want to change the interface
-    //TODO: converting uint16_t to uint32_t is safe anyway
-    //TODO: some parts of the code accumulates under the type of this variable, so it might be dangerous to change to uint16_t wihtout careful analysis
-    //TODO: leaving to uint32_t to be safe
+    //getters
+    /*
+    TODO: we should return a uint16_t instead of a uint32_t, but I did not want to change the interface, as it can be dangerous
+    WARNING: some parts of the code accumulates under the type of this return value,
+                     so it might be dangerous to change to uint16_t without careful analysis.
+             e.g.: I can see summing a bunch of coverage and potentially getting a value larger than 65535,
+                     which would incur overflow and bugs.
+    NOTE: converting uint16_t to uint32_t is safe anyway, so it is fine to leave like this
+    NOTE: the advantage of returning a uint16_t here is a negligible improvement in RAM usage, so I don't think it is
+             worth the risk now
+    TODO: leaving return type as uint32_t to be safe for now, need a recheck later
+     */
     uint32_t get_covg(uint32_t node_id, bool strand, uint32_t sample_id) const;
-
     uint32_t get_num_reads() const { return num_reads; }
     uint32_t get_total_number_samples() const {return total_number_samples; }
 

--- a/src/kmergraphwithcoverage.cpp
+++ b/src/kmergraphwithcoverage.cpp
@@ -34,37 +34,37 @@ void KmerGraphWithCoverage::set_binomial_parameter_p(const float e_rate) {
     //cout << "using p: " << p << endl;
 }
 
-void KmerGraphWithCoverage::increment_covg(uint32_t node_id, bool strand, uint32_t sample_id) {
-    assert(this->nodeIndex2SampleCoverage[node_id].size() > sample_id);
+void KmerGraphWithCoverage::increment_covg(uint32_t node_id, bool is_forward, uint32_t sample_id) {
+    assert(this->node_index_to_sample_coverage[node_id].size() > sample_id);
 
     //get a pointer to the value we want to increment
     uint16_t* coverage_ptr = nullptr;
-    if (strand)
-        coverage_ptr = &(this->nodeIndex2SampleCoverage[node_id][sample_id].first);
+    if (is_forward)
+        coverage_ptr = &(this->node_index_to_sample_coverage[node_id][sample_id].first);
     else
-        coverage_ptr = &(this->nodeIndex2SampleCoverage[node_id][sample_id].second);
+        coverage_ptr = &(this->node_index_to_sample_coverage[node_id][sample_id].second);
 
     if ((*coverage_ptr) < UINT16_MAX) //checks if it is safe to increase the coverage (no overflow)
         ++(*coverage_ptr);
 }
 
-uint32_t KmerGraphWithCoverage::get_covg(uint32_t node_id, bool strand, uint32_t sample_id) const {
+uint32_t KmerGraphWithCoverage::get_covg(uint32_t node_id, bool is_forward, uint32_t sample_id) const {
 
-    if (this->nodeIndex2SampleCoverage[node_id].size() <= sample_id)
+    if (this->node_index_to_sample_coverage[node_id].size() <= sample_id)
         return 0;
 
-    if (strand)
-        return (uint32_t)(this->nodeIndex2SampleCoverage[node_id][sample_id].first);
+    if (is_forward)
+        return (uint32_t)(this->node_index_to_sample_coverage[node_id][sample_id].first);
     else
-        return (uint32_t)(this->nodeIndex2SampleCoverage[node_id][sample_id].second);
+        return (uint32_t)(this->node_index_to_sample_coverage[node_id][sample_id].second);
 }
 
-void KmerGraphWithCoverage::set_covg(uint32_t node_id, uint16_t value, bool strand, uint32_t sample_id) {
-    assert(this->nodeIndex2SampleCoverage[node_id].size() > sample_id);
-    if (strand)
-        this->nodeIndex2SampleCoverage[node_id][sample_id].first = value;
+void KmerGraphWithCoverage::set_covg(uint32_t node_id, uint16_t value, bool is_forward, uint32_t sample_id) {
+    assert(this->node_index_to_sample_coverage[node_id].size() > sample_id);
+    if (is_forward)
+        this->node_index_to_sample_coverage[node_id][sample_id].first = value;
     else
-        this->nodeIndex2SampleCoverage[node_id][sample_id].second = value;
+        this->node_index_to_sample_coverage[node_id][sample_id].second = value;
 }
 
 
@@ -377,7 +377,7 @@ void KmerGraphWithCoverage::save_covg_dist(const std::string &filepath) {
         const KmerNode &kmer_node = *kmer_node_ptr;
 
         uint32_t sample_id = 0;
-        for (const auto &sample_coverage: nodeIndex2SampleCoverage[kmer_node.id]) {
+        for (const auto &sample_coverage: node_index_to_sample_coverage[kmer_node.id]) {
             handle << kmer_node.id << " "
                    << sample_id << " "
                    << sample_coverage.first << " "

--- a/src/pangenome/pangraph.cpp
+++ b/src/pangenome/pangraph.cpp
@@ -346,8 +346,8 @@ void pangenome::Graph::copy_coverages_to_kmergraphs(const Graph &ref_pangraph, c
         for (auto & kmergraph_node_ptr : pangraph_node.kmer_prg_with_coverage.kmer_prg->nodes){
             const auto &knode_id = kmergraph_node_ptr->id;
             assert(knode_id < ref_node.kmer_prg_with_coverage.kmer_prg->nodes.size());
-            pangraph_node.kmer_prg_with_coverage.set_covg(knode_id, ref_node.kmer_prg_with_coverage.get_covg(knode_id, 0, ref_sample_id), 0, sample_id);
-            pangraph_node.kmer_prg_with_coverage.set_covg(knode_id, ref_node.kmer_prg_with_coverage.get_covg(knode_id, 1, ref_sample_id), 1, sample_id);
+            pangraph_node.kmer_prg_with_coverage.set_covg(knode_id, (uint16_t)(ref_node.kmer_prg_with_coverage.get_covg(knode_id, 0, ref_sample_id)), 0, sample_id);
+            pangraph_node.kmer_prg_with_coverage.set_covg(knode_id, (uint16_t)(ref_node.kmer_prg_with_coverage.get_covg(knode_id, 1, ref_sample_id)), 1, sample_id);
         }
     }
 }


### PR DESCRIPTION
Closes https://github.com/rmcolq/pandora/issues/151

Switching to `uint16` for coverage information reduced the RAM usage for `pandora compare` on the full klebs dataset from 17.1 GB to 13.5 GB.

This dataset contains only 151 samples, and the more samples, the larger is the reduction, so this change is important for scalability.