### PR TITLE
Improving path enumeration speed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 .idea
-cmake-build-debug/
+cmake-build-*/
 doc/html
 
 # Ignore the build and lib dirs

--- a/include/denovo_discovery/denovo_discovery.h
+++ b/include/denovo_discovery/denovo_discovery.h
@@ -13,13 +13,13 @@
 
 namespace fs = boost::filesystem;
 
-
 class DenovoDiscovery {
 public:
     const uint_least8_t min_covg_for_node_in_assembly_graph { 2 };
     bool clean_assembly_graph { false };
+    const uint8_t max_insertion_size;
 
-    DenovoDiscovery(const uint_least8_t &kmer_size, const double &read_error_rate);
+    DenovoDiscovery(const uint_least8_t &kmer_size, const double &read_error_rate, const uint8_t max_insertion_size = 10);
 
     void find_paths_through_candidate_region(CandidateRegion &candidate_region);
 

--- a/include/denovo_discovery/local_assembly.h
+++ b/include/denovo_discovery/local_assembly.h
@@ -23,7 +23,7 @@ using DfsTree = std::unordered_map<std::string, GraphVector<Node>>;
 using DenovoPaths = std::vector<std::string>;
 
 constexpr float COVG_SCALING_FACTOR { 0.1 };
-constexpr auto MAX_NUMBER_CANDIDATE_PATHS { 50 };
+constexpr auto MAX_NUMBER_CANDIDATE_PATHS { 25 };
 
 
 class LocalAssemblyGraph : public Graph {
@@ -32,15 +32,15 @@ public:
 
     std::pair<Node, bool> get_node(const std::string &query_kmer);
 
-    DfsTree depth_first_search_from(const Node &start_node);
-
-    DenovoPaths get_paths_between(const std::string &start_kmer, const std::string &end_kmer,
-                                  std::unordered_map<string, GraphVector<Node> > &tree, const uint32_t &max_path_length,
+    DenovoPaths get_paths_between(const Node &start_node, const Node &end_node,
+                                  const uint32_t &max_path_length,
                                   const double &expected_coverage = 1);
 
 private:
+    DfsTree depth_first_search_from(const Node &start_node, bool reverse=false);
+
     void build_paths_between(const std::string &start_kmer, const std::string &end_kmer, std::string path_accumulator,
-                             std::unordered_map<string, GraphVector<Node>> &tree, DenovoPaths &paths_between_queries,
+                             DfsTree &tree, DfsTree &reverse_tree, DenovoPaths &paths_between_queries,
                              const uint32_t &max_path_length, const double &expected_kmer_covg,
                              const float &required_percent_of_expected_covg = COVG_SCALING_FACTOR,
                              uint32_t num_kmers_below_threshold = 0);

--- a/test/denovo_discovery/denovo_discovery_test.cpp
+++ b/test/denovo_discovery/denovo_discovery_test.cpp
@@ -189,7 +189,8 @@ TEST(FindPathsThroughCandidateRegionTest, endKmersDontExistInGraphReturnEmpty) {
 TEST(FindPathsThroughCandidateRegionTest, endKmerExistsInStartKmersFindPathAndCycles) {
     const int k { 9 };
     const double error_rate { 0.11 };
-    DenovoDiscovery denovo { k, error_rate };
+    const uint8_t max_insertion_size = 50;
+    DenovoDiscovery denovo { k, error_rate, max_insertion_size };
     CandidateRegion candidate_region { Interval(0, 1), "test" };
     candidate_region.max_likelihood_sequence = "ATGCGCTGAGATGCGCTGA";
     candidate_region.pileup = { "ATGCGCTGACATGCGCTGA", "ATGCGCTGACATGCGCTGA" };

--- a/test/denovo_discovery/local_assembly_test.cpp
+++ b/test/denovo_discovery/local_assembly_test.cpp
@@ -155,9 +155,9 @@ TEST(GetNodeFromGraph, NonExistentKmer_NotFoundInGraphAndNodeEmpty) {
 
 
 TEST(GetPathsBetweenTest, OnlyReturnPathsBetweenStartAndEndKmers) {
-    const std::string s1 { "AATGTAAGG" };
-    const std::string s2 { "AATGTCAGG" };
-    const std::string s3 { "AATGTTAGG" };
+    const std::string s1 { "AATGTAAGGCC" };
+    const std::string s2 { "AATGTCAGGCC" };
+    const std::string s3 { "AATGTTAGGCC" };
     std::vector<std::string> seqs = { s1, s2, s3 };
 
     LocalAssemblyGraph graph;
@@ -168,10 +168,11 @@ TEST(GetPathsBetweenTest, OnlyReturnPathsBetweenStartAndEndKmers) {
     bool found;
     std::tie(start_node, found) = graph.get_node("AATGT");
 
-    auto tree = graph.depth_first_search_from(start_node);
+    Node end_node;
+    const auto end_kmer { "AGGCC" };
+    std::tie(end_node, found) = graph.get_node(end_kmer);
 
-    const auto end_kmer { "AGG" };
-    auto result = graph.get_paths_between("AATGT", end_kmer, tree, g_test_max_path);
+    auto result = graph.get_paths_between(start_node, end_node, g_test_max_path);
 
     DenovoPaths expected_seqs(seqs.begin(), seqs.end());
     EXPECT_EQ(result, expected_seqs);
@@ -195,9 +196,12 @@ TEST(GetPathsBetweenTest, lotsOfHighCovgCyclesReturnEmpty) {
     Node start_node;
     bool found;
     std::tie(start_node, found) = graph.get_node(start_kmer);
-    auto tree { graph.depth_first_search_from(start_node) };
 
-    auto actual { graph.get_paths_between(start_kmer, end_kmer, tree, max_path_length, expected_coverage) };
+    Node end_node;
+    std::tie(end_node, found) = graph.get_node(end_kmer);
+
+
+    auto actual { graph.get_paths_between(start_node, end_node, max_path_length, expected_coverage) };
     DenovoPaths expected;
     remove_graph_file();
 
@@ -218,8 +222,10 @@ TEST(DepthFirstSearchFromTest, SimpleGraphTwoNodesReturnSeqPassedIn) {
     bool found;
     std::tie(start_node, found) = graph.get_node(start_kmer);
 
-    auto tree = graph.depth_first_search_from(start_node);
-    auto result = graph.get_paths_between(start_kmer, end_kmer, tree, g_test_max_path);
+    Node end_node;
+    std::tie(end_node, found) = graph.get_node(end_kmer);
+
+    auto result = graph.get_paths_between(start_node, end_node, g_test_max_path);
 
     EXPECT_EQ(result.size(), 1);
     EXPECT_EQ(*result.begin(), seq);
@@ -240,8 +246,10 @@ TEST(DepthFirstSearchFromTest, SimpleGraphSixNodesReturnSeqPassedIn) {
     bool found;
     std::tie(start_node, found) = graph.get_node(start_kmer);
 
-    auto tree = graph.depth_first_search_from(start_node);
-    auto result = graph.get_paths_between(start_kmer, end_kmer, tree, g_test_max_path);
+    Node end_node;
+    std::tie(end_node, found) = graph.get_node(end_kmer);
+
+    auto result = graph.get_paths_between(start_node, end_node, g_test_max_path);
 
     bool original_seq_found = false;
     // make sure all paths begin and end with correct kmer
@@ -274,8 +282,10 @@ TEST(DepthFirstSearchFromTest, TwoReadsSameSequenceReturnOneSequence) {
     bool found;
     std::tie(start_node, found) = graph.get_node(start_kmer);
 
-    auto tree = graph.depth_first_search_from(start_node);
-    auto result = graph.get_paths_between(start_kmer, end_kmer, tree, g_test_max_path);
+    Node end_node;
+    std::tie(end_node, found) = graph.get_node(end_kmer);
+
+    auto result = graph.get_paths_between(start_node, end_node, g_test_max_path);
 
     EXPECT_EQ(result.size(), 1);
     EXPECT_EQ(*result.begin(), seq1);
@@ -298,8 +308,10 @@ TEST(DepthFirstSearchFromTest, TwoReadsOneVariantReturnOriginalTwoSequences) {
     bool found;
     std::tie(start_node, found) = graph.get_node(start_kmer);
 
-    auto tree = graph.depth_first_search_from(start_node);
-    auto result = graph.get_paths_between(start_kmer, end_kmer, tree, g_test_max_path);
+    Node end_node;
+    std::tie(end_node, found) = graph.get_node(end_kmer);
+
+    auto result = graph.get_paths_between(start_node, end_node, g_test_max_path);
 
     int original_seq_found = 0;
     for (auto &path: result) {
@@ -332,8 +344,10 @@ TEST(DepthFirstSearchFromTest, ThreeReadsTwoVariantsReturnOriginalSequences) {
     bool found;
     std::tie(start_node, found) = graph.get_node(start_kmer);
 
-    auto tree = graph.depth_first_search_from(start_node);
-    auto result = graph.get_paths_between(start_kmer, end_kmer, tree, g_test_max_path);
+    Node end_node;
+    std::tie(end_node, found) = graph.get_node(end_kmer);
+
+    auto result = graph.get_paths_between(start_node, end_node, g_test_max_path);
 
     int original_seq_found = 0;
     for (auto &path: result) {
@@ -367,8 +381,10 @@ TEST(DepthFirstSearchFromTest, TwoReadsTwoVariantsReturnOriginalTwoSequencesPlus
     bool found;
     std::tie(start_node, found) = graph.get_node(start_kmer);
 
-    auto tree = graph.depth_first_search_from(start_node);
-    auto result = graph.get_paths_between(start_kmer, end_kmer, tree, g_test_max_path);
+    Node end_node;
+    std::tie(end_node, found) = graph.get_node(end_kmer);
+
+    auto result = graph.get_paths_between(start_node, end_node, g_test_max_path);
 
     // add other expected paths due to variants
     std::vector<std::string> expected_seqs = { seq1, seq2, "TTGGTGATCCCATTATG", "TTGGTCATCCCGTTATG" };
@@ -398,8 +414,10 @@ TEST(DepthFirstSearchFromTest, ThreeReadsOneReverseComplimentReturnPathsForStran
     bool found;
     std::tie(start_node, found) = graph.get_node(start_kmer);
 
-    auto tree = graph.depth_first_search_from(start_node);
-    auto result = graph.get_paths_between(start_kmer, end_kmer, tree, g_test_max_path);
+    Node end_node;
+    std::tie(end_node, found) = graph.get_node(end_kmer);
+
+    auto result = graph.get_paths_between(start_node, end_node, g_test_max_path);
 
     // add other expected paths due to variants
     const std::string expected_seq = "ATGTGCA";
@@ -426,8 +444,10 @@ TEST(DepthFirstSearchFromTest, SimpleCycleReturnPathsOfLengthsUpToMaxPathLengthC
     bool found;
     std::tie(start_node, found) = graph.get_node(start_kmer);
 
-    auto tree = graph.depth_first_search_from(start_node);
-    auto result = graph.get_paths_between(start_kmer, end_kmer, tree, g_test_max_path);
+    Node end_node;
+    std::tie(end_node, found) = graph.get_node(end_kmer);
+
+    auto result = graph.get_paths_between(start_node, end_node, g_test_max_path);
 
     const std::string min_expected_seq = "ATATAT";
     bool is_in = false;


### PR DESCRIPTION
* Ensure we just explore nodes that can reach the end kmer in denovo.

* Changing the default `max_insertion_size` from 50 to 10.

* Changing `MAX_NUMBER_CANDIDATE_PATHS` from 50 to 25.

* Now denovo will continue searching start and end kmers combination if it does not find any denovo paths between a pair.

* `LocalAssemblyGraph::depth_first_search_from()` is now private and it is called inside `LocalAssemblyGraph::get_paths_between()`.