### PR TITLE
Closes #183 - Fixes bug in LocalPRG::append_kmer_covgs_in_range

### DIFF
--- a/include/localPRG.h
+++ b/include/localPRG.h
@@ -95,9 +95,23 @@ public:
     //TODO: many of them should be in VCF class, or in the KmerGraphWithCoverage or Fastaq
     void build_vcf(VCF &, const std::vector<LocalNodePtr> &) const;
 
-    void append_kmer_covgs_in_range(const KmerGraphWithCoverage &, const std::vector<KmerNodePtr> &,
-                                    const std::vector<LocalNodePtr> &, const uint32_t &, const uint32_t &,
-                                    std::vector<uint32_t> &, std::vector<uint32_t> &, const uint32_t &sample_id) const;
+
+    virtual std::pair<std::vector<uint32_t>, std::vector<uint32_t>>
+    append_kmer_covgs_in_range(const KmerGraphWithCoverage &kmer_graph_with_coverage,
+                               const std::vector<KmerNodePtr> &kmer_path,
+                               const std::vector<LocalNodePtr> &local_path, const uint32_t &range_pos_start,
+                               const uint32_t &range_pos_end, const uint32_t &sample_id) const;
+
+protected: //helper methods of append_kmer_covgs_in_range():
+    virtual uint32_t
+    get_number_of_bases_in_local_path_before_a_given_position(const std::vector<LocalNodePtr> &local_path,
+                                                              uint32_t position) const;
+
+    virtual uint32_t
+    get_number_of_bases_that_are_exclusively_in_the_previous_kmer_node(const KmerNodePtr &previous_kmer_node,
+                                                                       const KmerNodePtr &current_kmer_node) const;
+
+public:
 
     void add_sample_covgs_to_vcf(VCF &, const KmerGraphWithCoverage &, const std::vector<LocalNodePtr> &,
                                      const uint32_t &min_kmer_covg, const std::string &sample_name="sample",

--- a/include/localPRG.h
+++ b/include/localPRG.h
@@ -97,12 +97,12 @@ public:
 
 
     virtual std::pair<std::vector<uint32_t>, std::vector<uint32_t>>
-    append_kmer_covgs_in_range(const KmerGraphWithCoverage &kmer_graph_with_coverage,
-                               const std::vector<KmerNodePtr> &kmer_path,
-                               const std::vector<LocalNodePtr> &local_path, const uint32_t &range_pos_start,
-                               const uint32_t &range_pos_end, const uint32_t &sample_id) const;
+    get_forward_and_reverse_kmer_coverages_in_range(const KmerGraphWithCoverage &kmer_graph_with_coverage,
+                                                    const std::vector<KmerNodePtr> &kmer_path,
+                                                    const std::vector<LocalNodePtr> &local_path, const uint32_t &range_pos_start,
+                                                    const uint32_t &range_pos_end, const uint32_t &sample_id) const;
 
-protected: //helper methods of append_kmer_covgs_in_range():
+protected: //helper methods of get_forward_and_reverse_kmer_coverages_in_range():
     virtual uint32_t
     get_number_of_bases_in_local_path_before_a_given_position(const std::vector<LocalNodePtr> &local_path,
                                                               uint32_t position) const;

--- a/src/localPRG.cpp
+++ b/src/localPRG.cpp
@@ -1235,10 +1235,10 @@ LocalPRG::get_number_of_bases_that_are_exclusively_in_the_previous_kmer_node(con
 
 
 std::pair<std::vector<uint32_t>, std::vector<uint32_t>>
-LocalPRG::append_kmer_covgs_in_range(const KmerGraphWithCoverage &kmer_graph_with_coverage,
-                                     const std::vector<KmerNodePtr> &kmer_path,
-                                     const std::vector<LocalNodePtr> &local_path, const uint32_t &range_pos_start,
-                                     const uint32_t &range_pos_end, const uint32_t &sample_id) const {
+LocalPRG::get_forward_and_reverse_kmer_coverages_in_range(const KmerGraphWithCoverage &kmer_graph_with_coverage,
+                                                          const std::vector<KmerNodePtr> &kmer_path,
+                                                          const std::vector<LocalNodePtr> &local_path, const uint32_t &range_pos_start,
+                                                          const uint32_t &range_pos_end, const uint32_t &sample_id) const {
     assert(kmer_path.size() >
            1); // this is an assert because it is the programmers responsibility to ensure that the kmer_path given to this function has at least size 1
     // TODO: this assert could be removed if we represent std::vector<KmerNodePtr> as a concept (class) in such a way that this class could only be constructed if given a large enough kmer_path (or whatever condition to build a correct kmer_path)
@@ -1400,7 +1400,9 @@ void LocalPRG::add_sample_covgs_to_vcf(VCF &vcf, const KmerGraphWithCoverage &kg
 
         std::vector<uint32_t> ref_fwd_covgs;
         std::vector<uint32_t> ref_rev_covgs;
-        std::tie(ref_fwd_covgs, ref_rev_covgs) = append_kmer_covgs_in_range(kg, ref_kmer_path, ref_path, record.pos, end_pos, sample_id);
+        std::tie(ref_fwd_covgs, ref_rev_covgs) = get_forward_and_reverse_kmer_coverages_in_range(kg, ref_kmer_path,
+                                                                                                 ref_path, record.pos,
+                                                                                                 end_pos, sample_id);
 
         // find corresponding alt kmers
         // if sample has alt path, we have the kmer path for this, but otherwise we will need to work it out
@@ -1429,7 +1431,10 @@ void LocalPRG::add_sample_covgs_to_vcf(VCF &vcf, const KmerGraphWithCoverage &kg
 
             std::vector<uint32_t> alt_fwd_covgs;
             std::vector<uint32_t> alt_rev_covgs;
-            std::tie(alt_fwd_covgs, alt_rev_covgs) = append_kmer_covgs_in_range(kg, alt_kmer_path, alt_path, record.pos, end_pos, sample_id);
+            std::tie(alt_fwd_covgs, alt_rev_covgs) = get_forward_and_reverse_kmer_coverages_in_range(kg, alt_kmer_path,
+                                                                                                     alt_path,
+                                                                                                     record.pos,
+                                                                                                     end_pos, sample_id);
 
             record.append_format(sample_index, "MEAN_FWD_COVG", mean(alt_fwd_covgs));
             record.append_format(sample_index, "MEAN_REV_COVG", mean(alt_rev_covgs));

--- a/test/README.md
+++ b/test/README.md
@@ -1,0 +1,132 @@
+# Testing guidelines
+
+Here are described some conventions to write tests in `pandora`. While you are encouraged to follow these conventions,
+we are not strict in the sense that you can bypass these conventions in case your test case needs, or if by following these
+conventions your tests are hard to read. The most important thing is to make tests readable and easy to understand. Also,
+we should consider tests as important as production code, because they are the ones enabling us to change, evolve, and ensure
+`pandora` is behaving as we expect. If the quality of our test code decrease, the quality of our production code will
+eventually decrease. So, make your tests readable, maintenable, clean, and without duplicated code.
+These conventions help you to achieve this.
+
+NB: this is a fairly incomplete and sometimes imprecise document, far from being good, it will
+get better with time. Some stuff here might not be the best way to do something, we will be improving it as we write more
+ and more unit tests following these conventions.
+ The big majority of `pandora` tests do not follow these conventions, they will be slowly refactored.
+
+## Conventions
+
+If you have any suggestions for these conventions, please feel free to add.
+
+* Use mocked objects to emulate complex dependencies which are hard to setup;
+  * For simple dependencies (e.g. an `Interval` object), feel free to skip mocking, as it is probably easier and readable to setup such simple dependencies with real objects; 
+
+* Use dependency injection when designing classes to make it easier to mock during tests;
+
+* Do not refer directly to test code inside production code
+  * For example, if you have to test a `private` method of your class, make it `virtual protected`, create a mock class
+  that extends your class to be tested, and change the visibility of the tested method to `public`. Prefer this than making test cases `friend`s
+  of the tested class. There is a specific place to create such a mock class (in a Fixture class, see below);
+
+* For each tested method of a class, always declare a Fixture class even if your tests do not have share a common setup/teardown
+  * This will encourage the non-duplication of setup and teardowns, and makes it easier to understand each test as they follow the same standard;
+  * The Fixture class naming should obey the following convention: `<class_name>Test___<method_name>___Fixture`
+  
+* Your fixture class should mock all dependencies of the tested method
+  * This includes methods of the same class of the tested method;
+  * Your fixture class should have several mock classes defined inside it;
+  
+* Each test should follow this very simple algorithm, which is divided in four sections:
+  1. Variable setups (aided by mocking and the Fixture class);
+  2. Invocation of the tested method/function;
+  3. Teardown (aided by the Fixture class)
+  4. Assertion of the result;
+
+* No section in each test should have more than a few lines. Sections 2 and 4 should preferably have a single line.
+If your tests are long, there should be probably some code that could be duplicated between tests, or a hidden concept that could be better
+described in a function or class to improve readability. Remember that your main task is to test the code, but also make it very easy for anyone reading the test to
+understand what it does;
+
+* A test tests only one condition and nothing else; 
+
+* Your test naming should obey the following convention: `TEST_F(<FixtureClassName>, <short_description_of_the_test>___<expected result>)`
+
+
+## Templates
+
+### Fixture class template
+
+```
+class <Class_name>Test___<Method_name>___Fixture : public ::testing::Test {
+protected:
+    class <First_mocked_class> : public <Real_class_or_another_mocked_class> {
+    public:
+        <methods_to_mock>
+    };
+
+
+    void SetUp() override {
+        // Code here will be called right before each test
+    }
+
+    void TearDown() override {
+        // Code here will be called immediately after each test 
+    }
+
+    // Objects declared here can be used by all tests for this fixture
+    // You should have at least one object for each mocked class
+};
+```
+
+### Test using the fixture class
+```
+TEST_F(<FixtureClassName>, <short_description_of_the_test>___<expected result>) {
+    <Section_1: additional_setups>
+
+    <Section_2: invocation_of_the_method>
+
+    <Section_3: additional_teardowns>
+
+    <Section_4: assertion_of_the_result>
+}
+```
+
+
+## Examples
+### Fixture class
+```
+class LocalPRGTest___get_number_of_bases_in_local_path_before_a_given_position___Fixture : public ::testing::Test {
+protected:
+    class LocalPRGMockExposesTestedMethod : public LocalPRGMock {
+    public:
+        virtual uint32_t get_number_of_bases_in_local_path_before_a_given_position(const std::vector<LocalNodePtr> &local_path,
+                                                                                   uint32_t position) const {
+            return LocalPRGMock::get_number_of_bases_in_local_path_before_a_given_position(local_path, position);
+        }
+    };
+
+
+    void SetUp() override {
+        local_path_with_two_intervals.push_back(std::make_shared<LocalNode>("", Interval(10, 20), 0));
+        local_path_with_two_intervals.push_back(std::make_shared<LocalNode>("", Interval(35, 45), 1));
+    }
+
+    void TearDown() override {
+    }
+
+    LocalPRGMockExposesTestedMethod local_prg_mock;
+    std::vector<LocalNodePtr> empty_local_path;
+    std::vector<LocalNodePtr> local_path_with_two_intervals;
+};
+```
+
+### Test
+```
+TEST_F(LocalPRGTest___get_number_of_bases_in_local_path_before_a_given_position___Fixture, empty_local_path___returns_0) {
+    uint32_t position = 30;
+
+    uint32_t actual = local_prg_mock.get_number_of_bases_in_local_path_before_a_given_position(empty_local_path, position);
+
+    uint32_t expected = 0;
+    ASSERT_EQ(actual, expected);
+}
+```

--- a/test/localPRG_test.cpp
+++ b/test/localPRG_test.cpp
@@ -1316,7 +1316,6 @@ TEST(LocalPRGTest, find_alt_path) {
 
 }
 
-// TODO: refactor some tests here to make use of mocks
 class LocalPRGMock : public LocalPRG {
 public:
     LocalPRGMock() : LocalPRG(0, "", "") {}
@@ -1613,7 +1612,7 @@ TEST_F(LocalPRGTest___get_number_of_bases_that_are_exclusively_in_the_previous_k
 
 
 
-TEST(LocalPRGTest, append_kmer_covgs_in_range) {
+TEST(LocalPRGTest, get_forward_and_reverse_kmer_coverages_in_range) {
     auto index = std::make_shared<Index>();
     LocalPRG l3(3, "nested varsite", "A 5 G 7 C 8 T 7  6 G 5 TAT");
     l3.minimizer_sketch(index, 1, 3);
@@ -1639,29 +1638,29 @@ TEST(LocalPRGTest, append_kmer_covgs_in_range) {
     };
     vector<uint32_t> fwd, rev, exp_fwd, exp_rev;
 
-    std::tie(fwd, rev) = l3.append_kmer_covgs_in_range(kg, kmp, lmp, 0, 0, 0);
+    std::tie(fwd, rev) = l3.get_forward_and_reverse_kmer_coverages_in_range(kg, kmp, lmp, 0, 0, 0);
     EXPECT_TRUE(fwd.empty());
     EXPECT_TRUE(rev.empty());
 
-    std::tie(fwd, rev) = l3.append_kmer_covgs_in_range(kg, kmp, lmp, 0, 1, 0);
+    std::tie(fwd, rev) = l3.get_forward_and_reverse_kmer_coverages_in_range(kg, kmp, lmp, 0, 1, 0);
     exp_fwd = {4};
     exp_rev = {3};
     EXPECT_ITERABLE_EQ(vector<uint32_t>, exp_fwd, fwd);
     EXPECT_ITERABLE_EQ(vector<uint32_t>, exp_rev, rev);
 
-    std::tie(fwd, rev) = l3.append_kmer_covgs_in_range(kg, kmp, lmp, 0, 2, 0);
+    std::tie(fwd, rev) = l3.get_forward_and_reverse_kmer_coverages_in_range(kg, kmp, lmp, 0, 2, 0);
     exp_fwd = {4, 4};
     exp_rev = {3, 5};
     EXPECT_ITERABLE_EQ(vector<uint32_t>, exp_fwd, fwd);
     EXPECT_ITERABLE_EQ(vector<uint32_t>, exp_rev, rev);
 
-    std::tie(fwd, rev) = l3.append_kmer_covgs_in_range(kg, kmp, lmp, 0, 3, 0);
+    std::tie(fwd, rev) = l3.get_forward_and_reverse_kmer_coverages_in_range(kg, kmp, lmp, 0, 3, 0);
     exp_fwd = {4, 4, 4};
     exp_rev = {3, 5, 6};
     EXPECT_ITERABLE_EQ(vector<uint32_t>, exp_fwd, fwd);
     EXPECT_ITERABLE_EQ(vector<uint32_t>, exp_rev, rev);
 
-    std::tie(fwd, rev) = l3.append_kmer_covgs_in_range(kg, kmp, lmp, 1, 2, 0);
+    std::tie(fwd, rev) = l3.get_forward_and_reverse_kmer_coverages_in_range(kg, kmp, lmp, 1, 2, 0);
     exp_fwd = {4, 4};
     exp_rev = {3, 5};
     EXPECT_ITERABLE_EQ(vector<uint32_t>, exp_fwd, fwd);

--- a/test/localPRG_test.cpp
+++ b/test/localPRG_test.cpp
@@ -1316,6 +1316,303 @@ TEST(LocalPRGTest, find_alt_path) {
 
 }
 
+// TODO: refactor some tests here to make use of mocks
+class LocalPRGMock : public LocalPRG {
+public:
+    LocalPRGMock() : LocalPRG(0, "", "") {}
+};
+
+
+class LocalPRGTest___get_number_of_bases_in_local_path_before_a_given_position___Fixture : public ::testing::Test {
+protected:
+    class LocalPRGMockExposesTestedMethod : public LocalPRGMock {
+    public:
+        virtual uint32_t
+        get_number_of_bases_in_local_path_before_a_given_position(const std::vector<LocalNodePtr> &local_path,
+                                                                  uint32_t position) const {
+            return LocalPRGMock::get_number_of_bases_in_local_path_before_a_given_position(local_path, position);
+        }
+    };
+
+
+    void SetUp() override {
+        local_path_with_two_intervals.push_back(std::make_shared<LocalNode>("", Interval(10, 20), 0));
+        local_path_with_two_intervals.push_back(std::make_shared<LocalNode>("", Interval(35, 45), 1));
+    }
+
+    void TearDown() override {
+    }
+
+    LocalPRGMockExposesTestedMethod local_prg_mock;
+    std::vector<LocalNodePtr> empty_local_path;
+    std::vector<LocalNodePtr> local_path_with_two_intervals;
+};
+
+
+TEST_F(LocalPRGTest___get_number_of_bases_in_local_path_before_a_given_position___Fixture,
+       empty_local_path___returns_0) {
+    uint32_t position = 30;
+
+    uint32_t actual = local_prg_mock.get_number_of_bases_in_local_path_before_a_given_position(empty_local_path,
+                                                                                               position);
+
+    uint32_t expected = 0;
+    ASSERT_EQ(actual, expected);
+}
+
+TEST_F(LocalPRGTest___get_number_of_bases_in_local_path_before_a_given_position___Fixture,
+       local_path_with_two_intervals___position_just_before_first_interval___returns_0) {
+    uint32_t position = 9;
+
+    uint32_t actual = local_prg_mock.get_number_of_bases_in_local_path_before_a_given_position(
+            local_path_with_two_intervals, position);
+
+    uint32_t expected = 0;
+    ASSERT_EQ(actual, expected);
+}
+
+TEST_F(LocalPRGTest___get_number_of_bases_in_local_path_before_a_given_position___Fixture,
+       local_path_with_two_intervals___position_at_the_start_of_first_interval___returns_0) {
+    uint32_t position = 10;
+
+    uint32_t actual = local_prg_mock.get_number_of_bases_in_local_path_before_a_given_position(
+            local_path_with_two_intervals, position);
+
+    uint32_t expected = 0;
+    ASSERT_EQ(actual, expected);
+}
+
+TEST_F(LocalPRGTest___get_number_of_bases_in_local_path_before_a_given_position___Fixture,
+       local_path_with_two_intervals___position_just_after_the_start_of_first_interval___returns_1) {
+    uint32_t position = 11;
+
+    uint32_t actual = local_prg_mock.get_number_of_bases_in_local_path_before_a_given_position(
+            local_path_with_two_intervals, position);
+
+    uint32_t expected = 1;
+    ASSERT_EQ(actual, expected);
+}
+
+TEST_F(LocalPRGTest___get_number_of_bases_in_local_path_before_a_given_position___Fixture,
+       local_path_with_two_intervals___position_just_before_the_end_of_first_interval___returns_8) {
+    uint32_t position = 18;
+
+    uint32_t actual = local_prg_mock.get_number_of_bases_in_local_path_before_a_given_position(
+            local_path_with_two_intervals, position);
+
+    uint32_t expected = 8;
+    ASSERT_EQ(actual, expected);
+}
+
+TEST_F(LocalPRGTest___get_number_of_bases_in_local_path_before_a_given_position___Fixture,
+       local_path_with_two_intervals___position_at_the_end_of_first_interval___returns_9) {
+    uint32_t position = 19;
+
+    uint32_t actual = local_prg_mock.get_number_of_bases_in_local_path_before_a_given_position(
+            local_path_with_two_intervals, position);
+
+    uint32_t expected = 9;
+    ASSERT_EQ(actual, expected);
+}
+
+TEST_F(LocalPRGTest___get_number_of_bases_in_local_path_before_a_given_position___Fixture,
+       local_path_with_two_intervals___position_just_after_the_end_of_first_interval___returns_10) {
+    uint32_t position = 20;
+
+    uint32_t actual = local_prg_mock.get_number_of_bases_in_local_path_before_a_given_position(
+            local_path_with_two_intervals, position);
+
+    uint32_t expected = 10;
+    ASSERT_EQ(actual, expected);
+}
+
+
+TEST_F(LocalPRGTest___get_number_of_bases_in_local_path_before_a_given_position___Fixture,
+       local_path_with_two_intervals___position_between_intervals___returns_10) {
+    uint32_t position = 30;
+
+    uint32_t actual = local_prg_mock.get_number_of_bases_in_local_path_before_a_given_position(
+            local_path_with_two_intervals, position);
+
+    uint32_t expected = 10;
+    ASSERT_EQ(actual, expected);
+}
+
+TEST_F(LocalPRGTest___get_number_of_bases_in_local_path_before_a_given_position___Fixture,
+       local_path_with_two_intervals___position_at_the_start_of_second_interval___returns_10) {
+    uint32_t position = 35;
+
+    uint32_t actual = local_prg_mock.get_number_of_bases_in_local_path_before_a_given_position(
+            local_path_with_two_intervals, position);
+
+    uint32_t expected = 10;
+    ASSERT_EQ(actual, expected);
+}
+
+TEST_F(LocalPRGTest___get_number_of_bases_in_local_path_before_a_given_position___Fixture,
+       local_path_with_two_intervals___position_just_after_the_start_of_second_interval___returns_11) {
+    uint32_t position = 36;
+
+    uint32_t actual = local_prg_mock.get_number_of_bases_in_local_path_before_a_given_position(
+            local_path_with_two_intervals, position);
+
+    uint32_t expected = 11;
+    ASSERT_EQ(actual, expected);
+}
+
+
+class LocalPRGTest___get_number_of_bases_that_are_exclusively_in_the_previous_kmer_node___Fixture
+        : public ::testing::Test {
+protected:
+    class LocalPRGMockExposesTestedMethod : public LocalPRGMock {
+    public:
+        virtual uint32_t
+        get_number_of_bases_that_are_exclusively_in_the_previous_kmer_node(const KmerNodePtr &previous_kmer_node,
+                                                                           const KmerNodePtr &current_kmer_node) const {
+            return LocalPRGMock::get_number_of_bases_that_are_exclusively_in_the_previous_kmer_node(previous_kmer_node,
+                                                                                                    current_kmer_node);
+        }
+    };
+
+
+    void SetUp() override {
+        {
+            prg::Path path_from_3_to_30;
+            path_from_3_to_30.push_back(Interval(3, 7));
+            path_from_3_to_30.push_back(Interval(12, 20));
+            path_from_3_to_30.push_back(Interval(20, 25));
+            path_from_3_to_30.push_back(Interval(25, 30));
+            kmer_node_from_3_to_30 = std::make_shared<KmerNode>(1, path_from_3_to_30);
+        }
+
+        {
+            prg::Path path_from_3_to_50;
+            path_from_3_to_50.push_back(Interval(3, 50));
+            kmer_node_from_3_to_50 = std::make_shared<KmerNode>(2, path_from_3_to_50);
+        }
+
+        {
+            prg::Path path_from_4_to_50;
+            path_from_4_to_50.push_back(Interval(4, 50));
+            kmer_node_from_4_to_50 = std::make_shared<KmerNode>(2, path_from_4_to_50);
+        }
+
+        {
+            prg::Path path_from_7_to_50;
+            path_from_7_to_50.push_back(Interval(7, 50));
+            kmer_node_from_7_to_50 = std::make_shared<KmerNode>(2, path_from_7_to_50);
+        }
+
+        {
+            prg::Path path_from_10_to_50;
+            path_from_10_to_50.push_back(Interval(10, 50));
+            kmer_node_from_10_to_50 = std::make_shared<KmerNode>(2, path_from_10_to_50);
+        }
+
+        {
+            prg::Path path_from_15_to_50;
+            path_from_15_to_50.push_back(Interval(15, 50));
+            kmer_node_from_15_to_50 = std::make_shared<KmerNode>(2, path_from_15_to_50);
+        }
+
+
+        {
+            prg::Path path_from_40_to_50;
+            path_from_40_to_50.push_back(Interval(40, 50));
+            kmer_node_from_40_to_50 = std::make_shared<KmerNode>(2, path_from_40_to_50);
+        }
+    }
+
+    void TearDown() override {
+    }
+
+    LocalPRGMockExposesTestedMethod local_prg_mock;
+    KmerNodePtr kmer_node_from_3_to_30;
+    KmerNodePtr kmer_node_from_3_to_50;
+    KmerNodePtr kmer_node_from_4_to_50;
+    KmerNodePtr kmer_node_from_7_to_50;
+    KmerNodePtr kmer_node_from_10_to_50;
+    KmerNodePtr kmer_node_from_15_to_50;
+    KmerNodePtr kmer_node_from_40_to_50;
+};
+
+
+TEST_F(LocalPRGTest___get_number_of_bases_that_are_exclusively_in_the_previous_kmer_node___Fixture,
+       previous_node_exactly_at_the_start_of_current_node___returns_0) {
+    KmerNodePtr previous_node = kmer_node_from_3_to_30;
+    KmerNodePtr current_node = kmer_node_from_3_to_50;
+
+    uint32_t actual = local_prg_mock.get_number_of_bases_that_are_exclusively_in_the_previous_kmer_node(previous_node,
+                                                                                                        current_node);
+
+    uint32_t expected = 0;
+    ASSERT_EQ(actual, expected);
+}
+
+TEST_F(LocalPRGTest___get_number_of_bases_that_are_exclusively_in_the_previous_kmer_node___Fixture,
+       previous_node_just_before_the_start_of_current_node___returns_1) {
+    KmerNodePtr previous_node = kmer_node_from_3_to_30;
+    KmerNodePtr current_node = kmer_node_from_4_to_50;
+
+    uint32_t actual = local_prg_mock.get_number_of_bases_that_are_exclusively_in_the_previous_kmer_node(previous_node,
+                                                                                                        current_node);
+
+    uint32_t expected = 1;
+    ASSERT_EQ(actual, expected);
+}
+
+TEST_F(LocalPRGTest___get_number_of_bases_that_are_exclusively_in_the_previous_kmer_node___Fixture,
+       current_node_right_at_the_end_of_first_interval_of_previous_node___returns_4) {
+    KmerNodePtr previous_node = kmer_node_from_3_to_30;
+    KmerNodePtr current_node = kmer_node_from_7_to_50;
+
+    uint32_t actual = local_prg_mock.get_number_of_bases_that_are_exclusively_in_the_previous_kmer_node(previous_node,
+                                                                                                        current_node);
+
+    uint32_t expected = 4;
+    ASSERT_EQ(actual, expected);
+}
+
+TEST_F(LocalPRGTest___get_number_of_bases_that_are_exclusively_in_the_previous_kmer_node___Fixture,
+       current_node_between_the_first_and_second_interval_of_previous_node___returns_4) {
+    KmerNodePtr previous_node = kmer_node_from_3_to_30;
+    KmerNodePtr current_node = kmer_node_from_10_to_50;
+
+    uint32_t actual = local_prg_mock.get_number_of_bases_that_are_exclusively_in_the_previous_kmer_node(previous_node,
+                                                                                                        current_node);
+
+    uint32_t expected = 4;
+    ASSERT_EQ(actual, expected);
+}
+
+
+TEST_F(LocalPRGTest___get_number_of_bases_that_are_exclusively_in_the_previous_kmer_node___Fixture,
+       current_node_inside_second_interval_of_previous_node___returns_7) {
+    KmerNodePtr previous_node = kmer_node_from_3_to_30;
+    KmerNodePtr current_node = kmer_node_from_15_to_50;
+
+    uint32_t actual = local_prg_mock.get_number_of_bases_that_are_exclusively_in_the_previous_kmer_node(previous_node,
+                                                                                                        current_node);
+
+    uint32_t expected = 7;
+    ASSERT_EQ(actual, expected);
+}
+
+
+TEST_F(LocalPRGTest___get_number_of_bases_that_are_exclusively_in_the_previous_kmer_node___Fixture,
+       current_node_after_previous_node___returns_22) {
+    KmerNodePtr previous_node = kmer_node_from_3_to_30;
+    KmerNodePtr current_node = kmer_node_from_40_to_50;
+
+    uint32_t actual = local_prg_mock.get_number_of_bases_that_are_exclusively_in_the_previous_kmer_node(previous_node,
+                                                                                                        current_node);
+
+    uint32_t expected = 22;
+    ASSERT_EQ(actual, expected);
+}
+
+
+
 TEST(LocalPRGTest, append_kmer_covgs_in_range) {
     auto index = std::make_shared<Index>();
     LocalPRG l3(3, "nested varsite", "A 5 G 7 C 8 T 7  6 G 5 TAT");
@@ -1342,40 +1639,29 @@ TEST(LocalPRGTest, append_kmer_covgs_in_range) {
     };
     vector<uint32_t> fwd, rev, exp_fwd, exp_rev;
 
-    l3.append_kmer_covgs_in_range(kg, kmp, lmp, 0, 0,
-                                  fwd, rev, 0);
+    std::tie(fwd, rev) = l3.append_kmer_covgs_in_range(kg, kmp, lmp, 0, 0, 0);
     EXPECT_TRUE(fwd.empty());
     EXPECT_TRUE(rev.empty());
 
-    l3.append_kmer_covgs_in_range(kg, kmp, lmp, 0, 1,
-                                  fwd, rev, 0);
+    std::tie(fwd, rev) = l3.append_kmer_covgs_in_range(kg, kmp, lmp, 0, 1, 0);
     exp_fwd = {4};
     exp_rev = {3};
     EXPECT_ITERABLE_EQ(vector<uint32_t>, exp_fwd, fwd);
     EXPECT_ITERABLE_EQ(vector<uint32_t>, exp_rev, rev);
 
-    fwd.clear();
-    rev.clear();
-    l3.append_kmer_covgs_in_range(kg, kmp, lmp, 0, 2,
-                                  fwd, rev, 0);
+    std::tie(fwd, rev) = l3.append_kmer_covgs_in_range(kg, kmp, lmp, 0, 2, 0);
     exp_fwd = {4, 4};
     exp_rev = {3, 5};
     EXPECT_ITERABLE_EQ(vector<uint32_t>, exp_fwd, fwd);
     EXPECT_ITERABLE_EQ(vector<uint32_t>, exp_rev, rev);
 
-    fwd.clear();
-    rev.clear();
-    l3.append_kmer_covgs_in_range(kg, kmp, lmp, 0, 3,
-                                  fwd, rev, 0);
+    std::tie(fwd, rev) = l3.append_kmer_covgs_in_range(kg, kmp, lmp, 0, 3, 0);
     exp_fwd = {4, 4, 4};
     exp_rev = {3, 5, 6};
     EXPECT_ITERABLE_EQ(vector<uint32_t>, exp_fwd, fwd);
     EXPECT_ITERABLE_EQ(vector<uint32_t>, exp_rev, rev);
 
-    fwd.clear();
-    rev.clear();
-    l3.append_kmer_covgs_in_range(kg, kmp, lmp, 1, 2,
-                                  fwd, rev, 0);
+    std::tie(fwd, rev) = l3.append_kmer_covgs_in_range(kg, kmp, lmp, 1, 2, 0);
     exp_fwd = {4, 4};
     exp_rev = {3, 5};
     EXPECT_ITERABLE_EQ(vector<uint32_t>, exp_fwd, fwd);


### PR DESCRIPTION
This PR closes #183 and https://github.com/iqbal-lab/pandora1_paper/issues/101 . We still did not manage to generate the new ROC curves due to cluster issues to check the impact of this fix, but we think this will eventually need to be merged anyway.

I had put the three of you as reviewers because this PR is not just a bugfix, it also describes how I will refactor / make unit tests from now on (i.e. it will impact in `pandora` evolution). Please pay attention to the refactoring of the `LocalPRG::append_kmer_covgs_in_range` method, and the new tests related to `LocalPRG::get_number_of_bases_that_are_exclusively_in_the_previous_kmer_node` and `ocalPRG::get_number_of_bases_that_are_exclusively_in_the_previous_kmer_node`. I will be refactoring `pandora` slowly whenever a bugfix is needed or taking one day/week to do some refactor. Refactoring has also some fraction of personal coding preference, and it also means investing time to improve code quality and maintenance, but no new features/performance improvement is really done.

In the specific case of this PR, the bugfix could have been done by changing only one condition, and it would take 5 minutes and one line change. Refactoring the code and adding unit tests for each new method added during refactoring extended this to ~3-4 hours. More unit tests means that the code is more robust, and this is nice, but the refactoring is more subjective to judge.

Tell me how should I proceed from here: should I spend time for refactoring + more unit tests like done in this PR, or should I focus solely on solving bugs as fast as possible, and investing time in new features/performance improvements? Also, is there a ratio of time spent on refactoring and on evolution (new features/performance improvement) that you are happy with?

Please don't hesitate on being very critical to any of the additions in this PR, it will actually help me and it will increase the code quality in the next PRs.