### PR TITLE
Resolves issue #174 and disable openmp for mac

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,12 +24,14 @@ else ()
     message(FATAL_ERROR "Compiler ${CMAKE_CXX_COMPILER} has no C++11 support")
 endif ()
 
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DBOOST_SYSTEM_NO_DEPRECATED -Wall -Wextra")
+
 if (${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
     set(MACOSX TRUE)
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DBOOST_SYSTEM_NO_DEPRECATED -DNO_OPENMP -Wall -Wextra")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DNO_OPENMP")
 else ()
-    find_package(OPENMP 4.5 REQUIRED)
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DBOOST_SYSTEM_NO_DEPRECATED -fopenmp -Wall -Wextra")
+    find_package(OPENMP 4.0 REQUIRED)
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fopenmp")
 endif()
 
 #print CMAKE debug and release flags to know what we are exactly doing

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,7 +24,13 @@ else ()
     message(FATAL_ERROR "Compiler ${CMAKE_CXX_COMPILER} has no C++11 support")
 endif ()
 
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DBOOST_SYSTEM_NO_DEPRECATED -fopenmp -Wall -Wextra")
+if (${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
+    set(MACOSX TRUE)
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DBOOST_SYSTEM_NO_DEPRECATED -DNO_OPENMP -Wall -Wextra")
+else ()
+    find_package(OPENMP 4.5 REQUIRED)
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DBOOST_SYSTEM_NO_DEPRECATED -fopenmp -Wall -Wextra")
+endif()
 
 #print CMAKE debug and release flags to know what we are exactly doing
 #message("CMAKE_CXX_FLAGS_DEBUG is ${CMAKE_CXX_FLAGS_DEBUG}")

--- a/include/denovo_discovery/candidate_region.h
+++ b/include/denovo_discovery/candidate_region.h
@@ -9,7 +9,10 @@
 #include "fastaq.h"
 #include "fastaq_handler.h"
 #include "localPRG.h"
-#include <omp.h>
+
+#ifndef NO_OPENMP
+#include<omp.h>
+#endif
 
 
 using CandidateRegionIdentifier = std::tuple<Interval, std::string>;
@@ -74,8 +77,11 @@ private:
     const Interval interval;
     const std::string name;
     const uint_least16_t interval_padding;
+
+    #ifndef NO_OPENMP
     //TODO: check if we might have issues here with copy constructor - I think not: OpenMP locks work on the address of the lock I think
     omp_lock_t add_pileup_entry_lock; //synchronizes multithreaded access to the add_pileup_entry() method
+    #endif
 
     void initialise_filename();
 

--- a/src/denovo_discovery/candidate_region.cpp
+++ b/src/denovo_discovery/candidate_region.cpp
@@ -10,18 +10,24 @@ size_t std::hash<CandidateRegionIdentifier>::operator()(const CandidateRegionIde
 CandidateRegion::CandidateRegion(const Interval &interval, std::string name)
         : interval { interval }, name { std::move(name) }, interval_padding { 0 } {
     initialise_filename();
+    #ifndef NO_OPENMP
     omp_init_lock(&add_pileup_entry_lock);
+    #endif
 }
 
 
 CandidateRegion::CandidateRegion(const Interval &interval, std::string name, const uint_least16_t &interval_padding)
         : interval { interval }, name { std::move(name) }, interval_padding { interval_padding } {
     initialise_filename();
+    #ifndef NO_OPENMP
     omp_init_lock(&add_pileup_entry_lock);
+    #endif
 }
 
 CandidateRegion::~CandidateRegion() {
+    #ifndef NO_OPENMP
     omp_destroy_lock(&add_pileup_entry_lock);
+    #endif
 }
 
 void CandidateRegion::initialise_filename() {
@@ -138,10 +144,13 @@ void CandidateRegion::add_pileup_entry(const std::string &read, const ReadCoordi
         if (!read_coordinate.is_forward) {
             sequence_in_read_overlapping_region = reverse_complement(sequence_in_read_overlapping_region);
         }
-
+        #ifndef NO_OPENMP
         omp_set_lock(&add_pileup_entry_lock);
             this->pileup.push_back(sequence_in_read_overlapping_region);
         omp_unset_lock(&add_pileup_entry_lock);
+        #else
+            this->pileup.push_back(sequence_in_read_overlapping_region);
+        #endif
     }
 }
 


### PR DESCRIPTION
As per the similar CD-hit issue, solution is to disable OpenMP (and multithreading) for MacOS.

- Fix includes removing the -fopenmp linker flag in cmakelists file if the OS is Mac.
- Also avoiding the openmp file locks where necessary.
- Slightly surprisingly, no further handling of the omp process sections seems to be needed for tests to pass (and not segfault), when the -fopenmp is not linked.
