### PR TITLE
add clang-format config

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,4 @@
+﻿---
+BasedOnStyle: WebKit
+
+...


### PR DESCRIPTION
This PR adds a `clang-format` config file which will set default formatting to follow the WebKit style guide.