### PR TITLE
Adding a RELEASE_WITH_ASSERTS build configuration

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,6 +3,9 @@ cmake_minimum_required(VERSION 2.8.7)
 set(PROJECT_NAME_STR pandora)
 project(${PROJECT_NAME_STR} C CXX)
 
+# add a RELEASE_WITH_ASSERTS build type
+set(CMAKE_CXX_FLAGS_RELEASE_WITH_ASSERTS "-O3")
+
 find_package(Threads REQUIRED)
 find_package(ZLIB REQUIRED)
 


### PR DESCRIPTION
Closes https://github.com/rmcolq/pandora/issues/166 if you are fine with enabling asserts in Release mode (which I strongly think we should do as of now).
Release binary now has to be built with: `cmake -DCMAKE_BUILD_TYPE=RELEASE_WITH_ASSERTS ..`.
All tests in both Release and Debug modes are passing.

Might also close https://github.com/rmcolq/pandora/issues/118 , since with optimization flags tests run a lot faster:
`1/1 Test #1: pandora_test .....................   Passed    6.37 sec`
