### PR TITLE
Optimise de novo path enumeration and limit max size of candidate regions

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,4 +1,4 @@
 ﻿---
 BasedOnStyle: WebKit
-
+ColumnLimit: 88
 ...

--- a/include/denovo_discovery/candidate_region.h
+++ b/include/denovo_discovery/candidate_region.h
@@ -89,7 +89,8 @@ private:
 
 std::vector<Interval> identify_low_coverage_intervals(
     const std::vector<uint32_t>& covg_at_each_position,
-    const uint32_t& min_required_covg = 2, const uint32_t& min_length = 1);
+    const uint32_t& min_required_covg = 2, const uint32_t& min_length = 1,
+    const uint32_t& max_length = 20);
 
 using CandidateRegions = std::unordered_map<CandidateRegionIdentifier, CandidateRegion>;
 

--- a/include/denovo_discovery/candidate_region.h
+++ b/include/denovo_discovery/candidate_region.h
@@ -1,45 +1,40 @@
 #ifndef PANDORA_CANDIDATE_REGION_H
 #define PANDORA_CANDIDATE_REGION_H
 
-#include <vector>
-#include <algorithm>
-#include <set>
-#include "interval.h"
 #include "denovo_utils.h"
 #include "fastaq.h"
 #include "fastaq_handler.h"
+#include "interval.h"
 #include "localPRG.h"
+#include <algorithm>
+#include <set>
+#include <vector>
 
 #ifndef NO_OPENMP
-#include<omp.h>
+#include <omp.h>
 #endif
-
 
 using CandidateRegionIdentifier = std::tuple<Interval, std::string>;
 
-
-template<>
-struct std::hash<CandidateRegionIdentifier> {
-    size_t operator()(const CandidateRegionIdentifier &id) const;
+template <> struct std::hash<CandidateRegionIdentifier> {
+    size_t operator()(const CandidateRegionIdentifier& id) const;
 };
-
 
 struct TmpPanNode {
-    const PanNodePtr &pangraph_node;
-    const std::shared_ptr<LocalPRG> &local_prg;
-    const std::vector<KmerNodePtr> &kmer_node_max_likelihood_path;
-    const std::vector<LocalNodePtr> &local_node_max_likelihood_path;
+    const PanNodePtr& pangraph_node;
+    const std::shared_ptr<LocalPRG>& local_prg;
+    const std::vector<KmerNodePtr>& kmer_node_max_likelihood_path;
+    const std::vector<LocalNodePtr>& local_node_max_likelihood_path;
 
-    TmpPanNode(const PanNodePtr &pangraph_node, const std::shared_ptr<LocalPRG> &local_prg,
-               const std::vector<KmerNodePtr> &kmer_node_max_likelihood_path,
-               const std::vector<LocalNodePtr> &local_node_max_likelihood_path);
+    TmpPanNode(const PanNodePtr& pangraph_node,
+        const std::shared_ptr<LocalPRG>& local_prg,
+        const std::vector<KmerNodePtr>& kmer_node_max_likelihood_path,
+        const std::vector<LocalNodePtr>& local_node_max_likelihood_path);
 };
-
 
 using DenovoPaths = std::vector<std::string>;
 using ReadPileup = std::vector<std::string>;
 using ReadCoordinates = std::set<ReadCoordinate>;
-
 
 class CandidateRegion {
 public:
@@ -51,61 +46,66 @@ public:
     fs::path filename;
     DenovoPaths denovo_paths;
 
-    CandidateRegion(const Interval &interval, std::string name);
+    CandidateRegion(const Interval& interval, std::string name);
 
-    CandidateRegion(const Interval &interval, std::string name, const uint_least16_t &interval_padding);
+    CandidateRegion(const Interval& interval, std::string name,
+        const uint_least16_t& interval_padding);
 
     virtual ~CandidateRegion();
 
-    bool operator==(const CandidateRegion &rhs) const;
+    bool operator==(const CandidateRegion& rhs) const;
 
-    bool operator!=(const CandidateRegion &rhs) const;
+    bool operator!=(const CandidateRegion& rhs) const;
 
     Interval get_interval() const;
 
-    const std::string &get_name() const;
+    const std::string& get_name() const;
 
     CandidateRegionIdentifier get_id() const;
 
     std::string get_max_likelihood_sequence_with_flanks() const;
 
-    void add_pileup_entry(const std::string &read, const ReadCoordinate &read_coordinate);
+    void add_pileup_entry(
+        const std::string& read, const ReadCoordinate& read_coordinate);
 
-    void write_denovo_paths_to_file(const fs::path &output_directory);
+    void write_denovo_paths_to_file(const fs::path& output_directory);
 
 private:
     const Interval interval;
     const std::string name;
     const uint_least16_t interval_padding;
 
-    #ifndef NO_OPENMP
-    //TODO: check if we might have issues here with copy constructor - I think not: OpenMP locks work on the address of the lock I think
-    omp_lock_t add_pileup_entry_lock; //synchronizes multithreaded access to the add_pileup_entry() method
-    #endif
+#ifndef NO_OPENMP
+    // TODO: check if we might have issues here with copy constructor - I think not:
+    // OpenMP locks work on the address of the lock I think
+    omp_lock_t add_pileup_entry_lock; // synchronizes multithreaded access to the
+                                      // add_pileup_entry() method
+#endif
 
     void initialise_filename();
 
     Fastaq generate_fasta_for_denovo_paths();
 };
 
-
-std::vector<Interval> identify_low_coverage_intervals(const std::vector<uint32_t> &covg_at_each_position,
-                                                      const uint32_t &min_required_covg = 2,
-                                                      const uint32_t &min_length = 1);
+std::vector<Interval> identify_low_coverage_intervals(
+    const std::vector<uint32_t>& covg_at_each_position,
+    const uint32_t& min_required_covg = 2, const uint32_t& min_length = 1);
 
 using CandidateRegions = std::unordered_map<CandidateRegionIdentifier, CandidateRegion>;
 
-CandidateRegions find_candidate_regions_for_pan_node(const TmpPanNode &pangraph_node_components,
-                                                     const uint_least16_t &candidate_region_interval_padding = 0);
-
+CandidateRegions find_candidate_regions_for_pan_node(
+    const TmpPanNode& pangraph_node_components,
+    const uint_least16_t& candidate_region_interval_padding = 0);
 
 using ReadId = uint32_t;
-using PileupConstructionMap = std::map<ReadId, std::vector<std::pair<CandidateRegion *, const ReadCoordinate *>>>;
+using PileupConstructionMap
+    = std::map<ReadId, std::vector<std::pair<CandidateRegion*, const ReadCoordinate*>>>;
 
-PileupConstructionMap construct_pileup_construction_map(CandidateRegions &candidate_regions);
+PileupConstructionMap construct_pileup_construction_map(
+    CandidateRegions& candidate_regions);
 
-void
-load_all_candidate_regions_pileups_from_fastq(const fs::path &reads_filepath, const CandidateRegions &candidate_regions,
-                                              const PileupConstructionMap &pileup_construction_map, const uint32_t threads=1);
+void load_all_candidate_regions_pileups_from_fastq(const fs::path& reads_filepath,
+    const CandidateRegions& candidate_regions,
+    const PileupConstructionMap& pileup_construction_map, const uint32_t threads = 1);
 
-#endif //PANDORA_CANDIDATE_REGION_H
+#endif // PANDORA_CANDIDATE_REGION_H

--- a/include/denovo_discovery/denovo_discovery.h
+++ b/include/denovo_discovery/denovo_discovery.h
@@ -19,7 +19,7 @@ public:
     bool clean_assembly_graph { false };
     const uint8_t max_insertion_size;
 
-    DenovoDiscovery(const uint_least8_t &kmer_size, const double &read_error_rate, const uint8_t max_insertion_size = 50);
+    DenovoDiscovery(const uint_least8_t &kmer_size, const double &read_error_rate, const uint8_t max_insertion_size = 10);
 
     void find_paths_through_candidate_region(CandidateRegion &candidate_region);
 

--- a/include/denovo_discovery/denovo_discovery.h
+++ b/include/denovo_discovery/denovo_discovery.h
@@ -1,15 +1,14 @@
 #ifndef PANDORA_DENOVO_DISCOVERY_H
 #define PANDORA_DENOVO_DISCOVERY_H
 
-#include <stdexcept>
-#include <boost/filesystem.hpp>
-#include <gatb/gatb_core.hpp>
-#include <gatb/debruijn/impl/Simplifications.hpp>
-#include "fastaq_handler.h"
+#include "denovo_discovery/candidate_region.h"
 #include "denovo_discovery/denovo_utils.h"
 #include "denovo_discovery/local_assembly.h"
-#include "denovo_discovery/candidate_region.h"
-
+#include "fastaq_handler.h"
+#include <boost/filesystem.hpp>
+#include <gatb/debruijn/impl/Simplifications.hpp>
+#include <gatb/gatb_core.hpp>
+#include <stdexcept>
 
 namespace fs = boost::filesystem;
 
@@ -19,17 +18,17 @@ public:
     bool clean_assembly_graph { false };
     const uint8_t max_insertion_size;
 
-    DenovoDiscovery(const uint_least8_t &kmer_size, const double &read_error_rate, const uint8_t max_insertion_size = 10);
+    DenovoDiscovery(const uint_least8_t& kmer_size, const double& read_error_rate,
+        const uint8_t max_insertion_size = 15);
 
-    void find_paths_through_candidate_region(CandidateRegion &candidate_region);
+    void find_paths_through_candidate_region(CandidateRegion& candidate_region);
 
-    double calculate_kmer_coverage(const uint32_t &read_covg, const uint32_t &ref_length) const;
+    double calculate_kmer_coverage(
+        const uint32_t& read_covg, const uint32_t& ref_length) const;
 
 private:
     const uint_least8_t kmer_size;
     const double read_error_rate;
-
 };
 
-
-#endif //PANDORA_DENOVO_DISCOVERY_H
+#endif // PANDORA_DENOVO_DISCOVERY_H

--- a/include/denovo_discovery/denovo_discovery.h
+++ b/include/denovo_discovery/denovo_discovery.h
@@ -19,7 +19,7 @@ public:
     bool clean_assembly_graph { false };
     const uint8_t max_insertion_size;
 
-    DenovoDiscovery(const uint_least8_t &kmer_size, const double &read_error_rate, const uint8_t max_insertion_size = 10);
+    DenovoDiscovery(const uint_least8_t &kmer_size, const double &read_error_rate, const uint8_t max_insertion_size = 50);
 
     void find_paths_through_candidate_region(CandidateRegion &candidate_region);
 

--- a/include/denovo_discovery/local_assembly.h
+++ b/include/denovo_discovery/local_assembly.h
@@ -6,6 +6,7 @@
 #include <stack>
 #include <unordered_map>
 #include <unordered_set>
+#include <queue>
 
 #include <gatb/gatb_core.hpp>
 #include <gatb/debruijn/impl/Simplifications.hpp>
@@ -20,6 +21,7 @@
 namespace logging = boost::log;
 namespace fs = boost::filesystem;
 using DfsTree = std::unordered_map<std::string, GraphVector<Node>>;
+using BfsDistanceMap = std::map<std::string, uint32_t>;
 using DenovoPaths = std::vector<std::string>;
 
 constexpr float COVG_SCALING_FACTOR { 0.1 };
@@ -39,8 +41,10 @@ public:
 private:
     DfsTree depth_first_search_from(const Node &start_node, bool reverse=false);
 
+    BfsDistanceMap breadth_first_search_from(const Node &start_node, bool reverse=false);
+
     void build_paths_between(const std::string &start_kmer, const std::string &end_kmer, std::string path_accumulator,
-                             DfsTree &tree, DfsTree &reverse_tree, DenovoPaths &paths_between_queries,
+                             DfsTree &tree, BfsDistanceMap &node_to_distance_to_the_end_node, DenovoPaths &paths_between_queries,
                              const uint32_t &max_path_length, const double &expected_kmer_covg,
                              const float &required_percent_of_expected_covg = COVG_SCALING_FACTOR,
                              uint32_t num_kmers_below_threshold = 0);

--- a/include/denovo_discovery/local_assembly.h
+++ b/include/denovo_discovery/local_assembly.h
@@ -1,22 +1,21 @@
 #ifndef PANDORA_LOCAL_ASSEMBLY_H
 #define PANDORA_LOCAL_ASSEMBLY_H
 
-#include <iostream>
 #include <fstream>
+#include <iostream>
+#include <queue>
 #include <stack>
 #include <unordered_map>
 #include <unordered_set>
-#include <queue>
 
-#include <gatb/gatb_core.hpp>
 #include <gatb/debruijn/impl/Simplifications.hpp>
+#include <gatb/gatb_core.hpp>
 #include <sys/stat.h>
 
-#include <boost/log/core.hpp>
-#include <boost/log/trivial.hpp>
-#include <boost/log/expressions.hpp>
 #include <boost/filesystem.hpp>
-
+#include <boost/log/core.hpp>
+#include <boost/log/expressions.hpp>
+#include <boost/log/trivial.hpp>
 
 namespace logging = boost::log;
 namespace fs = boost::filesystem;
@@ -27,42 +26,46 @@ using DenovoPaths = std::vector<std::string>;
 constexpr float COVG_SCALING_FACTOR { 0.1 };
 constexpr auto MAX_NUMBER_CANDIDATE_PATHS { 25 };
 
-
 class LocalAssemblyGraph : public Graph {
 public:
-    LocalAssemblyGraph& operator=(const Graph &graph);
+    LocalAssemblyGraph& operator=(const Graph& graph);
 
-    std::pair<Node, bool> get_node(const std::string &query_kmer);
+    std::pair<Node, bool> get_node(const std::string& query_kmer);
 
-    std::pair<DenovoPaths, bool> get_paths_between(const Node &start_node, const Node &end_node,
-                                  const uint32_t &max_path_length,
-                                  const double &expected_coverage = 1);
+    std::pair<DenovoPaths, bool> get_paths_between(const Node& start_node,
+        const Node& end_node, const uint32_t& max_path_length,
+        const double& expected_coverage = 1);
 
 private:
-    DfsTree depth_first_search_from(const Node &start_node, bool reverse=false);
+    DfsTree depth_first_search_from(const Node& start_node, bool reverse = false);
 
-    BfsDistanceMap breadth_first_search_from(const Node &start_node, bool reverse=false);
+    BfsDistanceMap breadth_first_search_from(
+        const Node& start_node, bool reverse = false);
 
-    void build_paths_between(const std::string &start_kmer, const std::string &end_kmer, std::string path_accumulator,
-                             DfsTree &tree, BfsDistanceMap &node_to_distance_to_the_end_node, DenovoPaths &paths_between_queries,
-                             const uint32_t &max_path_length, const double &expected_kmer_covg,
-                             const float &required_percent_of_expected_covg = COVG_SCALING_FACTOR,
-                             uint32_t num_kmers_below_threshold = 0);
+    void build_paths_between(const std::string& start_kmer, const std::string& end_kmer,
+        std::string path_accumulator, DfsTree& tree,
+        BfsDistanceMap& node_to_distance_to_the_end_node,
+        DenovoPaths& paths_between_queries, const uint32_t& max_path_length,
+        const double& expected_kmer_covg,
+        const float& required_percent_of_expected_covg = COVG_SCALING_FACTOR,
+        uint32_t num_kmers_below_threshold = 0);
 };
 
+void clean(Graph& graph, const uint16_t& num_cores = 1);
 
-void clean(Graph &graph, const uint16_t &num_cores = 1);
+bool string_ends_with(std::string const& query, std::string const& ending);
 
-bool string_ends_with(std::string const &query, std::string const &ending);
-
-std::string reverse_complement(const std::string &forward);
+std::string reverse_complement(const std::string& forward);
 
 void remove_graph_file();
 
-std::vector<std::string> generate_start_kmers(const std::string &sequence, const uint16_t &k, uint32_t num_to_generate);
+std::vector<std::string> generate_start_kmers(
+    const std::string& sequence, const uint16_t& k, uint32_t num_to_generate);
 
-std::vector<std::string> generate_end_kmers(const std::string &sequence, const uint32_t &k, uint32_t num_to_generate);
+std::vector<std::string> generate_end_kmers(
+    const std::string& sequence, const uint32_t& k, uint32_t num_to_generate);
 
-std::vector<std::string> all_kmers_in(const std::string &query, const uint_least8_t k_size);
+std::vector<std::string> all_kmers_in(
+    const std::string& query, const uint_least8_t k_size);
 
-#endif //PANDORA_LOCAL_ASSEMBLY_H
+#endif // PANDORA_LOCAL_ASSEMBLY_H

--- a/include/denovo_discovery/local_assembly.h
+++ b/include/denovo_discovery/local_assembly.h
@@ -25,7 +25,7 @@ using BfsDistanceMap = std::map<std::string, uint32_t>;
 using DenovoPaths = std::vector<std::string>;
 
 constexpr float COVG_SCALING_FACTOR { 0.1 };
-constexpr auto MAX_NUMBER_CANDIDATE_PATHS { 25 };
+constexpr auto MAX_NUMBER_CANDIDATE_PATHS { 50 };
 
 
 class LocalAssemblyGraph : public Graph {

--- a/include/denovo_discovery/local_assembly.h
+++ b/include/denovo_discovery/local_assembly.h
@@ -22,6 +22,7 @@ namespace fs = boost::filesystem;
 using DfsTree = std::unordered_map<std::string, GraphVector<Node>>;
 using BfsDistanceMap = std::map<std::string, uint32_t>;
 using DenovoPaths = std::vector<std::string>;
+using FoundPaths = bool;
 
 constexpr float COVG_SCALING_FACTOR { 0.1 };
 constexpr auto MAX_NUMBER_CANDIDATE_PATHS { 25 };
@@ -32,7 +33,7 @@ public:
 
     std::pair<Node, bool> get_node(const std::string& query_kmer);
 
-    std::pair<DenovoPaths, bool> get_paths_between(const Node& start_node,
+    std::pair<DenovoPaths, FoundPaths> get_paths_between(const Node& start_node,
         const Node& end_node, const uint32_t& max_path_length,
         const double& expected_coverage = 1);
 

--- a/include/denovo_discovery/local_assembly.h
+++ b/include/denovo_discovery/local_assembly.h
@@ -32,7 +32,7 @@ public:
 
     std::pair<Node, bool> get_node(const std::string &query_kmer);
 
-    DenovoPaths get_paths_between(const Node &start_node, const Node &end_node,
+    std::pair<DenovoPaths, bool> get_paths_between(const Node &start_node, const Node &end_node,
                                   const uint32_t &max_path_length,
                                   const double &expected_coverage = 1);
 

--- a/include/denovo_discovery/local_assembly.h
+++ b/include/denovo_discovery/local_assembly.h
@@ -25,7 +25,7 @@ using BfsDistanceMap = std::map<std::string, uint32_t>;
 using DenovoPaths = std::vector<std::string>;
 
 constexpr float COVG_SCALING_FACTOR { 0.1 };
-constexpr auto MAX_NUMBER_CANDIDATE_PATHS { 50 };
+constexpr auto MAX_NUMBER_CANDIDATE_PATHS { 25 };
 
 
 class LocalAssemblyGraph : public Graph {

--- a/src/denovo_discovery/candidate_region.cpp
+++ b/src/denovo_discovery/candidate_region.cpp
@@ -139,7 +139,8 @@ CandidateRegions find_candidate_regions_for_pan_node(
 
 std::vector<Interval> identify_low_coverage_intervals(
     const std::vector<uint32_t>& covg_at_each_position,
-    const uint32_t& min_required_covg, const uint32_t& min_length)
+    const uint32_t& min_required_covg, const uint32_t& min_length,
+    const uint32_t& max_length)
 {
     std::vector<Interval> identified_regions;
     const auto predicate { [min_required_covg](
@@ -152,7 +153,11 @@ std::vector<Interval> identify_low_coverage_intervals(
     while (current != covg_at_each_position.end()) {
         previous = current;
         current = std::find_if_not(current, covg_at_each_position.end(), predicate);
-        if (current - previous >= min_length) {
+        const auto length_of_interval { current - previous };
+        const bool interval_between_min_and_max_len
+            = (length_of_interval >= min_length) and (length_of_interval <= max_length);
+
+        if (interval_between_min_and_max_len) {
             identified_regions.emplace_back(previous - first, current - first);
         }
         if (current == covg_at_each_position.end()) {

--- a/src/denovo_discovery/candidate_region.cpp
+++ b/src/denovo_discovery/candidate_region.cpp
@@ -1,125 +1,154 @@
 #include "denovo_discovery/candidate_region.h"
 
-
-size_t std::hash<CandidateRegionIdentifier>::operator()(const CandidateRegionIdentifier &id) const {
-    return std::hash<int>()(std::get<0>(id).start) ^ std::hash<int>()(std::get<0>(id).get_end()) ^
-           std::hash<std::string>()(std::get<1>(id));
+size_t std::hash<CandidateRegionIdentifier>::operator()(
+    const CandidateRegionIdentifier& id) const
+{
+    return std::hash<int>()(std::get<0>(id).start)
+        ^ std::hash<int>()(std::get<0>(id).get_end())
+        ^ std::hash<std::string>()(std::get<1>(id));
 }
 
-
-CandidateRegion::CandidateRegion(const Interval &interval, std::string name)
-        : interval { interval }, name { std::move(name) }, interval_padding { 0 } {
+CandidateRegion::CandidateRegion(const Interval& interval, std::string name)
+    : interval { interval }
+    , name { std::move(name) }
+    , interval_padding { 0 }
+{
     initialise_filename();
-    #ifndef NO_OPENMP
+#ifndef NO_OPENMP
     omp_init_lock(&add_pileup_entry_lock);
-    #endif
+#endif
 }
 
-
-CandidateRegion::CandidateRegion(const Interval &interval, std::string name, const uint_least16_t &interval_padding)
-        : interval { interval }, name { std::move(name) }, interval_padding { interval_padding } {
+CandidateRegion::CandidateRegion(
+    const Interval& interval, std::string name, const uint_least16_t& interval_padding)
+    : interval { interval }
+    , name { std::move(name) }
+    , interval_padding { interval_padding }
+{
     initialise_filename();
-    #ifndef NO_OPENMP
+#ifndef NO_OPENMP
     omp_init_lock(&add_pileup_entry_lock);
-    #endif
+#endif
 }
 
-CandidateRegion::~CandidateRegion() {
-    #ifndef NO_OPENMP
+CandidateRegion::~CandidateRegion()
+{
+#ifndef NO_OPENMP
     omp_destroy_lock(&add_pileup_entry_lock);
-    #endif
+#endif
 }
 
-void CandidateRegion::initialise_filename() {
+void CandidateRegion::initialise_filename()
+{
     const auto i { get_interval() };
-    this->filename = fs::path(std::string(get_name()).append(".").append(std::to_string(i.start)).append("-")
-                                                     .append(std::to_string(i.get_end())).append("_denovo_discovery")
-                                                     .append(".fa"));
+    this->filename = fs::path(std::string(get_name())
+                                  .append(".")
+                                  .append(std::to_string(i.start))
+                                  .append("-")
+                                  .append(std::to_string(i.get_end()))
+                                  .append("_denovo_discovery")
+                                  .append(".fa"));
 }
 
-
-Interval CandidateRegion::get_interval() const {
-    const auto interval_start { (interval.start <= interval_padding) ? 0 : interval.start - interval_padding };
+Interval CandidateRegion::get_interval() const
+{
+    const auto interval_start {
+        (interval.start <= interval_padding) ? 0 : interval.start - interval_padding
+    };
     const auto interval_end { interval.get_end() + interval_padding };
     return { interval_start, interval_end };
 }
 
+const std::string& CandidateRegion::get_name() const { return name; }
 
-const std::string &CandidateRegion::get_name() const {
-    return name;
-}
-
-
-CandidateRegionIdentifier CandidateRegion::get_id() const {
+CandidateRegionIdentifier CandidateRegion::get_id() const
+{
     return std::make_tuple(this->get_interval(), this->get_name());
 }
 
-
-std::string CandidateRegion::get_max_likelihood_sequence_with_flanks() const {
-    return std::string(left_flanking_sequence).append(max_likelihood_sequence).append(right_flanking_sequence);
+std::string CandidateRegion::get_max_likelihood_sequence_with_flanks() const
+{
+    return std::string(left_flanking_sequence)
+        .append(max_likelihood_sequence)
+        .append(right_flanking_sequence);
 }
 
-
-bool CandidateRegion::operator==(const CandidateRegion &rhs) const {
+bool CandidateRegion::operator==(const CandidateRegion& rhs) const
+{
     return interval == rhs.interval && name == rhs.name;
 }
 
-
-bool CandidateRegion::operator!=(const CandidateRegion &rhs) const {
+bool CandidateRegion::operator!=(const CandidateRegion& rhs) const
+{
     return !(rhs == *this);
 }
 
-
-CandidateRegions find_candidate_regions_for_pan_node(const TmpPanNode &pangraph_node_components,
-                                                     const uint_least16_t &candidate_region_interval_padding) {
-    const auto &pangraph_node { pangraph_node_components.pangraph_node };
-    const auto &local_prg { pangraph_node_components.local_prg };
-    const auto &local_node_max_likelihood_path { pangraph_node_components.local_node_max_likelihood_path };
-    const auto &kmer_node_max_likelihood_path { pangraph_node_components.kmer_node_max_likelihood_path };
+CandidateRegions find_candidate_regions_for_pan_node(
+    const TmpPanNode& pangraph_node_components,
+    const uint_least16_t& candidate_region_interval_padding)
+{
+    const auto& pangraph_node { pangraph_node_components.pangraph_node };
+    const auto& local_prg { pangraph_node_components.local_prg };
+    const auto& local_node_max_likelihood_path {
+        pangraph_node_components.local_node_max_likelihood_path
+    };
+    const auto& kmer_node_max_likelihood_path {
+        pangraph_node_components.kmer_node_max_likelihood_path
+    };
     const uint32_t sample_id { 0 };
 
-    const auto covgs_along_localnode_path {
-            get_covgs_along_localnode_path(pangraph_node, local_node_max_likelihood_path, kmer_node_max_likelihood_path,
-                                           sample_id) };
-    const auto candidate_intervals { identify_low_coverage_intervals(covgs_along_localnode_path) };
+    const auto covgs_along_localnode_path { get_covgs_along_localnode_path(
+        pangraph_node, local_node_max_likelihood_path, kmer_node_max_likelihood_path,
+        sample_id) };
+    const auto candidate_intervals { identify_low_coverage_intervals(
+        covgs_along_localnode_path) };
 
     CandidateRegions candidate_regions;
 
-    BOOST_LOG_TRIVIAL(debug) << "there are " << candidate_intervals.size() << " intervals";
+    BOOST_LOG_TRIVIAL(debug) << "there are " << candidate_intervals.size()
+                             << " intervals";
 
-    for (const auto &current_interval: candidate_intervals) {
+    for (const auto& current_interval : candidate_intervals) {
         CandidateRegion candidate_region { current_interval, pangraph_node->get_name(),
-                                           candidate_region_interval_padding };
-        BOOST_LOG_TRIVIAL(debug) << "Looking at interval: " << candidate_region.get_interval();
+            candidate_region_interval_padding };
+        BOOST_LOG_TRIVIAL(debug)
+            << "Looking at interval: " << candidate_region.get_interval();
         BOOST_LOG_TRIVIAL(debug) << "For gene: " << candidate_region.get_name();
 
-        const auto interval_path_components { find_interval_and_flanks_in_localpath(candidate_region.get_interval(),
-                                                                                    local_node_max_likelihood_path) };
+        const auto interval_path_components { find_interval_and_flanks_in_localpath(
+            candidate_region.get_interval(), local_node_max_likelihood_path) };
 
-        candidate_region.read_coordinates = pangraph_node->get_read_overlap_coordinates(interval_path_components.slice);
+        candidate_region.read_coordinates = pangraph_node->get_read_overlap_coordinates(
+            interval_path_components.slice);
 
-        BOOST_LOG_TRIVIAL(debug) << "there are " << candidate_region.read_coordinates.size()
-                                 << " read_overlap_coordinates";
+        BOOST_LOG_TRIVIAL(debug)
+            << "there are " << candidate_region.read_coordinates.size()
+            << " read_overlap_coordinates";
 
-        candidate_region.max_likelihood_sequence = local_prg->string_along_path(interval_path_components.slice);
-        candidate_region.left_flanking_sequence = local_prg->string_along_path(interval_path_components.flank_left);
-        candidate_region.right_flanking_sequence = local_prg->string_along_path(interval_path_components.flank_right);
-        candidate_regions.insert(std::make_pair(candidate_region.get_id(), candidate_region));
+        candidate_region.max_likelihood_sequence
+            = local_prg->string_along_path(interval_path_components.slice);
+        candidate_region.left_flanking_sequence
+            = local_prg->string_along_path(interval_path_components.flank_left);
+        candidate_region.right_flanking_sequence
+            = local_prg->string_along_path(interval_path_components.flank_right);
+        candidate_regions.insert(
+            std::make_pair(candidate_region.get_id(), candidate_region));
     }
     return candidate_regions;
 }
 
-
-std::vector<Interval>
-identify_low_coverage_intervals(const std::vector<uint32_t> &covg_at_each_position, const uint32_t &min_required_covg,
-                                const uint32_t &min_length) {
+std::vector<Interval> identify_low_coverage_intervals(
+    const std::vector<uint32_t>& covg_at_each_position,
+    const uint32_t& min_required_covg, const uint32_t& min_length)
+{
     std::vector<Interval> identified_regions;
-    const auto predicate { [min_required_covg](uint_least32_t x) { return x <= min_required_covg; }};
+    const auto predicate { [min_required_covg](
+                               uint_least32_t x) { return x <= min_required_covg; } };
     auto first { covg_at_each_position.begin() };
     auto previous { covg_at_each_position.begin() };
     auto current { first };
 
-    //TODO: merging candidate regions that are close enough together
+    // TODO: merging candidate regions that are close enough together
     while (current != covg_at_each_position.end()) {
         previous = current;
         current = std::find_if_not(current, covg_at_each_position.end(), predicate);
@@ -134,28 +163,33 @@ identify_low_coverage_intervals(const std::vector<uint32_t> &covg_at_each_positi
     return identified_regions;
 }
 
-void CandidateRegion::add_pileup_entry(const std::string &read, const ReadCoordinate &read_coordinate) {
-    const bool read_coord_start_is_past_read_end { read_coordinate.start >= read.length() };
+void CandidateRegion::add_pileup_entry(
+    const std::string& read, const ReadCoordinate& read_coordinate)
+{
+    const bool read_coord_start_is_past_read_end { read_coordinate.start
+        >= read.length() };
     if (not read_coord_start_is_past_read_end) {
-        const auto end_pos_of_region_in_read{std::min(read_coordinate.end, (uint32_t) read.length())};
-        std::string sequence_in_read_overlapping_region{
-                read.substr(read_coordinate.start, end_pos_of_region_in_read - read_coordinate.start)};
+        const auto end_pos_of_region_in_read { std::min(
+            read_coordinate.end, (uint32_t)read.length()) };
+        std::string sequence_in_read_overlapping_region { read.substr(
+            read_coordinate.start, end_pos_of_region_in_read - read_coordinate.start) };
 
         if (!read_coordinate.is_forward) {
-            sequence_in_read_overlapping_region = reverse_complement(sequence_in_read_overlapping_region);
+            sequence_in_read_overlapping_region
+                = reverse_complement(sequence_in_read_overlapping_region);
         }
-        #ifndef NO_OPENMP
+#ifndef NO_OPENMP
         omp_set_lock(&add_pileup_entry_lock);
-            this->pileup.push_back(sequence_in_read_overlapping_region);
+        this->pileup.push_back(sequence_in_read_overlapping_region);
         omp_unset_lock(&add_pileup_entry_lock);
-        #else
-            this->pileup.push_back(sequence_in_read_overlapping_region);
-        #endif
+#else
+        this->pileup.push_back(sequence_in_read_overlapping_region);
+#endif
     }
 }
 
-
-void CandidateRegion::write_denovo_paths_to_file(const fs::path &output_directory) {
+void CandidateRegion::write_denovo_paths_to_file(const fs::path& output_directory)
+{
     fs::create_directories(output_directory);
 
     if (denovo_paths.empty()) {
@@ -169,121 +203,128 @@ void CandidateRegion::write_denovo_paths_to_file(const fs::path &output_director
 
     fasta.save(discovered_paths_filepath.string());
 
-    BOOST_LOG_TRIVIAL(debug) << "Denovo path for " << name << " written to: " << discovered_paths_filepath;
-
+    BOOST_LOG_TRIVIAL(debug) << "Denovo path for " << name
+                             << " written to: " << discovered_paths_filepath;
 }
 
-
-Fastaq CandidateRegion::generate_fasta_for_denovo_paths() {
+Fastaq CandidateRegion::generate_fasta_for_denovo_paths()
+{
     const bool gzip { false };
     const bool fastq { false };
     Fastaq fasta { gzip, fastq };
 
     for (size_t i = 0; i < denovo_paths.size(); ++i) {
-        const auto &path { denovo_paths.at(i) };
-        const std::string path_name { std::string(name).append(".").append(std::to_string(i)) };
+        const auto& path { denovo_paths.at(i) };
+        const std::string path_name { std::string(name).append(".").append(
+            std::to_string(i)) };
         fasta.add_entry(path_name, path, "");
     }
 
     return fasta;
 }
 
+TmpPanNode::TmpPanNode(const PanNodePtr& pangraph_node,
+    const shared_ptr<LocalPRG>& local_prg,
+    const vector<KmerNodePtr>& kmer_node_max_likelihood_path,
+    const vector<LocalNodePtr>& local_node_max_likelihood_path)
+    : pangraph_node { pangraph_node }
+    , local_prg { local_prg }
+    , kmer_node_max_likelihood_path { kmer_node_max_likelihood_path }
+    , local_node_max_likelihood_path { local_node_max_likelihood_path }
+{
+}
 
-TmpPanNode::TmpPanNode(const PanNodePtr &pangraph_node, const shared_ptr<LocalPRG> &local_prg,
-                       const vector<KmerNodePtr> &kmer_node_max_likelihood_path,
-                       const vector<LocalNodePtr> &local_node_max_likelihood_path)
-        : pangraph_node { pangraph_node }, local_prg { local_prg },
-          kmer_node_max_likelihood_path { kmer_node_max_likelihood_path },
-          local_node_max_likelihood_path { local_node_max_likelihood_path } {}
-
-
-
-
-PileupConstructionMap construct_pileup_construction_map(CandidateRegions &candidate_regions) {
+PileupConstructionMap construct_pileup_construction_map(
+    CandidateRegions& candidate_regions)
+{
     PileupConstructionMap pileup_construction_map;
-    for (auto &element : candidate_regions) {
-        auto &candidate_region{element.second};
-        for (const auto &read_coordinate : candidate_region.read_coordinates) {
-            pileup_construction_map[read_coordinate.id].emplace_back(&candidate_region, &read_coordinate);
+    for (auto& element : candidate_regions) {
+        auto& candidate_region { element.second };
+        for (const auto& read_coordinate : candidate_region.read_coordinates) {
+            pileup_construction_map[read_coordinate.id].emplace_back(
+                &candidate_region, &read_coordinate);
         }
     }
     return pileup_construction_map;
 }
 
-
-
-void
-load_all_candidate_regions_pileups_from_fastq(const fs::path &reads_filepath, const CandidateRegions &candidate_regions,
-                                              const PileupConstructionMap &pileup_construction_map, const uint32_t threads) {
-    BOOST_LOG_TRIVIAL(info) << " Loading all candidate regions pileups from " << reads_filepath.string() << " ...";
+void load_all_candidate_regions_pileups_from_fastq(const fs::path& reads_filepath,
+    const CandidateRegions& candidate_regions,
+    const PileupConstructionMap& pileup_construction_map, const uint32_t threads)
+{
+    BOOST_LOG_TRIVIAL(info) << " Loading all candidate regions pileups from "
+                            << reads_filepath.string() << " ...";
 
     if (candidate_regions.empty() or pileup_construction_map.empty())
         return;
 
-    const uint32_t nb_reads_to_map_in_a_batch = 1000; //nb of reads to map in a batch
+    const uint32_t nb_reads_to_map_in_a_batch = 1000; // nb of reads to map in a batch
 
-    //shared variables - controlled by critical(ReadFileMutex)
+    // shared variables - controlled by critical(ReadFileMutex)
     FastaqHandler fh(reads_filepath.string());
-    uint32_t id{0};
+    uint32_t id { 0 };
 
-    //parallel region
-    //TODO: this is duplicated code with pangraph_from_read_file(), refactor
-    #pragma omp parallel num_threads(threads)
+// parallel region
+// TODO: this is duplicated code with pangraph_from_read_file(), refactor
+#pragma omp parallel num_threads(threads)
     {
-        //will hold the reads batch
-        std::vector<std::pair<uint32_t, std::string>> sequencesBuffer(nb_reads_to_map_in_a_batch, make_pair(0, ""));
+        // will hold the reads batch
+        std::vector<std::pair<uint32_t, std::string>> sequencesBuffer(
+            nb_reads_to_map_in_a_batch, make_pair(0, ""));
         while (true) {
-            //read the next batch of reads
+            // read the next batch of reads
             uint32_t nbOfReads = 0;
 
-            //read the reads in batch
-            #pragma omp critical(ReadFileMutex)
+// read the reads in batch
+#pragma omp critical(ReadFileMutex)
             {
-                //TODO: we need to read only until the max read id
-                for (auto &id_and_sequence : sequencesBuffer) {
-                    //did we reach the end already?
-                    if (!fh.eof()) { //no
-                        //print some logging
+                // TODO: we need to read only until the max read id
+                for (auto& id_and_sequence : sequencesBuffer) {
+                    // did we reach the end already?
+                    if (!fh.eof()) { // no
+                        // print some logging
                         if (id && id % 100000 == 0)
                             BOOST_LOG_TRIVIAL(info) << id << " reads processed...";
 
-                        //read the read
+                        // read the read
                         fh.get_next();
                         id_and_sequence = make_pair(id, fh.read);
                         ++nbOfReads;
                         ++id;
-                    } else { //yes
-                        break; //we read everything already, exit this loop
+                    } else { // yes
+                        break; // we read everything already, exit this loop
                     }
                 }
             }
 
+            if (nbOfReads == 0)
+                break; // we reached the end of the file, nothing else to map
 
-            if (nbOfReads == 0) break; //we reached the end of the file, nothing else to map
-
-            //process nbOfReads reads
-            for (uint32_t i=0; i<nbOfReads; i++) {
+            // process nbOfReads reads
+            for (uint32_t i = 0; i < nbOfReads; i++) {
                 uint32_t id;
                 std::string sequence;
-                std::tie(id, sequence)  = sequencesBuffer[i];
+                std::tie(id, sequence) = sequencesBuffer[i];
 
-                auto pileup_construction_map_iterator = pileup_construction_map.find(id);
-                const bool is_read_required_for_pileup = pileup_construction_map_iterator != pileup_construction_map.end();
+                auto pileup_construction_map_iterator
+                    = pileup_construction_map.find(id);
+                const bool is_read_required_for_pileup
+                    = pileup_construction_map_iterator != pileup_construction_map.end();
 
                 if (not is_read_required_for_pileup)
                     continue;
 
-                //create all pileups for this read
-                for (const auto &pair : pileup_construction_map_iterator->second) {
-                    CandidateRegion * candidate_region;
-                    const ReadCoordinate * read_coordinate;
+                // create all pileups for this read
+                for (const auto& pair : pileup_construction_map_iterator->second) {
+                    CandidateRegion* candidate_region;
+                    const ReadCoordinate* read_coordinate;
                     std::tie(candidate_region, read_coordinate) = pair;
 
                     candidate_region->add_pileup_entry(sequence, *read_coordinate);
                 }
             }
-
         }
     }
-    BOOST_LOG_TRIVIAL(info) << " Loaded all candidate regions pileups from " << reads_filepath.string();
+    BOOST_LOG_TRIVIAL(info) << " Loaded all candidate regions pileups from "
+                            << reads_filepath.string();
 }

--- a/src/denovo_discovery/denovo_discovery.cpp
+++ b/src/denovo_discovery/denovo_discovery.cpp
@@ -71,7 +71,7 @@ void DenovoDiscovery::find_paths_through_candidate_region(
 
             if (end_found) {
                 DenovoPaths denovo_paths;
-                bool abandoned;
+                FoundPaths abandoned;
                 std::tie(denovo_paths, abandoned) = graph.get_paths_between(
                     start_node, end_node, max_path_length, expected_kmer_covg);
 

--- a/src/denovo_discovery/denovo_discovery.cpp
+++ b/src/denovo_discovery/denovo_discovery.cpp
@@ -59,8 +59,15 @@ void DenovoDiscovery::find_paths_through_candidate_region(CandidateRegion &candi
             std::tie(end_node, end_found) = graph.get_node(current_end_kmer);
 
             if (end_found) {
-                auto denovo_paths {
-                        graph.get_paths_between(start_node, end_node, max_path_length, expected_kmer_covg) };
+                DenovoPaths denovo_paths;
+                bool abandoned;
+                std::tie(denovo_paths, abandoned) =
+                        graph.get_paths_between(start_node, end_node, max_path_length, expected_kmer_covg);
+
+                if (abandoned) {
+                    remove_graph_file();
+                    return;
+                }
 
                 if (not denovo_paths.empty()) {
                     candidate_region.denovo_paths.insert(candidate_region.denovo_paths.begin(), denovo_paths.begin(),

--- a/src/denovo_discovery/denovo_discovery.cpp
+++ b/src/denovo_discovery/denovo_discovery.cpp
@@ -1,40 +1,49 @@
 #include "denovo_discovery/denovo_discovery.h"
 
-
-void DenovoDiscovery::find_paths_through_candidate_region(CandidateRegion &candidate_region) {
+void DenovoDiscovery::find_paths_through_candidate_region(
+    CandidateRegion& candidate_region)
+{
     const auto read_covg { candidate_region.pileup.size() };
-    const auto length_of_candidate_sequence { candidate_region.max_likelihood_sequence.length() };
-    const double expected_kmer_covg { calculate_kmer_coverage(read_covg, length_of_candidate_sequence) };
+    const auto length_of_candidate_sequence {
+        candidate_region.max_likelihood_sequence.length()
+    };
+    const double expected_kmer_covg { calculate_kmer_coverage(
+        read_covg, length_of_candidate_sequence) };
 
-    BOOST_LOG_TRIVIAL(debug) << "Running local assembly for: " << candidate_region.get_name() << " - interval ["
+    BOOST_LOG_TRIVIAL(debug) << "Running local assembly for: "
+                             << candidate_region.get_name() << " - interval ["
                              << candidate_region.get_interval() << "]";
 
     if (candidate_region.pileup.empty()) {
-        BOOST_LOG_TRIVIAL(debug) << "No sequences to assemble. Skipping local assembly.";
+        BOOST_LOG_TRIVIAL(debug)
+            << "No sequences to assemble. Skipping local assembly.";
         return;
     }
 
     const auto max_path_length { length_of_candidate_sequence + max_insertion_size };
 
     if (kmer_size > max_path_length) {
-        BOOST_LOG_TRIVIAL(debug) << "Kmer size " << kmer_size << " is greater than the maximum path length "
-                                 << max_path_length << ". Skipping local assembly.";
+        BOOST_LOG_TRIVIAL(debug)
+            << "Kmer size " << kmer_size << " is greater than the maximum path length "
+            << max_path_length << ". Skipping local assembly.";
         return;
     }
 
     LocalAssemblyGraph graph;
 
     try {
-        Graph gatb_graph = LocalAssemblyGraph::create(new BankStrings(candidate_region.pileup),
-                                                      "-kmer-size %d -abundance-min %d -verbose 0 -nb-cores 1", kmer_size,
-                                                      min_covg_for_node_in_assembly_graph);
+        Graph gatb_graph
+            = LocalAssemblyGraph::create(new BankStrings(candidate_region.pileup),
+                "-kmer-size %d -abundance-min %d -verbose 0 -nb-cores 1", kmer_size,
+                min_covg_for_node_in_assembly_graph);
         if (clean_assembly_graph) {
             clean(gatb_graph);
         }
-        graph = gatb_graph; //TODO: use move constructor
+        graph = gatb_graph; // TODO: use move constructor
 
-    } catch (gatb::core::system::Exception &error) {
-        BOOST_LOG_TRIVIAL(debug) << "Couldn't create GATB graph." << "\n\tEXCEPTION: " << error.getMessage();
+    } catch (gatb::core::system::Exception& error) {
+        BOOST_LOG_TRIVIAL(debug) << "Couldn't create GATB graph."
+                                 << "\n\tEXCEPTION: " << error.getMessage();
         remove_graph_file();
         return;
     }
@@ -42,11 +51,13 @@ void DenovoDiscovery::find_paths_through_candidate_region(CandidateRegion &candi
     Node start_node, end_node;
     bool start_found { false };
     bool end_found { false };
-    const auto start_kmers { generate_start_kmers(candidate_region.max_likelihood_sequence, kmer_size, kmer_size) };
-    const auto end_kmers { generate_end_kmers(candidate_region.max_likelihood_sequence, kmer_size, kmer_size) };
+    const auto start_kmers { generate_start_kmers(
+        candidate_region.max_likelihood_sequence, kmer_size, kmer_size) };
+    const auto end_kmers { generate_end_kmers(
+        candidate_region.max_likelihood_sequence, kmer_size, kmer_size) };
 
     for (uint_least16_t start_idx = 0; start_idx < start_kmers.size(); start_idx++) {
-        const auto &current_start_kmer { start_kmers[start_idx] };
+        const auto& current_start_kmer { start_kmers[start_idx] };
         std::tie(start_node, start_found) = graph.get_node(current_start_kmer);
 
         if (not start_found) {
@@ -54,15 +65,15 @@ void DenovoDiscovery::find_paths_through_candidate_region(CandidateRegion &candi
         }
 
         for (uint_least16_t end_idx = 0; end_idx < end_kmers.size(); end_idx++) {
-            const auto &current_end_kmer { end_kmers[end_idx] };
+            const auto& current_end_kmer { end_kmers[end_idx] };
 
             std::tie(end_node, end_found) = graph.get_node(current_end_kmer);
 
             if (end_found) {
                 DenovoPaths denovo_paths;
                 bool abandoned;
-                std::tie(denovo_paths, abandoned) =
-                        graph.get_paths_between(start_node, end_node, max_path_length, expected_kmer_covg);
+                std::tie(denovo_paths, abandoned) = graph.get_paths_between(
+                    start_node, end_node, max_path_length, expected_kmer_covg);
 
                 if (abandoned) {
                     remove_graph_file();
@@ -70,20 +81,28 @@ void DenovoDiscovery::find_paths_through_candidate_region(CandidateRegion &candi
                 }
 
                 if (not denovo_paths.empty()) {
-                    candidate_region.denovo_paths.insert(candidate_region.denovo_paths.begin(), denovo_paths.begin(),
-                                                         denovo_paths.end());
+                    candidate_region.denovo_paths.insert(
+                        candidate_region.denovo_paths.begin(), denovo_paths.begin(),
+                        denovo_paths.end());
 
-                    // add flank to each sequence - the whole sequence from the start to the end of the gene
-                    for (auto &current_path : candidate_region.denovo_paths) {
-                        const auto start_kmer_offset { candidate_region.max_likelihood_sequence.substr(0, start_idx) };
-                        const auto end_kmer_offset { candidate_region.max_likelihood_sequence
-                                                                     .substr(candidate_region.max_likelihood_sequence
-                                                                                             .length() - end_idx) };
-                        current_path = std::string(candidate_region.left_flanking_sequence).append(start_kmer_offset)
-                                                                                           .append(current_path)
-                                                                                           .append(end_kmer_offset)
-                                                                                           .append(candidate_region
-                                                                                                           .right_flanking_sequence);
+                    // add flank to each sequence - the whole sequence from the start to
+                    // the end of the gene
+                    for (auto& current_path : candidate_region.denovo_paths) {
+                        const auto start_kmer_offset {
+                            candidate_region.max_likelihood_sequence.substr(
+                                0, start_idx)
+                        };
+                        const auto end_kmer_offset {
+                            candidate_region.max_likelihood_sequence.substr(
+                                candidate_region.max_likelihood_sequence.length()
+                                - end_idx)
+                        };
+                        current_path
+                            = std::string(candidate_region.left_flanking_sequence)
+                                  .append(start_kmer_offset)
+                                  .append(current_path)
+                                  .append(end_kmer_offset)
+                                  .append(candidate_region.right_flanking_sequence);
                     }
 
                     remove_graph_file();
@@ -92,18 +111,23 @@ void DenovoDiscovery::find_paths_through_candidate_region(CandidateRegion &candi
             }
         }
     }
-    BOOST_LOG_TRIVIAL(debug) << "Could not find any combination of start and end k-mers. Skipping local assembly for "
+    BOOST_LOG_TRIVIAL(debug) << "Could not find any combination of start and end "
+                                "k-mers. Skipping local assembly for "
                              << candidate_region.get_name();
     remove_graph_file();
-
 }
 
+DenovoDiscovery::DenovoDiscovery(const uint_least8_t& kmer_size,
+    const double& read_error_rate, const uint8_t max_insertion_size)
+    : kmer_size { kmer_size }
+    , read_error_rate { read_error_rate }
+    , max_insertion_size { max_insertion_size }
+{
+}
 
-DenovoDiscovery::DenovoDiscovery(const uint_least8_t &kmer_size, const double &read_error_rate, const uint8_t max_insertion_size)
-        : kmer_size { kmer_size }, read_error_rate { read_error_rate }, max_insertion_size { max_insertion_size } {}
-
-
-double DenovoDiscovery::calculate_kmer_coverage(const uint32_t &read_covg, const uint32_t &ref_length) const {
+double DenovoDiscovery::calculate_kmer_coverage(
+    const uint32_t& read_covg, const uint32_t& ref_length) const
+{
     if (ref_length == 0) {
         throw std::invalid_argument("ref_length should be greater than 0.");
     } else if (kmer_size == 0) {
@@ -112,8 +136,8 @@ double DenovoDiscovery::calculate_kmer_coverage(const uint32_t &read_covg, const
         throw std::invalid_argument("error_rate should not be a negative value.");
     }
 
-    const auto numerator { read_covg * (ref_length - kmer_size + 1) * std::pow(1 - read_error_rate, kmer_size) };
+    const auto numerator { read_covg * (ref_length - kmer_size + 1)
+        * std::pow(1 - read_error_rate, kmer_size) };
     const auto denominator { ref_length };
     return numerator / denominator;
 }
-

--- a/src/denovo_discovery/local_assembly.cpp
+++ b/src/denovo_discovery/local_assembly.cpp
@@ -145,7 +145,7 @@ BfsDistanceMap LocalAssemblyGraph::breadth_first_search_from(
  * The associated util function is a recursive function that generates a path down to a
  * "leaf" of the tree and then comes back up to the next unexplored branching point.
  */
-std::pair<DenovoPaths, bool> LocalAssemblyGraph::get_paths_between(
+std::pair<DenovoPaths, FoundPaths> LocalAssemblyGraph::get_paths_between(
     const Node& start_node, const Node& end_node, const uint32_t& max_path_length,
     const double& expected_coverage)
 {
@@ -209,8 +209,9 @@ void LocalAssemblyGraph::build_paths_between(const std::string& start_kmer,
             and path_accumulator.length()
                     + node_to_distance_to_the_end_node.at(start_kmer)
                 <= max_path_length);
-    if (not start_kmer_can_reach_end_kmer_with_distance_max_path_length)
+    if (not start_kmer_can_reach_end_kmer_with_distance_max_path_length) {
         return;
+    }
 
     auto start_node { buildNode(start_kmer.c_str()) };
     const auto kmer_coverage { queryAbundance(start_node) };

--- a/src/denovo_discovery/local_assembly.cpp
+++ b/src/denovo_discovery/local_assembly.cpp
@@ -187,14 +187,10 @@ void LocalAssemblyGraph::build_paths_between(const std::string &start_kmer, cons
         return;
     }
 
-    bool start_kmer_cannot_reach_end_kmer = node_to_distance_to_the_end_node.find(start_kmer) == node_to_distance_to_the_end_node.end();
-    if (start_kmer_cannot_reach_end_kmer) {
-        return;
-    }
-
-    bool start_kmer_cannot_reach_end_kmer_with_distance_max_path_length =
-            path_accumulator.length() + node_to_distance_to_the_end_node.at(start_kmer) > max_path_length;
-    if (start_kmer_cannot_reach_end_kmer_with_distance_max_path_length)
+    bool start_kmer_can_reach_end_kmer_with_distance_max_path_length =
+            (node_to_distance_to_the_end_node.find(start_kmer) != node_to_distance_to_the_end_node.end() and
+            path_accumulator.length() + node_to_distance_to_the_end_node.at(start_kmer) <= max_path_length);
+    if (not start_kmer_can_reach_end_kmer_with_distance_max_path_length)
         return;
 
     auto start_node { buildNode(start_kmer.c_str()) };

--- a/src/denovo_discovery/local_assembly.cpp
+++ b/src/denovo_discovery/local_assembly.cpp
@@ -1,7 +1,7 @@
 #include "denovo_discovery/local_assembly.h"
 
-
-LocalAssemblyGraph& LocalAssemblyGraph::operator=(const Graph &graph) {
+LocalAssemblyGraph& LocalAssemblyGraph::operator=(const Graph& graph)
+{
     if (this != &graph) {
         _kmerSize = graph._kmerSize;
         _storageMode = graph._storageMode;
@@ -15,28 +15,31 @@ LocalAssemblyGraph& LocalAssemblyGraph::operator=(const Graph &graph) {
 
         setStorage(graph._storage);
 
-        if (graph._variant) { *((GraphDataVariant *) _variant) = *((GraphDataVariant *) graph._variant); }
+        if (graph._variant) {
+            *((GraphDataVariant*)_variant) = *((GraphDataVariant*)graph._variant);
+        }
     }
     return *this;
 }
 
-
-bool string_ends_with(std::string const &query, std::string const &ending) {
+bool string_ends_with(std::string const& query, std::string const& ending)
+{
     if (query.length() < ending.length()) {
         return false;
     }
-    return 0 == query.compare(query.length() - ending.length(), ending.length(), ending);
+    return 0
+        == query.compare(query.length() - ending.length(), ending.length(), ending);
 }
 
-
-std::pair<Node, bool> LocalAssemblyGraph::get_node(const std::string &query_kmer) {
+std::pair<Node, bool> LocalAssemblyGraph::get_node(const std::string& query_kmer)
+{
     const auto query_node { buildNode(query_kmer.c_str()) };
     Node requested_node;
     bool node_found { false };
     auto nodes_in_graph { iterator() };
 
     for (nodes_in_graph.first(); !nodes_in_graph.isDone(); nodes_in_graph.next()) {
-        const auto &current_node { nodes_in_graph.item() };
+        const auto& current_node { nodes_in_graph.item() };
         node_found = (current_node == query_node);
 
         if (node_found) {
@@ -53,26 +56,30 @@ std::pair<Node, bool> LocalAssemblyGraph::get_node(const std::string &query_kmer
     return std::make_pair(requested_node, node_found);
 }
 
-
-// Non-recursive implementation of DFS from "Algorithm Design" - Kleinberg and Tardos (First Edition)
-DfsTree LocalAssemblyGraph::depth_first_search_from(const Node &start_node, bool reverse) {
+// Non-recursive implementation of DFS from "Algorithm Design" - Kleinberg and Tardos
+// (First Edition)
+DfsTree LocalAssemblyGraph::depth_first_search_from(
+    const Node& start_node, bool reverse)
+{
     BOOST_LOG_TRIVIAL(debug) << "Starting DFS...";
-    std::stack <Node> nodes_to_explore({ start_node });
+    std::stack<Node> nodes_to_explore({ start_node });
 
-    std::unordered_set <std::string> explored_nodes;
+    std::unordered_set<std::string> explored_nodes;
     DfsTree tree_of_nodes_visited;
 
     while (not nodes_to_explore.empty()) {
-        auto &current_node { nodes_to_explore.top() };
+        auto& current_node { nodes_to_explore.top() };
         nodes_to_explore.pop();
 
-        bool previously_explored { explored_nodes.find(toString(current_node)) != explored_nodes.end() };
+        bool previously_explored { explored_nodes.find(toString(current_node))
+            != explored_nodes.end() };
         if (previously_explored) {
             continue;
         }
 
         explored_nodes.insert(toString(current_node));
-        auto children_of_current_node { (reverse ? predecessors(current_node) : successors(current_node)) };
+        auto children_of_current_node { (
+            reverse ? predecessors(current_node) : successors(current_node)) };
         tree_of_nodes_visited[toString(current_node)] = children_of_current_node;
 
         for (unsigned int i = 0; i < children_of_current_node.size(); ++i) {
@@ -84,56 +91,64 @@ DfsTree LocalAssemblyGraph::depth_first_search_from(const Node &start_node, bool
 }
 
 /*
-BFS implementation - returns a distance map with where the keys are kmers of the nodes found in the BFS
-and the values are the distances from the start node to the such found nodes
+BFS implementation - returns a distance map with where the keys are kmers of the nodes
+found in the BFS and the values are the distances from the start node to the such found
+nodes
 */
-BfsDistanceMap LocalAssemblyGraph::breadth_first_search_from(const Node &start_node, bool reverse) {
+BfsDistanceMap LocalAssemblyGraph::breadth_first_search_from(
+    const Node& start_node, bool reverse)
+{
     BOOST_LOG_TRIVIAL(debug) << "Starting BFS...";
 
-    std::unordered_set <std::string> explored_nodes;
+    std::unordered_set<std::string> explored_nodes;
     BfsDistanceMap node_to_distance_to_the_start_node;
     std::map<std::string, std::string> child_kmer_to_parent_kmer;
 
-    std::queue <Node> nodes_to_explore({ start_node });
+    std::queue<Node> nodes_to_explore({ start_node });
     child_kmer_to_parent_kmer[toString(start_node)] = "none";
 
     while (not nodes_to_explore.empty()) {
-        auto &current_node { nodes_to_explore.front() };
+        auto& current_node { nodes_to_explore.front() };
         nodes_to_explore.pop();
 
         auto current_kmer = toString(current_node);
         auto parent_kmer = child_kmer_to_parent_kmer.at(current_kmer);
 
-        bool previously_explored { explored_nodes.find(current_kmer) != explored_nodes.end() };
+        bool previously_explored { explored_nodes.find(current_kmer)
+            != explored_nodes.end() };
         if (previously_explored) {
             continue;
         }
 
         explored_nodes.insert(current_kmer);
-        node_to_distance_to_the_start_node[current_kmer] =
-                (parent_kmer == "none" ? 0 : node_to_distance_to_the_start_node.at(parent_kmer)+1);
+        node_to_distance_to_the_start_node[current_kmer] = (parent_kmer == "none"
+                ? 0
+                : node_to_distance_to_the_start_node.at(parent_kmer) + 1);
 
-        auto children_of_current_node { (reverse ? predecessors(current_node) : successors(current_node)) };
+        auto children_of_current_node { (
+            reverse ? predecessors(current_node) : successors(current_node)) };
 
         for (unsigned int i = 0; i < children_of_current_node.size(); ++i) {
             nodes_to_explore.push(children_of_current_node[i]);
-            child_kmer_to_parent_kmer[toString(children_of_current_node[i])] = current_kmer;
+            child_kmer_to_parent_kmer[toString(children_of_current_node[i])]
+                = current_kmer;
         }
     }
     BOOST_LOG_TRIVIAL(debug) << "BFS finished.";
     return node_to_distance_to_the_start_node;
 }
 
-
-/* The aim of this function is to take a DFS tree, and return all paths within this tree that start at start_kmer
- * and end at end_kmer. Allowing for the different combinations in the number of cycles if the path contains any.
+/* The aim of this function is to take a DFS tree, and return all paths within this tree
+ * that start at start_kmer and end at end_kmer. Allowing for the different combinations
+ * in the number of cycles if the path contains any.
  *
- * The associated util function is a recursive function that generates a path down to a "leaf" of the tree and
- * then comes back up to the next unexplored branching point.
+ * The associated util function is a recursive function that generates a path down to a
+ * "leaf" of the tree and then comes back up to the next unexplored branching point.
  */
-std::pair<DenovoPaths, bool>
-LocalAssemblyGraph::get_paths_between(const Node &start_node, const Node &end_node,
-                                      const uint32_t &max_path_length, const double &expected_coverage) {
+std::pair<DenovoPaths, bool> LocalAssemblyGraph::get_paths_between(
+    const Node& start_node, const Node& end_node, const uint32_t& max_path_length,
+    const double& expected_coverage)
+{
     DenovoPaths paths_between_queries;
     bool abandoned = false;
     const std::string start_kmer = toString(start_node);
@@ -141,17 +156,16 @@ LocalAssemblyGraph::get_paths_between(const Node &start_node, const Node &end_no
 
     auto tree { depth_first_search_from(start_node) };
 
-    //check if end node is in forward tree, if not just return
-    bool end_kmer_not_reachable_from_start_kmer =
-            tree.find(end_kmer) == tree.end();
+    // check if end node is in forward tree, if not just return
+    bool end_kmer_not_reachable_from_start_kmer = tree.find(end_kmer) == tree.end();
     if (end_kmer_not_reachable_from_start_kmer) {
         return std::make_pair(paths_between_queries, abandoned);
     }
 
     auto node_to_distance_to_the_end_node { breadth_first_search_from(end_node, true) };
 
-
-    BOOST_LOG_TRIVIAL(debug) << "Enumerating all paths in DFS tree between " << start_kmer << " and " << end_kmer;
+    BOOST_LOG_TRIVIAL(debug) << "Enumerating all paths in DFS tree between "
+                             << start_kmer << " and " << end_kmer;
     std::string path_accumulator { start_kmer.substr(0, start_kmer.length() - 1) };
     uint8_t retries { 1 };
 
@@ -160,36 +174,41 @@ LocalAssemblyGraph::get_paths_between(const Node &start_node, const Node &end_no
 
         const float required_percent_of_expected_covg { retries * COVG_SCALING_FACTOR };
         if (required_percent_of_expected_covg > 1.0) {
-            BOOST_LOG_TRIVIAL(debug) << "Abandoning local assembly for slice as too many paths.";
+            BOOST_LOG_TRIVIAL(debug)
+                << "Abandoning local assembly for slice as too many paths.";
             abandoned = true;
             break;
         }
-        build_paths_between(start_kmer, end_kmer, path_accumulator, tree, node_to_distance_to_the_end_node, paths_between_queries, max_path_length,
-                            expected_coverage, required_percent_of_expected_covg);
+        build_paths_between(start_kmer, end_kmer, path_accumulator, tree,
+            node_to_distance_to_the_end_node, paths_between_queries, max_path_length,
+            expected_coverage, required_percent_of_expected_covg);
         retries++;
     } while (paths_between_queries.size() > MAX_NUMBER_CANDIDATE_PATHS);
 
-    BOOST_LOG_TRIVIAL(debug) << "Path enumeration complete. There were " << std::to_string(paths_between_queries.size())
+    BOOST_LOG_TRIVIAL(debug) << "Path enumeration complete. There were "
+                             << std::to_string(paths_between_queries.size())
                              << " paths found.";
     return std::make_pair(paths_between_queries, abandoned);
 }
 
-
-void LocalAssemblyGraph::build_paths_between(const std::string &start_kmer, const std::string &end_kmer,
-                                             std::string path_accumulator,
-                                             DfsTree &tree,
-                                             BfsDistanceMap &node_to_distance_to_the_end_node,
-                                             DenovoPaths &paths_between_queries, const uint32_t &max_path_length,
-                                             const double &expected_kmer_covg,
-                                             const float &required_percent_of_expected_covg,
-                                             uint32_t num_kmers_below_threshold) {
-    if (path_accumulator.length() > max_path_length or paths_between_queries.size() > MAX_NUMBER_CANDIDATE_PATHS) {
+void LocalAssemblyGraph::build_paths_between(const std::string& start_kmer,
+    const std::string& end_kmer, std::string path_accumulator, DfsTree& tree,
+    BfsDistanceMap& node_to_distance_to_the_end_node,
+    DenovoPaths& paths_between_queries, const uint32_t& max_path_length,
+    const double& expected_kmer_covg, const float& required_percent_of_expected_covg,
+    uint32_t num_kmers_below_threshold)
+{
+    if (path_accumulator.length() > max_path_length
+        or paths_between_queries.size() > MAX_NUMBER_CANDIDATE_PATHS) {
         return;
     }
 
-    bool start_kmer_can_reach_end_kmer_with_distance_max_path_length =
-            (node_to_distance_to_the_end_node.find(start_kmer) != node_to_distance_to_the_end_node.end() and
-            path_accumulator.length() + node_to_distance_to_the_end_node.at(start_kmer) <= max_path_length);
+    bool start_kmer_can_reach_end_kmer_with_distance_max_path_length
+        = (node_to_distance_to_the_end_node.find(start_kmer)
+                != node_to_distance_to_the_end_node.end()
+            and path_accumulator.length()
+                    + node_to_distance_to_the_end_node.at(start_kmer)
+                <= max_path_length);
     if (not start_kmer_can_reach_end_kmer_with_distance_max_path_length)
         return;
 
@@ -206,46 +225,52 @@ void LocalAssemblyGraph::build_paths_between(const std::string &start_kmer, cons
 
     path_accumulator.push_back(start_kmer.back());
 
-    if (string_ends_with(path_accumulator, end_kmer) and path_accumulator.length() > end_kmer.length()) {
+    if (string_ends_with(path_accumulator, end_kmer)
+        and path_accumulator.length() > end_kmer.length()) {
         paths_between_queries.push_back(path_accumulator);
-        // we dont return here so as to make sure we get all possible cycle repetitions up to the maximum length
+        // we dont return here so as to make sure we get all possible cycle repetitions
+        // up to the maximum length
     }
 
-    auto &children_of_start_node { tree[start_kmer] };
+    auto& children_of_start_node { tree[start_kmer] };
     const auto num_children { children_of_start_node.size() };
 
     for (unsigned int i = 0; i < num_children; ++i) {
         const auto next_start_kmer { toString(children_of_start_node[i]) };
-        build_paths_between(next_start_kmer, end_kmer, path_accumulator, tree, node_to_distance_to_the_end_node,
-                paths_between_queries, max_path_length, expected_kmer_covg, required_percent_of_expected_covg,
-                num_kmers_below_threshold);
+        build_paths_between(next_start_kmer, end_kmer, path_accumulator, tree,
+            node_to_distance_to_the_end_node, paths_between_queries, max_path_length,
+            expected_kmer_covg, required_percent_of_expected_covg,
+            num_kmers_below_threshold);
     }
 }
 
-
-void remove_graph_file() {
+void remove_graph_file()
+{
     const fs::path p { "dummy.h5" };
     fs::remove(p);
 }
 
-
-void clean(Graph &graph, const uint16_t &num_cores) {
-    Simplifications <Graph, Node, Edge> graph_simplifications(graph, num_cores);
+void clean(Graph& graph, const uint16_t& num_cores)
+{
+    Simplifications<Graph, Node, Edge> graph_simplifications(graph, num_cores);
     graph_simplifications._doTipRemoval = true;
     graph_simplifications._doBulgeRemoval = false;
     graph_simplifications._doECRemoval = false;
 
-    graph_simplifications
-            ._tipLen_Topo_kMult = 2; // remove all tips of length <= k * X bp  [default '2.500000'] set to 0 to turn off
-    graph_simplifications
-            ._tipLen_RCTC_kMult = 0;  // remove tips that pass coverage criteria, of length <= k * X bp  [default '10.000000'] set to 0 to turn off
-    graph_simplifications
-            ._tipRCTCcutoff = 2; // tip relative coverage coefficient: mean coverage of neighbors >  X * tip coverage default 2.0
+    graph_simplifications._tipLen_Topo_kMult
+        = 2; // remove all tips of length <= k * X bp  [default '2.500000'] set to 0 to
+             // turn off
+    graph_simplifications._tipLen_RCTC_kMult
+        = 0; // remove tips that pass coverage criteria, of length <= k * X bp  [default
+             // '10.000000'] set to 0 to turn off
+    graph_simplifications._tipRCTCcutoff
+        = 2; // tip relative coverage coefficient: mean coverage of neighbors >  X * tip
+             // coverage default 2.0
     graph_simplifications.simplify();
 }
 
-
-std::string reverse_complement(const std::string &forward) {
+std::string reverse_complement(const std::string& forward)
+{
     const auto len { forward.size() };
     std::string reverse(len, ' ');
     for (size_t k = 0; k < len; k++) {
@@ -257,11 +282,12 @@ std::string reverse_complement(const std::string &forward) {
     return reverse;
 }
 
-
-std::vector <std::string>
-generate_start_kmers(const std::string &sequence, const uint16_t &k, uint32_t num_to_generate) {
+std::vector<std::string> generate_start_kmers(
+    const std::string& sequence, const uint16_t& k, uint32_t num_to_generate)
+{
     const auto seq_len { sequence.length() };
-    const auto more_combinations_requested_than_possible { k + (num_to_generate - 1) > seq_len };
+    const auto more_combinations_requested_than_possible { k + (num_to_generate - 1)
+        > seq_len };
 
     if (more_combinations_requested_than_possible) {
         num_to_generate = seq_len - k + 1;
@@ -272,16 +298,19 @@ generate_start_kmers(const std::string &sequence, const uint16_t &k, uint32_t nu
     return all_kmers_in(generate_kmers_from, k);
 }
 
-
-std::vector <std::string> generate_end_kmers(const std::string &sequence, const uint32_t &k, uint32_t num_to_generate) {
+std::vector<std::string> generate_end_kmers(
+    const std::string& sequence, const uint32_t& k, uint32_t num_to_generate)
+{
     const auto seq_len { sequence.length() };
-    const auto more_combinations_requested_than_possible { k + (num_to_generate - 1) > seq_len };
+    const auto more_combinations_requested_than_possible { k + (num_to_generate - 1)
+        > seq_len };
 
     if (more_combinations_requested_than_possible) {
         num_to_generate = seq_len - k + 1;
     }
 
-    const auto generate_kmers_from { sequence.substr(seq_len - (num_to_generate + (k - 1))) };
+    const auto generate_kmers_from { sequence.substr(
+        seq_len - (num_to_generate + (k - 1))) };
     auto end_kmers { all_kmers_in(generate_kmers_from, k) };
 
     std::reverse(end_kmers.begin(), end_kmers.end());
@@ -289,9 +318,10 @@ std::vector <std::string> generate_end_kmers(const std::string &sequence, const 
     return end_kmers;
 }
 
-
-std::vector <std::string> all_kmers_in(const std::string &query, const uint_least8_t k_size) {
-    std::vector <std::string> kmers;
+std::vector<std::string> all_kmers_in(
+    const std::string& query, const uint_least8_t k_size)
+{
+    std::vector<std::string> kmers;
 
     if (k_size > query.length()) {
         return kmers;

--- a/test/denovo_discovery/candidate_region_test.cpp
+++ b/test/denovo_discovery/candidate_region_test.cpp
@@ -1,14 +1,14 @@
-#include <iostream>
-#include <cstdio>
-#include "gtest/gtest.h"
-#include "gmock/gmock.h"
+#include "../test_helpers.h"
 #include "../test_macro.cpp"
 #include "denovo_discovery/candidate_region.h"
 #include "fastaq.h"
-#include "../test_helpers.h"
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+#include <cstdio>
+#include <iostream>
 
-
-TEST(CandidateRegionGetIntervalTest, noPaddingReturnsOriginalInterval) {
+TEST(CandidateRegionGetIntervalTest, noPaddingReturnsOriginalInterval)
+{
     const CandidateRegion candidate { Interval(0, 2), "test" };
 
     const auto actual { candidate.get_interval() };
@@ -17,8 +17,9 @@ TEST(CandidateRegionGetIntervalTest, noPaddingReturnsOriginalInterval) {
     EXPECT_EQ(actual, expected);
 }
 
-
-TEST(CandidateRegionGetIntervalTest, withPaddingLessThanIntervalStartReturnsOriginalIntervalWithPadding) {
+TEST(CandidateRegionGetIntervalTest,
+    withPaddingLessThanIntervalStartReturnsOriginalIntervalWithPadding)
+{
     const CandidateRegion candidate { Interval(3, 4), "test", 1 };
 
     const auto actual { candidate.get_interval() };
@@ -27,8 +28,9 @@ TEST(CandidateRegionGetIntervalTest, withPaddingLessThanIntervalStartReturnsOrig
     EXPECT_EQ(actual, expected);
 }
 
-
-TEST(CandidateRegionGetIntervalTest, withPaddingGreaterThanIntervalStartReturnsOriginalIntervalWithPadding) {
+TEST(CandidateRegionGetIntervalTest,
+    withPaddingGreaterThanIntervalStartReturnsOriginalIntervalWithPadding)
+{
     const CandidateRegion candidate { Interval(3, 4), "test", 5 };
 
     const auto actual { candidate.get_interval() };
@@ -37,38 +39,40 @@ TEST(CandidateRegionGetIntervalTest, withPaddingGreaterThanIntervalStartReturnsO
     EXPECT_EQ(actual, expected);
 }
 
-
-TEST(CandidateRegionGetNameTest, testCorrectValueRetrieved) {
+TEST(CandidateRegionGetNameTest, testCorrectValueRetrieved)
+{
     const CandidateRegion candidate { Interval(0, 2), "test" };
 
-    const auto &actual { candidate.get_name() };
+    const auto& actual { candidate.get_name() };
     const std::string expected { "test" };
 
     EXPECT_EQ(actual, expected);
 }
 
-
-TEST(CandidateRegionGetIdTest, noPaddingTestCorrectIdRetrieved) {
+TEST(CandidateRegionGetIdTest, noPaddingTestCorrectIdRetrieved)
+{
     const CandidateRegion candidate { Interval(0, 2), "test" };
 
     const auto actual { candidate.get_id() };
-    const CandidateRegionIdentifier expected { candidate.get_interval(), candidate.get_name() };
+    const CandidateRegionIdentifier expected { candidate.get_interval(),
+        candidate.get_name() };
 
     EXPECT_EQ(actual, expected);
 }
 
-
-TEST(CandidateRegionGetIdTest, withPaddingTestCorrectIdRetrieved) {
+TEST(CandidateRegionGetIdTest, withPaddingTestCorrectIdRetrieved)
+{
     const CandidateRegion candidate { Interval(0, 2), "test", 6 };
 
     const auto actual { candidate.get_id() };
-    const CandidateRegionIdentifier expected { candidate.get_interval(), candidate.get_name() };
+    const CandidateRegionIdentifier expected { candidate.get_interval(),
+        candidate.get_name() };
 
     EXPECT_EQ(actual, expected);
 }
 
-
-TEST(GetMaxLikelihoodSequenceWithFlanksTest, noSequencesReturnEmptyString) {
+TEST(GetMaxLikelihoodSequenceWithFlanksTest, noSequencesReturnEmptyString)
+{
     const CandidateRegion candidate { Interval(0, 2), "test", 6 };
 
     const auto actual { candidate.get_max_likelihood_sequence_with_flanks() };
@@ -77,8 +81,9 @@ TEST(GetMaxLikelihoodSequenceWithFlanksTest, noSequencesReturnEmptyString) {
     EXPECT_EQ(actual, expected);
 }
 
-
-TEST(GetMaxLikelihoodSequenceWithFlanksTest, noLeftFlankSequencesReturnMaxAndRightSequence) {
+TEST(GetMaxLikelihoodSequenceWithFlanksTest,
+    noLeftFlankSequencesReturnMaxAndRightSequence)
+{
     CandidateRegion candidate { Interval(0, 2), "test", 6 };
     candidate.max_likelihood_sequence = "max";
     candidate.right_flanking_sequence = "right";
@@ -89,8 +94,9 @@ TEST(GetMaxLikelihoodSequenceWithFlanksTest, noLeftFlankSequencesReturnMaxAndRig
     EXPECT_EQ(actual, expected);
 }
 
-
-TEST(GetMaxLikelihoodSequenceWithFlanksTest, noRightFlankSequencesReturnLeftAndMaxSequence) {
+TEST(GetMaxLikelihoodSequenceWithFlanksTest,
+    noRightFlankSequencesReturnLeftAndMaxSequence)
+{
     CandidateRegion candidate { Interval(0, 2), "test", 6 };
     candidate.max_likelihood_sequence = "max";
     candidate.left_flanking_sequence = "left";
@@ -101,8 +107,8 @@ TEST(GetMaxLikelihoodSequenceWithFlanksTest, noRightFlankSequencesReturnLeftAndM
     EXPECT_EQ(actual, expected);
 }
 
-
-TEST(GetMaxLikelihoodSequenceWithFlanksTest, allSequencesPresentReturnAllJoined) {
+TEST(GetMaxLikelihoodSequenceWithFlanksTest, allSequencesPresentReturnAllJoined)
+{
     CandidateRegion candidate { Interval(0, 2), "test", 6 };
     candidate.max_likelihood_sequence = "max";
     candidate.left_flanking_sequence = "left";
@@ -114,40 +120,40 @@ TEST(GetMaxLikelihoodSequenceWithFlanksTest, allSequencesPresentReturnAllJoined)
     EXPECT_EQ(actual, expected);
 }
 
-
-TEST(CandidateRegionEqualityTest, identicalCandidateRegionsReturnsTrue) {
+TEST(CandidateRegionEqualityTest, identicalCandidateRegionsReturnsTrue)
+{
     const CandidateRegion candidate1 { Interval(0, 2), "test" };
     const CandidateRegion candidate2 { Interval(0, 2), "test" };
 
     EXPECT_TRUE(candidate1 == candidate2);
 }
 
-
-TEST(CandidateRegionEqualityTest, differentCandidateRegionsReturnsFalse) {
+TEST(CandidateRegionEqualityTest, differentCandidateRegionsReturnsFalse)
+{
     const CandidateRegion candidate1 { Interval(0, 2), "test" };
     const CandidateRegion candidate2 { Interval(0, 1), "test" };
 
     EXPECT_FALSE(candidate1 == candidate2);
 }
 
-
-TEST(CandidateRegionInequalityTest, identicalCandidateRegionsReturnsFalse) {
+TEST(CandidateRegionInequalityTest, identicalCandidateRegionsReturnsFalse)
+{
     const CandidateRegion candidate1 { Interval(0, 2), "test" };
     const CandidateRegion candidate2 { Interval(0, 2), "test" };
 
     EXPECT_FALSE(candidate1 != candidate2);
 }
 
-
-TEST(CandidateRegionInequalityTest, differentCandidateRegionsReturnsTrue) {
+TEST(CandidateRegionInequalityTest, differentCandidateRegionsReturnsTrue)
+{
     const CandidateRegion candidate1 { Interval(0, 2), "test" };
     const CandidateRegion candidate2 { Interval(0, 2), "test2" };
 
     EXPECT_TRUE(candidate1 != candidate2);
 }
 
-
-TEST(IdentifyLowCoverageIntervalsTest, emptyCovgsReturnEmpty) {
+TEST(IdentifyLowCoverageIntervalsTest, emptyCovgsReturnEmpty)
+{
     const auto min_len { 5 };
     const auto min_covg { 0 };
     const std::vector<uint32_t> covgs;
@@ -158,8 +164,8 @@ TEST(IdentifyLowCoverageIntervalsTest, emptyCovgsReturnEmpty) {
     EXPECT_EQ(actual, expected);
 }
 
-
-TEST(IdentifyLowCoverageIntervalsTest, singleCovgPositionAboveThresholdReturnEmpty) {
+TEST(IdentifyLowCoverageIntervalsTest, singleCovgPositionAboveThresholdReturnEmpty)
+{
     const auto min_len { 1 };
     const auto min_covg { 1 };
     const std::vector<uint32_t> covgs { 2 };
@@ -170,8 +176,9 @@ TEST(IdentifyLowCoverageIntervalsTest, singleCovgPositionAboveThresholdReturnEmp
     EXPECT_EQ(actual, expected);
 }
 
-
-TEST(IdentifyLowCoverageIntervalsTest, singleCovgPositionBelowThresholdReturnSingleInterval) {
+TEST(IdentifyLowCoverageIntervalsTest,
+    singleCovgPositionBelowThresholdReturnSingleInterval)
+{
     const auto min_len { 1 };
     const auto min_covg { 3 };
     const std::vector<uint32_t> covgs { 2 };
@@ -182,8 +189,8 @@ TEST(IdentifyLowCoverageIntervalsTest, singleCovgPositionBelowThresholdReturnSin
     EXPECT_EQ(actual, expected);
 }
 
-
-TEST(IdentifyLowCoverageIntervalsTest, allPositionsAboveThresholdReturnEmpty) {
+TEST(IdentifyLowCoverageIntervalsTest, allPositionsAboveThresholdReturnEmpty)
+{
     const auto min_len { 1 };
     const auto min_covg { 1 };
     const std::vector<uint32_t> covgs { 2, 2, 2, 2 };
@@ -194,8 +201,9 @@ TEST(IdentifyLowCoverageIntervalsTest, allPositionsAboveThresholdReturnEmpty) {
     EXPECT_EQ(actual, expected);
 }
 
-
-TEST(IdentifyLowCoverageIntervalsTest, allPositionsBelowThresholdReturnIntervalForWholeVector) {
+TEST(IdentifyLowCoverageIntervalsTest,
+    allPositionsBelowThresholdReturnIntervalForWholeVector)
+{
     const auto min_len { 1 };
     const auto min_covg { 3 };
     const std::vector<uint32_t> covgs { 2, 2, 2, 2 };
@@ -206,8 +214,9 @@ TEST(IdentifyLowCoverageIntervalsTest, allPositionsBelowThresholdReturnIntervalF
     EXPECT_EQ(actual, expected);
 }
 
-
-TEST(IdentifyLowCoverageIntervalsTest, allPositionsBelowThresholdButLessThanMinLengthReturnEmpty) {
+TEST(IdentifyLowCoverageIntervalsTest,
+    allPositionsBelowThresholdButLessThanMinLengthReturnEmpty)
+{
     const auto min_len { 10 };
     const auto min_covg { 3 };
     const std::vector<uint32_t> covgs { 2, 2, 2, 2 };
@@ -218,8 +227,9 @@ TEST(IdentifyLowCoverageIntervalsTest, allPositionsBelowThresholdButLessThanMinL
     EXPECT_EQ(actual, expected);
 }
 
-
-TEST(IdentifyLowCoverageIntervalsTest, twoPositionsAtStartBelowThresholdButLessThanMinLenReturnEmpty) {
+TEST(IdentifyLowCoverageIntervalsTest,
+    twoPositionsAtStartBelowThresholdButLessThanMinLenReturnEmpty)
+{
     const auto min_len { 3 };
     const auto min_covg { 3 };
     const std::vector<uint32_t> covgs { 2, 2, 4, 4, 4 };
@@ -230,8 +240,9 @@ TEST(IdentifyLowCoverageIntervalsTest, twoPositionsAtStartBelowThresholdButLessT
     EXPECT_EQ(actual, expected);
 }
 
-
-TEST(IdentifyLowCoverageIntervalsTest, twoPositionsInMiddleBelowThresholdButLessThanMinLenReturnEmpty) {
+TEST(IdentifyLowCoverageIntervalsTest,
+    twoPositionsInMiddleBelowThresholdButLessThanMinLenReturnEmpty)
+{
     const auto min_len { 3 };
     const auto min_covg { 3 };
     const std::vector<uint32_t> covgs { 4, 2, 2, 4, 4 };
@@ -242,8 +253,9 @@ TEST(IdentifyLowCoverageIntervalsTest, twoPositionsInMiddleBelowThresholdButLess
     EXPECT_EQ(actual, expected);
 }
 
-
-TEST(IdentifyLowCoverageIntervalsTest, twoPositionsAtEndBelowThresholdButLessThanMinLenReturnEmpty) {
+TEST(IdentifyLowCoverageIntervalsTest,
+    twoPositionsAtEndBelowThresholdButLessThanMinLenReturnEmpty)
+{
     const auto min_len { 3 };
     const auto min_covg { 3 };
     const std::vector<uint32_t> covgs { 4, 4, 4, 2, 2 };
@@ -254,8 +266,9 @@ TEST(IdentifyLowCoverageIntervalsTest, twoPositionsAtEndBelowThresholdButLessTha
     EXPECT_EQ(actual, expected);
 }
 
-
-TEST(IdentifyLowCoverageIntervalsTest, twoPositionsAtStartBelowThresholdReturnSingleInterval) {
+TEST(IdentifyLowCoverageIntervalsTest,
+    twoPositionsAtStartBelowThresholdReturnSingleInterval)
+{
     const auto min_len { 2 };
     const auto min_covg { 3 };
     const std::vector<uint32_t> covgs { 2, 2, 4, 4, 4 };
@@ -266,8 +279,9 @@ TEST(IdentifyLowCoverageIntervalsTest, twoPositionsAtStartBelowThresholdReturnSi
     EXPECT_EQ(actual, expected);
 }
 
-
-TEST(IdentifyLowCoverageIntervalsTest, twoPositionsInMiddleBelowThresholdReturnSingleInterval) {
+TEST(IdentifyLowCoverageIntervalsTest,
+    twoPositionsInMiddleBelowThresholdReturnSingleInterval)
+{
     const auto min_len { 1 };
     const auto min_covg { 3 };
     const std::vector<uint32_t> covgs { 4, 2, 2, 4, 4 };
@@ -278,8 +292,9 @@ TEST(IdentifyLowCoverageIntervalsTest, twoPositionsInMiddleBelowThresholdReturnS
     EXPECT_EQ(actual, expected);
 }
 
-
-TEST(IdentifyLowCoverageIntervalsTest, twoPositionsAtEndBelowThresholdReturnSingleInterval) {
+TEST(IdentifyLowCoverageIntervalsTest,
+    twoPositionsAtEndBelowThresholdReturnSingleInterval)
+{
     const auto min_len { 2 };
     const auto min_covg { 3 };
     const std::vector<uint32_t> covgs { 4, 4, 4, 2, 2 };
@@ -290,8 +305,9 @@ TEST(IdentifyLowCoverageIntervalsTest, twoPositionsAtEndBelowThresholdReturnSing
     EXPECT_EQ(actual, expected);
 }
 
-
-TEST(IdentifyLowCoverageIntervalsTest, twoRegionsAtStartAndEndBelowThresholdReturnTwoIntervals) {
+TEST(IdentifyLowCoverageIntervalsTest,
+    twoRegionsAtStartAndEndBelowThresholdReturnTwoIntervals)
+{
     const auto min_len { 2 };
     const auto min_covg { 3 };
     const std::vector<uint32_t> covgs { 2, 2, 4, 4, 4, 2, 2 };
@@ -302,8 +318,8 @@ TEST(IdentifyLowCoverageIntervalsTest, twoRegionsAtStartAndEndBelowThresholdRetu
     EXPECT_EQ(actual, expected);
 }
 
-
-TEST(IdentifyLowCoverageIntervalsTest, twoRegionsBelowThresholdReturnTwoIntervals) {
+TEST(IdentifyLowCoverageIntervalsTest, twoRegionsBelowThresholdReturnTwoIntervals)
+{
     const auto min_len { 2 };
     const auto min_covg { 3 };
     const std::vector<uint32_t> covgs { 4, 2, 1, 1, 4, 1, 2, 4 };
@@ -314,8 +330,9 @@ TEST(IdentifyLowCoverageIntervalsTest, twoRegionsBelowThresholdReturnTwoInterval
     EXPECT_EQ(actual, expected);
 }
 
-
-TEST(IdentifyLowCoverageIntervalsTest, twoRegionsBelowThresholdOneLessThanMinLengthReturnOneInterval) {
+TEST(IdentifyLowCoverageIntervalsTest,
+    twoRegionsBelowThresholdOneLessThanMinLengthReturnOneInterval)
+{
     const auto min_len { 3 };
     const auto min_covg { 3 };
     const std::vector<uint32_t> covgs { 4, 2, 1, 1, 4, 1, 2, 4 };
@@ -326,81 +343,93 @@ TEST(IdentifyLowCoverageIntervalsTest, twoRegionsBelowThresholdOneLessThanMinLen
     EXPECT_EQ(actual, expected);
 }
 
-
-TEST(FindCandidateRegionsForPanNodeTest, emptyPanNodeReturnsNoCandidates) {
+TEST(FindCandidateRegionsForPanNodeTest, emptyPanNodeReturnsNoCandidates)
+{
     const auto num_samples { 1 };
     const auto prg_id { 3 };
     auto local_prg_ptr { std::make_shared<LocalPRG>(prg_id, "test", "") };
     const std::vector<LocalNodePtr> local_node_max_likelihood_path;
     const std::vector<KmerNodePtr> kmer_node_max_likelihood_path;
 
-    PanNodePtr pangraph_node { std::make_shared<pangenome::Node>(local_prg_ptr, local_prg_ptr->id, num_samples) };
+    PanNodePtr pangraph_node { std::make_shared<pangenome::Node>(
+        local_prg_ptr, local_prg_ptr->id, num_samples) };
 
-
-    const TmpPanNode pangraph_node_components { pangraph_node, local_prg_ptr, kmer_node_max_likelihood_path,
-                                                local_node_max_likelihood_path };
+    const TmpPanNode pangraph_node_components { pangraph_node, local_prg_ptr,
+        kmer_node_max_likelihood_path, local_node_max_likelihood_path };
 
     const CandidateRegions expected;
     const auto actual { find_candidate_regions_for_pan_node(pangraph_node_components) };
 
     EXPECT_EQ(actual, expected);
-
 }
 
-
-TEST(FindCandidateRegionsForPanNodeTest, noCoverageReturnWholePrgAsCandidate) {
+TEST(FindCandidateRegionsForPanNodeTest, noCoverageReturnWholePrgAsCandidate)
+{
     const auto num_samples { 1 };
     const auto prg_id { 3 };
-    auto local_prg_ptr { std::make_shared<LocalPRG>(prg_id, "test", "AAA 5 G 6 C 5 TTT") };
+    auto local_prg_ptr { std::make_shared<LocalPRG>(
+        prg_id, "test", "AAA 5 G 6 C 5 TTT") };
     auto index { std::make_shared<Index>() };
     const auto w { 1 };
     const auto k { 3 };
     local_prg_ptr->minimizer_sketch(index, w, k);
     const std::string expected_sequence { "AAAGTTT" };
-    const std::vector<LocalNodePtr> local_node_max_likelihood_path { local_prg_ptr->prg.nodes[0], local_prg_ptr->prg.nodes[1],
-                                                                     local_prg_ptr->prg.nodes[3] };
+    const std::vector<LocalNodePtr> local_node_max_likelihood_path {
+        local_prg_ptr->prg.nodes[0], local_prg_ptr->prg.nodes[1],
+        local_prg_ptr->prg.nodes[3]
+    };
     std::vector<KmerNodePtr> kmer_node_max_likelihood_path {
-            local_prg_ptr->kmernode_path_from_localnode_path(local_node_max_likelihood_path) };
+        local_prg_ptr->kmernode_path_from_localnode_path(local_node_max_likelihood_path)
+    };
 
-    PanNodePtr pangraph_node { std::make_shared<pangenome::Node>(local_prg_ptr, local_prg_ptr->id, num_samples) };
+    PanNodePtr pangraph_node { std::make_shared<pangenome::Node>(
+        local_prg_ptr, local_prg_ptr->id, num_samples) };
 
-
-    const TmpPanNode pangraph_node_components { pangraph_node, local_prg_ptr, kmer_node_max_likelihood_path,
-                                                local_node_max_likelihood_path };
+    const TmpPanNode pangraph_node_components { pangraph_node, local_prg_ptr,
+        kmer_node_max_likelihood_path, local_node_max_likelihood_path };
 
     CandidateRegion expected_candidate { Interval(0, 7), pangraph_node->get_name() };
     expected_candidate.max_likelihood_sequence = expected_sequence;
-    const CandidateRegions expected { std::make_pair(expected_candidate.get_id(), expected_candidate) };
+    const CandidateRegions expected { std::make_pair(
+        expected_candidate.get_id(), expected_candidate) };
     const auto actual { find_candidate_regions_for_pan_node(pangraph_node_components) };
-    const auto actual_sequence { actual.at(expected_candidate.get_id()).max_likelihood_sequence };
+    const auto actual_sequence {
+        actual.at(expected_candidate.get_id()).max_likelihood_sequence
+    };
 
     EXPECT_EQ(actual, expected);
     EXPECT_EQ(actual_sequence, expected_sequence);
 }
 
-
-TEST(FindCandidateRegionsForPanNodeTest, highCoverageReturnEmpty) {
+TEST(FindCandidateRegionsForPanNodeTest, highCoverageReturnEmpty)
+{
     const auto num_samples { 1 };
     const auto prg_id { 3 };
-    auto local_prg_ptr { std::make_shared<LocalPRG>(prg_id, "test", "AAA 5 G 6 C 5 TTT") };
+    auto local_prg_ptr { std::make_shared<LocalPRG>(
+        prg_id, "test", "AAA 5 G 6 C 5 TTT") };
     auto index { std::make_shared<Index>() };
     const auto w { 1 };
     const auto k { 3 };
     local_prg_ptr->minimizer_sketch(index, w, k);
     const std::string expected_sequence { "AAAGTTT" };
-    const std::vector<LocalNodePtr> local_node_max_likelihood_path { local_prg_ptr->prg.nodes[0], local_prg_ptr->prg.nodes[1],
-                                                                     local_prg_ptr->prg.nodes[3] };
+    const std::vector<LocalNodePtr> local_node_max_likelihood_path {
+        local_prg_ptr->prg.nodes[0], local_prg_ptr->prg.nodes[1],
+        local_prg_ptr->prg.nodes[3]
+    };
     std::vector<KmerNodePtr> kmer_node_max_likelihood_path {
-            local_prg_ptr->kmernode_path_from_localnode_path(local_node_max_likelihood_path) };
+        local_prg_ptr->kmernode_path_from_localnode_path(local_node_max_likelihood_path)
+    };
 
-    PanNodePtr pangraph_node { std::make_shared<pangenome::Node>(local_prg_ptr, local_prg_ptr->id, num_samples) };
+    PanNodePtr pangraph_node { std::make_shared<pangenome::Node>(
+        local_prg_ptr, local_prg_ptr->id, num_samples) };
 
-    for (const auto &kmer_node : pangraph_node->kmer_prg_with_coverage.kmer_prg->nodes) {
+    for (const auto& kmer_node :
+        pangraph_node->kmer_prg_with_coverage.kmer_prg->nodes) {
         pangraph_node->kmer_prg_with_coverage.set_covg(kmer_node->id, 100, false, 0);
     }
 
-    const TmpPanNode pangraph_node_components { pangraph_node, local_prg_ptr, kmer_node_max_likelihood_path,
-                                                local_node_max_likelihood_path };
+    const TmpPanNode pangraph_node_components { pangraph_node, local_prg_ptr,
+        kmer_node_max_likelihood_path, local_node_max_likelihood_path };
 
     const CandidateRegions expected;
     const auto actual { find_candidate_regions_for_pan_node(pangraph_node_components) };
@@ -408,47 +437,58 @@ TEST(FindCandidateRegionsForPanNodeTest, highCoverageReturnEmpty) {
     EXPECT_EQ(actual, expected);
 }
 
-
-TEST(FindCandidateRegionsForPanNodeTest, noCoverageOnFiveBasesReturnFiveBasesAsCandidate) {
+TEST(
+    FindCandidateRegionsForPanNodeTest, noCoverageOnFiveBasesReturnFiveBasesAsCandidate)
+{
     const auto num_samples { 1 };
     const auto prg_id { 3 };
-    auto local_prg_ptr { std::make_shared<LocalPRG>(prg_id, "test", "AAAA 5 GGG 6 CCC 5 TTTT") };
+    auto local_prg_ptr { std::make_shared<LocalPRG>(
+        prg_id, "test", "AAAA 5 GGG 6 CCC 5 TTTT") };
     auto index { std::make_shared<Index>() };
     const auto w { 1 };
     const auto k { 3 };
     local_prg_ptr->minimizer_sketch(index, w, k);
     const std::string expected_sequence { "AAAAGGGTTTT" };
-    const std::vector<LocalNodePtr> local_node_max_likelihood_path { local_prg_ptr->prg.nodes[0], local_prg_ptr->prg.nodes[1],
-                                                                     local_prg_ptr->prg.nodes[3] };
-    const std::vector<int> kmer_node_idxs_for_max_path { 0, 1, 2, 3, 5, 7, 9, 11, 13, 14, 15 };
+    const std::vector<LocalNodePtr> local_node_max_likelihood_path {
+        local_prg_ptr->prg.nodes[0], local_prg_ptr->prg.nodes[1],
+        local_prg_ptr->prg.nodes[3]
+    };
+    const std::vector<int> kmer_node_idxs_for_max_path { 0, 1, 2, 3, 5, 7, 9, 11, 13,
+        14, 15 };
     std::vector<KmerNodePtr> kmer_node_max_likelihood_path;
     kmer_node_max_likelihood_path.reserve(kmer_node_idxs_for_max_path.size());
-    for (const auto &idx : kmer_node_idxs_for_max_path) {
+    for (const auto& idx : kmer_node_idxs_for_max_path) {
         kmer_node_max_likelihood_path.push_back(local_prg_ptr->kmer_prg.nodes[idx]);
     }
 
-    PanNodePtr pangraph_node { std::make_shared<pangenome::Node>(local_prg_ptr, local_prg_ptr->id, num_samples) };
+    PanNodePtr pangraph_node { std::make_shared<pangenome::Node>(
+        local_prg_ptr, local_prg_ptr->id, num_samples) };
     const std::vector<int> kmer_node_idxs_for_high_covg { 0, 1, 14, 15 };
-    for (const auto &idx : kmer_node_idxs_for_high_covg) {
+    for (const auto& idx : kmer_node_idxs_for_high_covg) {
         pangraph_node->kmer_prg_with_coverage.set_covg(idx, 100, false, 0);
     }
 
-    const TmpPanNode pangraph_node_components { pangraph_node, local_prg_ptr, kmer_node_max_likelihood_path,
-                                                local_node_max_likelihood_path };
+    const TmpPanNode pangraph_node_components { pangraph_node, local_prg_ptr,
+        kmer_node_max_likelihood_path, local_node_max_likelihood_path };
 
     CandidateRegion expected_candidate { Interval(3, 8), pangraph_node->get_name() };
-    const CandidateRegions expected { std::make_pair(expected_candidate.get_id(), expected_candidate) };
+    const CandidateRegions expected { std::make_pair(
+        expected_candidate.get_id(), expected_candidate) };
     const auto actual { find_candidate_regions_for_pan_node(pangraph_node_components) };
-    const auto actual_sequence { actual.at(expected_candidate.get_id()).get_max_likelihood_sequence_with_flanks() };
+    const auto actual_sequence {
+        actual.at(expected_candidate.get_id()).get_max_likelihood_sequence_with_flanks()
+    };
 
     EXPECT_EQ(actual, expected);
     EXPECT_EQ(actual_sequence, expected_sequence);
 }
 
-
-TEST(FindCandidateRegionsForPanNodeTest, noCoverageOnFiveBasesReturnFiveBasesPlusPaddingAsCandidate) {
+TEST(FindCandidateRegionsForPanNodeTest,
+    noCoverageOnFiveBasesReturnFiveBasesPlusPaddingAsCandidate)
+{
     const auto prg_id { 3 };
-    auto local_prg_ptr { std::make_shared<LocalPRG>(prg_id, "test", "AAAA 5 GGG 6 CCC 5 TTTT") };
+    auto local_prg_ptr { std::make_shared<LocalPRG>(
+        prg_id, "test", "AAAA 5 GGG 6 CCC 5 TTTT") };
     const std::string expected_sequence { "AAAAGGGTTTT" };
     const auto expected_max_likelihood_sequence { "AAGGGTT" };
     auto index { std::make_shared<Index>() };
@@ -460,45 +500,56 @@ TEST(FindCandidateRegionsForPanNodeTest, noCoverageOnFiveBasesReturnFiveBasesPlu
     std::vector<LocalNodePtr> local_node_max_likelihood_path;
     local_node_max_likelihood_path.reserve(local_node_idxs_for_max_path.size());
 
-    for (const auto &idx : local_node_idxs_for_max_path) {
+    for (const auto& idx : local_node_idxs_for_max_path) {
         local_node_max_likelihood_path.push_back(local_prg_ptr->prg.nodes[idx]);
     }
 
-    const std::vector<int> kmer_node_idxs_for_max_path { 0, 1, 2, 3, 5, 7, 9, 11, 13, 14, 15 };
+    const std::vector<int> kmer_node_idxs_for_max_path { 0, 1, 2, 3, 5, 7, 9, 11, 13,
+        14, 15 };
     std::vector<KmerNodePtr> kmer_node_max_likelihood_path;
     kmer_node_max_likelihood_path.reserve(kmer_node_idxs_for_max_path.size());
 
-    for (const auto &idx : kmer_node_idxs_for_max_path) {
+    for (const auto& idx : kmer_node_idxs_for_max_path) {
         kmer_node_max_likelihood_path.push_back(local_prg_ptr->kmer_prg.nodes[idx]);
     }
 
     const auto num_samples { 1 };
-    PanNodePtr pangraph_node { std::make_shared<pangenome::Node>(local_prg_ptr, local_prg_ptr->id, num_samples) };
+    PanNodePtr pangraph_node { std::make_shared<pangenome::Node>(
+        local_prg_ptr, local_prg_ptr->id, num_samples) };
     const std::vector<int> kmer_node_idxs_for_high_covg { 0, 1, 14, 15 };
 
-    for (const auto &idx : kmer_node_idxs_for_high_covg) {
+    for (const auto& idx : kmer_node_idxs_for_high_covg) {
         pangraph_node->kmer_prg_with_coverage.set_covg(idx, 100, false, 0);
     }
 
-    const TmpPanNode pangraph_node_components { pangraph_node, local_prg_ptr, kmer_node_max_likelihood_path,
-                                                local_node_max_likelihood_path };
+    const TmpPanNode pangraph_node_components { pangraph_node, local_prg_ptr,
+        kmer_node_max_likelihood_path, local_node_max_likelihood_path };
 
     const auto interval_padding { 1 };
-    CandidateRegion expected_candidate { Interval(3, 8), pangraph_node->get_name(), interval_padding };
-    const CandidateRegions expected { std::make_pair(expected_candidate.get_id(), expected_candidate) };
-    const auto actual { find_candidate_regions_for_pan_node(pangraph_node_components, interval_padding) };
-    const auto actual_sequence { actual.at(expected_candidate.get_id()).get_max_likelihood_sequence_with_flanks() };
-    const auto actual_max_likelihood_sequence { actual.at(expected_candidate.get_id()).max_likelihood_sequence };
+    CandidateRegion expected_candidate { Interval(3, 8), pangraph_node->get_name(),
+        interval_padding };
+    const CandidateRegions expected { std::make_pair(
+        expected_candidate.get_id(), expected_candidate) };
+    const auto actual { find_candidate_regions_for_pan_node(
+        pangraph_node_components, interval_padding) };
+    const auto actual_sequence {
+        actual.at(expected_candidate.get_id()).get_max_likelihood_sequence_with_flanks()
+    };
+    const auto actual_max_likelihood_sequence {
+        actual.at(expected_candidate.get_id()).max_likelihood_sequence
+    };
 
     EXPECT_EQ(actual, expected);
     EXPECT_EQ(actual_sequence, expected_sequence);
     EXPECT_EQ(actual_max_likelihood_sequence, expected_max_likelihood_sequence);
 }
 
-
-TEST(FindCandidateRegionsForPanNodeTest, noCoverageOnStartFiveBasesReturnFiveBasesAsCandidate) {
+TEST(FindCandidateRegionsForPanNodeTest,
+    noCoverageOnStartFiveBasesReturnFiveBasesAsCandidate)
+{
     const auto prg_id { 3 };
-    auto local_prg_ptr { std::make_shared<LocalPRG>(prg_id, "test", "AAAA 5 GGG 6 CCC 5 TTTT") };
+    auto local_prg_ptr { std::make_shared<LocalPRG>(
+        prg_id, "test", "AAAA 5 GGG 6 CCC 5 TTTT") };
     const std::string expected_sequence { "AAAAGGGTTTT" };
     const auto expected_max_likelihood_sequence { "AAAAG" };
     auto index { std::make_shared<Index>() };
@@ -510,46 +561,56 @@ TEST(FindCandidateRegionsForPanNodeTest, noCoverageOnStartFiveBasesReturnFiveBas
     std::vector<LocalNodePtr> local_node_max_likelihood_path;
     local_node_max_likelihood_path.reserve(local_node_idxs_for_max_path.size());
 
-    for (const auto &idx : local_node_idxs_for_max_path) {
+    for (const auto& idx : local_node_idxs_for_max_path) {
         local_node_max_likelihood_path.push_back(local_prg_ptr->prg.nodes[idx]);
     }
 
-    const std::vector<int> kmer_node_idxs_for_max_path { 0, 1, 2, 3, 5, 7, 9, 11, 13, 14, 15 };
+    const std::vector<int> kmer_node_idxs_for_max_path { 0, 1, 2, 3, 5, 7, 9, 11, 13,
+        14, 15 };
     std::vector<KmerNodePtr> kmer_node_max_likelihood_path;
     kmer_node_max_likelihood_path.reserve(kmer_node_idxs_for_max_path.size());
 
-    for (const auto &idx : kmer_node_idxs_for_max_path) {
+    for (const auto& idx : kmer_node_idxs_for_max_path) {
         kmer_node_max_likelihood_path.push_back(local_prg_ptr->kmer_prg.nodes[idx]);
     }
 
     const auto num_samples { 1 };
-    PanNodePtr pangraph_node { std::make_shared<pangenome::Node>(local_prg_ptr, local_prg_ptr->id, num_samples) };
+    PanNodePtr pangraph_node { std::make_shared<pangenome::Node>(
+        local_prg_ptr, local_prg_ptr->id, num_samples) };
     const std::vector<int> kmer_node_idxs_for_high_covg { 9, 11, 13, 14, 15 };
 
-    for (const auto &idx : kmer_node_idxs_for_high_covg) {
+    for (const auto& idx : kmer_node_idxs_for_high_covg) {
         pangraph_node->kmer_prg_with_coverage.set_covg(idx, 100, false, 0);
     }
 
-
-    const TmpPanNode pangraph_node_components { pangraph_node, local_prg_ptr, kmer_node_max_likelihood_path,
-                                                local_node_max_likelihood_path };
+    const TmpPanNode pangraph_node_components { pangraph_node, local_prg_ptr,
+        kmer_node_max_likelihood_path, local_node_max_likelihood_path };
 
     const auto interval_padding { 0 };
-    CandidateRegion expected_candidate { Interval(0, 5), pangraph_node->get_name(), interval_padding };
-    const CandidateRegions expected { std::make_pair(expected_candidate.get_id(), expected_candidate) };
-    const auto actual { find_candidate_regions_for_pan_node(pangraph_node_components, interval_padding) };
-    const auto actual_sequence { actual.at(expected_candidate.get_id()).get_max_likelihood_sequence_with_flanks() };
-    const auto actual_max_likelihood_sequence { actual.at(expected_candidate.get_id()).max_likelihood_sequence };
+    CandidateRegion expected_candidate { Interval(0, 5), pangraph_node->get_name(),
+        interval_padding };
+    const CandidateRegions expected { std::make_pair(
+        expected_candidate.get_id(), expected_candidate) };
+    const auto actual { find_candidate_regions_for_pan_node(
+        pangraph_node_components, interval_padding) };
+    const auto actual_sequence {
+        actual.at(expected_candidate.get_id()).get_max_likelihood_sequence_with_flanks()
+    };
+    const auto actual_max_likelihood_sequence {
+        actual.at(expected_candidate.get_id()).max_likelihood_sequence
+    };
 
     EXPECT_EQ(actual, expected);
     EXPECT_EQ(actual_sequence, expected_sequence);
     EXPECT_EQ(actual_max_likelihood_sequence, expected_max_likelihood_sequence);
 }
 
-
-TEST(FindCandidateRegionsForPanNodeTest, noCoverageOnEndFiveBasesReturnFiveBasesAsCandidate) {
+TEST(FindCandidateRegionsForPanNodeTest,
+    noCoverageOnEndFiveBasesReturnFiveBasesAsCandidate)
+{
     const auto prg_id { 3 };
-    auto local_prg_ptr { std::make_shared<LocalPRG>(prg_id, "test", "AAAA 5 GGG 6 CCC 5 TTTT") };
+    auto local_prg_ptr { std::make_shared<LocalPRG>(
+        prg_id, "test", "AAAA 5 GGG 6 CCC 5 TTTT") };
     const std::string expected_sequence { "AAAAGGGTTTT" };
     const auto expected_max_likelihood_sequence { "GTTTT" };
     auto index { std::make_shared<Index>() };
@@ -561,46 +622,56 @@ TEST(FindCandidateRegionsForPanNodeTest, noCoverageOnEndFiveBasesReturnFiveBases
     std::vector<LocalNodePtr> local_node_max_likelihood_path;
     local_node_max_likelihood_path.reserve(local_node_idxs_for_max_path.size());
 
-    for (const auto &idx : local_node_idxs_for_max_path) {
+    for (const auto& idx : local_node_idxs_for_max_path) {
         local_node_max_likelihood_path.push_back(local_prg_ptr->prg.nodes[idx]);
     }
 
-    const std::vector<int> kmer_node_idxs_for_max_path { 0, 1, 2, 3, 5, 7, 9, 11, 13, 14, 15 };
+    const std::vector<int> kmer_node_idxs_for_max_path { 0, 1, 2, 3, 5, 7, 9, 11, 13,
+        14, 15 };
     std::vector<KmerNodePtr> kmer_node_max_likelihood_path;
     kmer_node_max_likelihood_path.reserve(kmer_node_idxs_for_max_path.size());
 
-    for (const auto &idx : kmer_node_idxs_for_max_path) {
+    for (const auto& idx : kmer_node_idxs_for_max_path) {
         kmer_node_max_likelihood_path.push_back(local_prg_ptr->kmer_prg.nodes[idx]);
     }
 
     const auto num_samples { 1 };
-    PanNodePtr pangraph_node { std::make_shared<pangenome::Node>(local_prg_ptr, local_prg_ptr->id, num_samples) };
+    PanNodePtr pangraph_node { std::make_shared<pangenome::Node>(
+        local_prg_ptr, local_prg_ptr->id, num_samples) };
     const std::vector<int> kmer_node_idxs_for_high_covg { 0, 1, 2, 3, 5 };
 
-    for (const auto &idx : kmer_node_idxs_for_high_covg) {
+    for (const auto& idx : kmer_node_idxs_for_high_covg) {
         pangraph_node->kmer_prg_with_coverage.set_covg(idx, 100, false, 0);
     }
 
-    const TmpPanNode pangraph_node_components { pangraph_node, local_prg_ptr, kmer_node_max_likelihood_path,
-                                                local_node_max_likelihood_path };
+    const TmpPanNode pangraph_node_components { pangraph_node, local_prg_ptr,
+        kmer_node_max_likelihood_path, local_node_max_likelihood_path };
 
     const auto interval_padding { 0 };
-    CandidateRegion expected_candidate { Interval(6, 11), pangraph_node->get_name(), interval_padding };
-    const CandidateRegions expected { std::make_pair(expected_candidate.get_id(), expected_candidate) };
-    const auto actual { find_candidate_regions_for_pan_node(pangraph_node_components, interval_padding) };
-    const auto actual_sequence { actual.at(expected_candidate.get_id()).get_max_likelihood_sequence_with_flanks() };
-    const auto actual_max_likelihood_sequence { actual.at(expected_candidate.get_id()).max_likelihood_sequence };
+    CandidateRegion expected_candidate { Interval(6, 11), pangraph_node->get_name(),
+        interval_padding };
+    const CandidateRegions expected { std::make_pair(
+        expected_candidate.get_id(), expected_candidate) };
+    const auto actual { find_candidate_regions_for_pan_node(
+        pangraph_node_components, interval_padding) };
+    const auto actual_sequence {
+        actual.at(expected_candidate.get_id()).get_max_likelihood_sequence_with_flanks()
+    };
+    const auto actual_max_likelihood_sequence {
+        actual.at(expected_candidate.get_id()).max_likelihood_sequence
+    };
 
     EXPECT_EQ(actual, expected);
     EXPECT_EQ(actual_sequence, expected_sequence);
     EXPECT_EQ(actual_max_likelihood_sequence, expected_max_likelihood_sequence);
 }
 
-
 TEST(FindCandidateRegionsForPanNodeTest,
-     noCoverageOnFiveBasesWithinDoubleNestingReturnFiveBasesPlusPaddingAsCandidate) {
+    noCoverageOnFiveBasesWithinDoubleNestingReturnFiveBasesPlusPaddingAsCandidate)
+{
     const auto prg_id { 3 };
-    auto local_prg_ptr { std::make_shared<LocalPRG>(prg_id, "test", "AAAA 5 CCCC 6 GG 7 XXX 8 YYY 7 GG 5 TTTT") };
+    auto local_prg_ptr { std::make_shared<LocalPRG>(
+        prg_id, "test", "AAAA 5 CCCC 6 GG 7 XXX 8 YYY 7 GG 5 TTTT") };
     const std::string expected_sequence { "AAAAGGYYYGGTTTT" };
     const auto expected_max_likelihood_sequence { "GGYYYGG" };
     auto index { std::make_shared<Index>() };
@@ -612,45 +683,56 @@ TEST(FindCandidateRegionsForPanNodeTest,
     std::vector<LocalNodePtr> local_node_max_likelihood_path;
     local_node_max_likelihood_path.reserve(local_node_idxs_for_max_path.size());
 
-    for (const auto &idx : local_node_idxs_for_max_path) {
+    for (const auto& idx : local_node_idxs_for_max_path) {
         local_node_max_likelihood_path.push_back(local_prg_ptr->prg.nodes[idx]);
     }
 
-    const std::vector<int> kmer_node_idxs_for_max_path { 0, 1, 2, 4, 6, 9, 12, 15, 18, 21, 23, 24, 19, 22, 25 };
+    const std::vector<int> kmer_node_idxs_for_max_path { 0, 1, 2, 4, 6, 9, 12, 15, 18,
+        21, 23, 24, 19, 22, 25 };
     std::vector<KmerNodePtr> kmer_node_max_likelihood_path;
     kmer_node_max_likelihood_path.reserve(kmer_node_idxs_for_max_path.size());
 
-    for (const auto &idx : kmer_node_idxs_for_max_path) {
+    for (const auto& idx : kmer_node_idxs_for_max_path) {
         kmer_node_max_likelihood_path.push_back(local_prg_ptr->kmer_prg.nodes[idx]);
     }
 
     const auto num_samples { 1 };
-    PanNodePtr pangraph_node { std::make_shared<pangenome::Node>(local_prg_ptr, local_prg_ptr->id, num_samples) };
+    PanNodePtr pangraph_node { std::make_shared<pangenome::Node>(
+        local_prg_ptr, local_prg_ptr->id, num_samples) };
     const std::vector<int> kmer_node_idxs_for_high_covg { 0, 1, 2, 4, 24, 19, 22, 25 };
 
-    for (const auto &idx : kmer_node_idxs_for_high_covg) {
+    for (const auto& idx : kmer_node_idxs_for_high_covg) {
         pangraph_node->kmer_prg_with_coverage.set_covg(idx, 100, false, 0);
     }
 
-    const TmpPanNode pangraph_node_components { pangraph_node, local_prg_ptr, kmer_node_max_likelihood_path,
-                                                local_node_max_likelihood_path };
+    const TmpPanNode pangraph_node_components { pangraph_node, local_prg_ptr,
+        kmer_node_max_likelihood_path, local_node_max_likelihood_path };
 
     const auto interval_padding { 1 };
-    CandidateRegion expected_candidate { Interval(5, 10), pangraph_node->get_name(), interval_padding };
-    const CandidateRegions expected { std::make_pair(expected_candidate.get_id(), expected_candidate) };
-    const auto actual { find_candidate_regions_for_pan_node(pangraph_node_components, interval_padding) };
-    const auto actual_sequence { actual.at(expected_candidate.get_id()).get_max_likelihood_sequence_with_flanks() };
-    const auto actual_max_likelihood_sequence { actual.at(expected_candidate.get_id()).max_likelihood_sequence };
+    CandidateRegion expected_candidate { Interval(5, 10), pangraph_node->get_name(),
+        interval_padding };
+    const CandidateRegions expected { std::make_pair(
+        expected_candidate.get_id(), expected_candidate) };
+    const auto actual { find_candidate_regions_for_pan_node(
+        pangraph_node_components, interval_padding) };
+    const auto actual_sequence {
+        actual.at(expected_candidate.get_id()).get_max_likelihood_sequence_with_flanks()
+    };
+    const auto actual_max_likelihood_sequence {
+        actual.at(expected_candidate.get_id()).max_likelihood_sequence
+    };
 
     EXPECT_EQ(actual, expected);
     EXPECT_EQ(actual_sequence, expected_sequence);
     EXPECT_EQ(actual_max_likelihood_sequence, expected_max_likelihood_sequence);
 }
 
-
-TEST(FindCandidateRegionsForPanNodeTest, noCoverageOnTwoFiveBaseRegionsWithinDoubleNestingReturnTwoRegionsAsCandidate) {
+TEST(FindCandidateRegionsForPanNodeTest,
+    noCoverageOnTwoFiveBaseRegionsWithinDoubleNestingReturnTwoRegionsAsCandidate)
+{
     const auto prg_id { 3 };
-    auto local_prg_ptr { std::make_shared<LocalPRG>(prg_id, "test", "AAAA 5 CCCC 6 GG 7 XXX 8 YYY 7 GG 5 TTTTT") };
+    auto local_prg_ptr { std::make_shared<LocalPRG>(
+        prg_id, "test", "AAAA 5 CCCC 6 GG 7 XXX 8 YYY 7 GG 5 TTTTT") };
     const std::string expected_sequence { "AAAAGGYYYGGTTTTT" };
     std::vector<std::string> expected_max_likelihood_sequences { "AAAAG", "YGGTT" };
     auto index { std::make_shared<Index>() };
@@ -662,63 +744,74 @@ TEST(FindCandidateRegionsForPanNodeTest, noCoverageOnTwoFiveBaseRegionsWithinDou
     std::vector<LocalNodePtr> local_node_max_likelihood_path;
     local_node_max_likelihood_path.reserve(local_node_idxs_for_max_path.size());
 
-    for (const auto &idx : local_node_idxs_for_max_path) {
+    for (const auto& idx : local_node_idxs_for_max_path) {
         local_node_max_likelihood_path.push_back(local_prg_ptr->prg.nodes[idx]);
     }
 
-    const std::vector<int> kmer_node_idxs_for_max_path { 0, 1, 2, 4, 6, 9, 12, 15, 18, 21, 23, 25, 19, 22, 24, 26 };
+    const std::vector<int> kmer_node_idxs_for_max_path { 0, 1, 2, 4, 6, 9, 12, 15, 18,
+        21, 23, 25, 19, 22, 24, 26 };
     std::vector<KmerNodePtr> kmer_node_max_likelihood_path;
     kmer_node_max_likelihood_path.reserve(kmer_node_idxs_for_max_path.size());
 
-    for (const auto &idx : kmer_node_idxs_for_max_path) {
+    for (const auto& idx : kmer_node_idxs_for_max_path) {
         kmer_node_max_likelihood_path.push_back(local_prg_ptr->kmer_prg.nodes[idx]);
     }
 
     const auto num_samples { 1 };
-    PanNodePtr pangraph_node { std::make_shared<pangenome::Node>(local_prg_ptr, local_prg_ptr->id, num_samples) };
+    PanNodePtr pangraph_node { std::make_shared<pangenome::Node>(
+        local_prg_ptr, local_prg_ptr->id, num_samples) };
     const std::vector<int> kmer_node_idxs_for_high_covg { 12, 24, 26 };
 
-    for (const auto &idx : kmer_node_idxs_for_high_covg) {
+    for (const auto& idx : kmer_node_idxs_for_high_covg) {
         pangraph_node->kmer_prg_with_coverage.set_covg(idx, 100, false, 0);
     }
 
-    const TmpPanNode pangraph_node_components { pangraph_node, local_prg_ptr, kmer_node_max_likelihood_path,
-                                                local_node_max_likelihood_path };
+    const TmpPanNode pangraph_node_components { pangraph_node, local_prg_ptr,
+        kmer_node_max_likelihood_path, local_node_max_likelihood_path };
 
     const auto interval_padding { 0 };
-    CandidateRegion expected_candidate1 { Interval(0, 5), pangraph_node->get_name(), interval_padding };
-    CandidateRegion expected_candidate2 { Interval(8, 13), pangraph_node->get_name(), interval_padding };
-    const CandidateRegions expected { std::make_pair(expected_candidate1.get_id(), expected_candidate1),
-                                      std::make_pair(expected_candidate2.get_id(), expected_candidate2) };
-    const auto actual { find_candidate_regions_for_pan_node(pangraph_node_components, interval_padding) };
+    CandidateRegion expected_candidate1 { Interval(0, 5), pangraph_node->get_name(),
+        interval_padding };
+    CandidateRegion expected_candidate2 { Interval(8, 13), pangraph_node->get_name(),
+        interval_padding };
+    const CandidateRegions expected { std::make_pair(expected_candidate1.get_id(),
+                                          expected_candidate1),
+        std::make_pair(expected_candidate2.get_id(), expected_candidate2) };
+    const auto actual { find_candidate_regions_for_pan_node(
+        pangraph_node_components, interval_padding) };
 
     EXPECT_EQ(actual, expected);
     std::vector<std::string> actual_max_likelihood_sequences;
     actual_max_likelihood_sequences.reserve(2);
-    for (const auto &actual_candidate : actual) {
-        EXPECT_EQ(actual_candidate.second.get_max_likelihood_sequence_with_flanks(), expected_sequence);
-        actual_max_likelihood_sequences.push_back(actual_candidate.second.max_likelihood_sequence);
+    for (const auto& actual_candidate : actual) {
+        EXPECT_EQ(actual_candidate.second.get_max_likelihood_sequence_with_flanks(),
+            expected_sequence);
+        actual_max_likelihood_sequences.push_back(
+            actual_candidate.second.max_likelihood_sequence);
     }
-    std::sort(actual_max_likelihood_sequences.begin(), actual_max_likelihood_sequences.end());
-    std::sort(expected_max_likelihood_sequences.begin(), expected_max_likelihood_sequences.end());
+    std::sort(
+        actual_max_likelihood_sequences.begin(), actual_max_likelihood_sequences.end());
+    std::sort(expected_max_likelihood_sequences.begin(),
+        expected_max_likelihood_sequences.end());
     EXPECT_EQ(actual_max_likelihood_sequences, expected_max_likelihood_sequences);
 }
 
-TEST(AddPileupEntryForCandidateRegionTest, emptyReadWithReadCoordsPileupsEmpty) {
+TEST(AddPileupEntryForCandidateRegionTest, emptyReadWithReadCoordsPileupsEmpty)
+{
     const auto read_sequence { "" };
     CandidateRegion candidate { Interval(1, 3), "test" };
     ReadCoordinate read_coord_1 { 0, 6, 10, true };
 
     candidate.read_coordinates.insert(read_coord_1);
     candidate.add_pileup_entry(read_sequence, read_coord_1);
-    const auto &actual { candidate.pileup };
+    const auto& actual { candidate.pileup };
     const ReadPileup expected;
 
     EXPECT_EQ(actual, expected);
 }
 
-
-TEST(AddPileupEntryForCandidateRegionTest, oneReadOneReadCoordPileupHasOneEntry) {
+TEST(AddPileupEntryForCandidateRegionTest, oneReadOneReadCoordPileupHasOneEntry)
+{
     const std::string read_sequence { "XXXFOOXXX" };
     CandidateRegion candidate { Interval(0, 3), "test" };
     ReadCoordinate read_coord { 0, 3, 6, true }; // FOO
@@ -726,14 +819,15 @@ TEST(AddPileupEntryForCandidateRegionTest, oneReadOneReadCoordPileupHasOneEntry)
 
     candidate.add_pileup_entry(read_sequence, read_coord);
 
-    const auto &actual { candidate.pileup };
+    const auto& actual { candidate.pileup };
     const ReadPileup expected { "FOO" };
 
     EXPECT_EQ(actual, expected);
 }
 
-
-TEST(AddPileupEntryForCandidateRegionTest, oneReadOneWholeReadCoordPileupHasOneEntrySameAsRead) {
+TEST(AddPileupEntryForCandidateRegionTest,
+    oneReadOneWholeReadCoordPileupHasOneEntrySameAsRead)
+{
     const std::string read_sequence { "XXXFOOXXX" };
     CandidateRegion candidate { Interval(0, 3), "test" };
     ReadCoordinate read_coord { 0, 0, 10, true }; // XXXFOOXXX
@@ -741,15 +835,15 @@ TEST(AddPileupEntryForCandidateRegionTest, oneReadOneWholeReadCoordPileupHasOneE
 
     candidate.add_pileup_entry(read_sequence, read_coord);
 
-    const auto &actual { candidate.pileup };
+    const auto& actual { candidate.pileup };
     const ReadPileup expected { "XXXFOOXXX" };
 
     EXPECT_EQ(actual, expected);
 }
 
-
 TEST(AddPileupEntryForCandidateRegionTest,
-     oneReadOneReadCoordThatRunsPastEndOfReadPileupHasOneEntryUpToEndOfRead) {
+    oneReadOneReadCoordThatRunsPastEndOfReadPileupHasOneEntryUpToEndOfRead)
+{
     const std::string read_sequence { "XXXFOOXXX" };
 
     CandidateRegion candidate { Interval(0, 3), "test" };
@@ -758,15 +852,15 @@ TEST(AddPileupEntryForCandidateRegionTest,
 
     candidate.add_pileup_entry(read_sequence, read_coord);
 
-    const auto &actual { candidate.pileup };
+    const auto& actual { candidate.pileup };
     const ReadPileup expected { "OXXX" };
 
     EXPECT_EQ(actual, expected);
 }
 
-
 TEST(AddPileupEntryForCandidateRegionTest,
-     oneReadOneReverseReadCoordThatRunsPastEndOfReadPileupHasOneEntryUpToEndOfRead) {
+    oneReadOneReverseReadCoordThatRunsPastEndOfReadPileupHasOneEntryUpToEndOfRead)
+{
     const std::string read_sequence { "AATTCCGG" };
 
     CandidateRegion candidate { Interval(0, 3), "test" };
@@ -775,14 +869,14 @@ TEST(AddPileupEntryForCandidateRegionTest,
 
     candidate.add_pileup_entry(read_sequence, read_coord);
 
-    const auto &actual { candidate.pileup };
+    const auto& actual { candidate.pileup };
     const ReadPileup expected { "CCG" };
 
     EXPECT_EQ(actual, expected);
 }
 
-
-TEST(AddPileupEntryForCandidateRegionTest, oneReadOneReadCoordOutsideReadPileupEmpty) {
+TEST(AddPileupEntryForCandidateRegionTest, oneReadOneReadCoordOutsideReadPileupEmpty)
+{
 
     const std::string read_sequence { "XXXFOOXXX" };
 
@@ -792,14 +886,14 @@ TEST(AddPileupEntryForCandidateRegionTest, oneReadOneReadCoordOutsideReadPileupE
 
     candidate.add_pileup_entry(read_sequence, read_coord);
 
-    const auto &actual { candidate.pileup };
+    const auto& actual { candidate.pileup };
     const ReadPileup expected;
 
     EXPECT_EQ(actual, expected);
 }
 
-
-TEST(LoadAllCandidateRegionsPileupsFromFastq, emptyCandidateRegionReturnsEmptyPileup) {
+TEST(LoadAllCandidateRegionsPileupsFromFastq, emptyCandidateRegionReturnsEmptyPileup)
+{
     Fastaq temp_fastq { false, true };
     auto read_name { "0" };
     std::string read_sequence { "AATTCCGG" };
@@ -814,7 +908,8 @@ TEST(LoadAllCandidateRegionsPileupsFromFastq, emptyCandidateRegionReturnsEmptyPi
 
     CandidateRegions candidate_regions;
     auto pileup_construction_map = construct_pileup_construction_map(candidate_regions);
-    load_all_candidate_regions_pileups_from_fastq(temp_reads_filepath, candidate_regions, pileup_construction_map);
+    load_all_candidate_regions_pileups_from_fastq(
+        temp_reads_filepath, candidate_regions, pileup_construction_map);
 
     const auto temp_removed_successfully { fs::remove(temp_reads_filepath) };
     ASSERT_TRUE(temp_removed_successfully);
@@ -822,7 +917,9 @@ TEST(LoadAllCandidateRegionsPileupsFromFastq, emptyCandidateRegionReturnsEmptyPi
     EXPECT_TRUE(candidate_regions.empty());
 }
 
-TEST(AddPileupEntryForCandidateRegionTest, oneCandidateZeroReadsInFilePileupHasZeroEntries) {
+TEST(AddPileupEntryForCandidateRegionTest,
+    oneCandidateZeroReadsInFilePileupHasZeroEntries)
+{
 
     Fastaq temp_fastq { false, true };
     const fs::path temp_reads_filepath { fs::unique_path() };
@@ -834,20 +931,24 @@ TEST(AddPileupEntryForCandidateRegionTest, oneCandidateZeroReadsInFilePileupHasZ
     candidate.read_coordinates.insert(read_coord1);
     candidate.read_coordinates.insert(read_coord2);
 
-    CandidateRegions candidate_regions { std::make_pair(candidate.get_id(), candidate) };
+    CandidateRegions candidate_regions { std::make_pair(
+        candidate.get_id(), candidate) };
     auto pileup_construction_map = construct_pileup_construction_map(candidate_regions);
-    load_all_candidate_regions_pileups_from_fastq(temp_reads_filepath, candidate_regions, pileup_construction_map);
+    load_all_candidate_regions_pileups_from_fastq(
+        temp_reads_filepath, candidate_regions, pileup_construction_map);
 
     const auto temp_removed_successfully { fs::remove(temp_reads_filepath) };
     ASSERT_TRUE(temp_removed_successfully);
 
-    const auto &actual { candidate_regions.at(candidate.get_id()).pileup };
+    const auto& actual { candidate_regions.at(candidate.get_id()).pileup };
     const ReadPileup expected {};
 
     EXPECT_EQ(actual, expected);
 }
 
-TEST(AddPileupEntryForCandidateRegionTest, oneCandidateTwoReadsInFileOneReadInCandidatePileupHasOneEntry) {
+TEST(AddPileupEntryForCandidateRegionTest,
+    oneCandidateTwoReadsInFileOneReadInCandidatePileupHasOneEntry)
+{
 
     Fastaq temp_fastq { false, true };
     auto read_name { "0" };
@@ -867,20 +968,24 @@ TEST(AddPileupEntryForCandidateRegionTest, oneCandidateTwoReadsInFileOneReadInCa
     candidate.read_coordinates.insert(read_coord1);
     candidate.read_coordinates.insert(read_coord2);
 
-    CandidateRegions candidate_regions { std::make_pair(candidate.get_id(), candidate) };
+    CandidateRegions candidate_regions { std::make_pair(
+        candidate.get_id(), candidate) };
     auto pileup_construction_map = construct_pileup_construction_map(candidate_regions);
-    load_all_candidate_regions_pileups_from_fastq(temp_reads_filepath, candidate_regions, pileup_construction_map);
+    load_all_candidate_regions_pileups_from_fastq(
+        temp_reads_filepath, candidate_regions, pileup_construction_map);
 
     const auto temp_removed_successfully { fs::remove(temp_reads_filepath) };
     ASSERT_TRUE(temp_removed_successfully);
 
-    const auto &actual { candidate_regions.at(candidate.get_id()).pileup };
+    const auto& actual { candidate_regions.at(candidate.get_id()).pileup };
     const ReadPileup expected { "TT" };
 
     EXPECT_EQ(actual, expected);
 }
 
-TEST(AddPileupEntryForCandidateRegionTest, oneCandidateTwoReadsInFileTwoReadsInCandidatePileupHasTwoEntries) {
+TEST(AddPileupEntryForCandidateRegionTest,
+    oneCandidateTwoReadsInFileTwoReadsInCandidatePileupHasTwoEntries)
+{
 
     Fastaq temp_fastq { false, true };
     auto read_name { "0" };
@@ -900,20 +1005,24 @@ TEST(AddPileupEntryForCandidateRegionTest, oneCandidateTwoReadsInFileTwoReadsInC
     candidate.read_coordinates.insert(read_coord1);
     candidate.read_coordinates.insert(read_coord2);
 
-    CandidateRegions candidate_regions { std::make_pair(candidate.get_id(), candidate) };
+    CandidateRegions candidate_regions { std::make_pair(
+        candidate.get_id(), candidate) };
     auto pileup_construction_map = construct_pileup_construction_map(candidate_regions);
-    load_all_candidate_regions_pileups_from_fastq(temp_reads_filepath, candidate_regions, pileup_construction_map);
+    load_all_candidate_regions_pileups_from_fastq(
+        temp_reads_filepath, candidate_regions, pileup_construction_map);
 
     const auto temp_removed_successfully { fs::remove(temp_reads_filepath) };
     ASSERT_TRUE(temp_removed_successfully);
 
-    const auto &actual { candidate_regions.at(candidate.get_id()).pileup };
+    const auto& actual { candidate_regions.at(candidate.get_id()).pileup };
     const ReadPileup expected { "TT", "GTA" };
 
     EXPECT_EQ(actual, expected);
 }
 
-TEST(AddPileupEntryForCandidateRegionTest, twoCandidatesZeroReadsInFilePileupHasZeroEntries) {
+TEST(AddPileupEntryForCandidateRegionTest,
+    twoCandidatesZeroReadsInFilePileupHasZeroEntries)
+{
 
     Fastaq temp_fastq { false, true };
     const fs::path temp_reads_filepath { fs::unique_path() };
@@ -931,23 +1040,27 @@ TEST(AddPileupEntryForCandidateRegionTest, twoCandidatesZeroReadsInFilePileupHas
     candidate_2.read_coordinates.insert(read_coord3);
     candidate_2.read_coordinates.insert(read_coord4);
 
-    CandidateRegions candidate_regions { std::make_pair(candidate_1.get_id(), candidate_1),
-                                         std::make_pair(candidate_2.get_id(), candidate_2) };
+    CandidateRegions candidate_regions { std::make_pair(
+                                             candidate_1.get_id(), candidate_1),
+        std::make_pair(candidate_2.get_id(), candidate_2) };
     auto pileup_construction_map = construct_pileup_construction_map(candidate_regions);
-    load_all_candidate_regions_pileups_from_fastq(temp_reads_filepath, candidate_regions, pileup_construction_map);
+    load_all_candidate_regions_pileups_from_fastq(
+        temp_reads_filepath, candidate_regions, pileup_construction_map);
 
     const auto temp_removed_successfully { fs::remove(temp_reads_filepath) };
     ASSERT_TRUE(temp_removed_successfully);
 
-    const auto &actual_1 { candidate_regions.at(candidate_1.get_id()).pileup };
-    const auto &actual_2 { candidate_regions.at(candidate_2.get_id()).pileup };
+    const auto& actual_1 { candidate_regions.at(candidate_1.get_id()).pileup };
+    const auto& actual_2 { candidate_regions.at(candidate_2.get_id()).pileup };
     const ReadPileup expected {};
 
     EXPECT_EQ(actual_1, expected);
     EXPECT_EQ(actual_2, expected);
 }
 
-TEST(AddPileupEntryForCandidateRegionTest, twoCandidatesTwoReadsInFileOneReadInOneCandidatePileupHasOneEntryInOneCandidate) {
+TEST(AddPileupEntryForCandidateRegionTest,
+    twoCandidatesTwoReadsInFileOneReadInOneCandidatePileupHasOneEntryInOneCandidate)
+{
 
     Fastaq temp_fastq { false, true };
     auto read_name { "0" };
@@ -969,25 +1082,28 @@ TEST(AddPileupEntryForCandidateRegionTest, twoCandidatesTwoReadsInFileOneReadInO
     ReadCoordinate read_coord2 { 4, 3, 6, false };
     candidate_2.read_coordinates.insert(read_coord2);
 
-    CandidateRegions candidate_regions { std::make_pair(candidate_1.get_id(), candidate_1),
-                                         std::make_pair(candidate_2.get_id(), candidate_2) };
+    CandidateRegions candidate_regions { std::make_pair(
+                                             candidate_1.get_id(), candidate_1),
+        std::make_pair(candidate_2.get_id(), candidate_2) };
     auto pileup_construction_map = construct_pileup_construction_map(candidate_regions);
-    load_all_candidate_regions_pileups_from_fastq(temp_reads_filepath, candidate_regions, pileup_construction_map);
+    load_all_candidate_regions_pileups_from_fastq(
+        temp_reads_filepath, candidate_regions, pileup_construction_map);
 
     const auto temp_removed_successfully { fs::remove(temp_reads_filepath) };
     ASSERT_TRUE(temp_removed_successfully);
 
-    const auto &actual_1 { candidate_regions.at(candidate_1.get_id()).pileup };
-    const auto &actual_2 { candidate_regions.at(candidate_2.get_id()).pileup };
-    const ReadPileup expected_1 {"TT"};
+    const auto& actual_1 { candidate_regions.at(candidate_1.get_id()).pileup };
+    const auto& actual_2 { candidate_regions.at(candidate_2.get_id()).pileup };
+    const ReadPileup expected_1 { "TT" };
     const ReadPileup expected_2 {};
 
     EXPECT_EQ(actual_1, expected_1);
     EXPECT_EQ(actual_2, expected_2);
 }
 
-
-TEST(AddPileupEntryForCandidateRegionTest, twoCandidatesTwoReadsInFileOneReadInEachCandidatePileupHasOneEntryInEachCandidate) {
+TEST(AddPileupEntryForCandidateRegionTest,
+    twoCandidatesTwoReadsInFileOneReadInEachCandidatePileupHasOneEntryInEachCandidate)
+{
 
     Fastaq temp_fastq { false, true };
     auto read_name { "0" };
@@ -1002,23 +1118,25 @@ TEST(AddPileupEntryForCandidateRegionTest, twoCandidatesTwoReadsInFileOneReadInE
     temp_fastq.save(temp_reads_filepath.string());
 
     CandidateRegion candidate_1 { Interval(0, 3), "test" };
-    ReadCoordinate read_coord1 { 0, 2, 4, true }; //TT
+    ReadCoordinate read_coord1 { 0, 2, 4, true }; // TT
     candidate_1.read_coordinates.insert(read_coord1);
 
     CandidateRegion candidate_2 { Interval(0, 3), "test2" };
     ReadCoordinate read_coord2 { 1, 3, 6, true }; // TAC
     candidate_2.read_coordinates.insert(read_coord2);
 
-    CandidateRegions candidate_regions { std::make_pair(candidate_1.get_id(), candidate_1),
-                                         std::make_pair(candidate_2.get_id(), candidate_2) };
+    CandidateRegions candidate_regions { std::make_pair(
+                                             candidate_1.get_id(), candidate_1),
+        std::make_pair(candidate_2.get_id(), candidate_2) };
     auto pileup_construction_map = construct_pileup_construction_map(candidate_regions);
-    load_all_candidate_regions_pileups_from_fastq(temp_reads_filepath, candidate_regions, pileup_construction_map);
+    load_all_candidate_regions_pileups_from_fastq(
+        temp_reads_filepath, candidate_regions, pileup_construction_map);
 
     const auto temp_removed_successfully { fs::remove(temp_reads_filepath) };
     ASSERT_TRUE(temp_removed_successfully);
 
-    const auto &actual_1 { candidate_regions.at(candidate_1.get_id()).pileup };
-    const auto &actual_2 { candidate_regions.at(candidate_2.get_id()).pileup };
+    const auto& actual_1 { candidate_regions.at(candidate_1.get_id()).pileup };
+    const auto& actual_2 { candidate_regions.at(candidate_2.get_id()).pileup };
     const ReadPileup expected_1 { "TT" };
     const ReadPileup expected_2 { "TAC" };
 
@@ -1026,7 +1144,9 @@ TEST(AddPileupEntryForCandidateRegionTest, twoCandidatesTwoReadsInFileOneReadInE
     EXPECT_EQ(actual_2, expected_2);
 }
 
-TEST(AddPileupEntryForCandidateRegionTest, twoCandidatesTwoReadsInFileOneReadInEachCandidatePileupHasOneEntryInEachCandidateUsingFourThreads) {
+TEST(AddPileupEntryForCandidateRegionTest,
+    twoCandidatesTwoReadsInFileOneReadInEachCandidatePileupHasOneEntryInEachCandidateUsingFourThreads)
+{
 
     const uint32_t threads = 4;
     Fastaq temp_fastq { false, true };
@@ -1034,36 +1154,37 @@ TEST(AddPileupEntryForCandidateRegionTest, twoCandidatesTwoReadsInFileOneReadInE
     std::string read_sequence { "AATTCCGG" };
     const auto global_covg { 2 };
     const std::vector<uint32_t> read_covg(read_sequence.length(), global_covg);
-    for (uint32_t i=0; i < threads/2*1000; ++i) {
+    for (uint32_t i = 0; i < threads / 2 * 1000; ++i) {
         temp_fastq.add_entry(read_name, read_sequence, read_covg, global_covg);
     }
     read_name = "1";
     read_sequence = "GATTACAA";
-    for (uint32_t i=0; i < threads/2*1000; ++i) {
+    for (uint32_t i = 0; i < threads / 2 * 1000; ++i) {
         temp_fastq.add_entry(read_name, read_sequence, read_covg, global_covg);
     }
     const fs::path temp_reads_filepath { fs::unique_path() };
     temp_fastq.save(temp_reads_filepath.string());
 
-
     CandidateRegion candidate_1 { Interval(0, 3), "test" };
-    ReadCoordinate read_coord1 { 0, 2, 4, true }; //TT
+    ReadCoordinate read_coord1 { 0, 2, 4, true }; // TT
     candidate_1.read_coordinates.insert(read_coord1);
 
     CandidateRegion candidate_2 { Interval(0, 3), "test2" };
     ReadCoordinate read_coord2 { 3000, 3, 6, true }; // TAC
     candidate_2.read_coordinates.insert(read_coord2);
 
-    CandidateRegions candidate_regions { std::make_pair(candidate_1.get_id(), candidate_1),
-                                         std::make_pair(candidate_2.get_id(), candidate_2) };
+    CandidateRegions candidate_regions { std::make_pair(
+                                             candidate_1.get_id(), candidate_1),
+        std::make_pair(candidate_2.get_id(), candidate_2) };
     auto pileup_construction_map = construct_pileup_construction_map(candidate_regions);
-    load_all_candidate_regions_pileups_from_fastq(temp_reads_filepath, candidate_regions, pileup_construction_map, threads);
+    load_all_candidate_regions_pileups_from_fastq(
+        temp_reads_filepath, candidate_regions, pileup_construction_map, threads);
 
     const auto temp_removed_successfully { fs::remove(temp_reads_filepath) };
     ASSERT_TRUE(temp_removed_successfully);
 
-    const auto &actual_1 { candidate_regions.at(candidate_1.get_id()).pileup };
-    const auto &actual_2 { candidate_regions.at(candidate_2.get_id()).pileup };
+    const auto& actual_1 { candidate_regions.at(candidate_1.get_id()).pileup };
+    const auto& actual_2 { candidate_regions.at(candidate_2.get_id()).pileup };
     const ReadPileup expected_1 { "TT" };
     const ReadPileup expected_2 { "TAC" };
 
@@ -1071,16 +1192,16 @@ TEST(AddPileupEntryForCandidateRegionTest, twoCandidatesTwoReadsInFileOneReadInE
     EXPECT_EQ(actual_2, expected_2);
 }
 
-
-std::string read_file_to_string(const fs::path &filepath) {
+std::string read_file_to_string(const fs::path& filepath)
+{
     fs::ifstream f(filepath);
     std::stringstream buffer;
     buffer << f.rdbuf();
     return buffer.str();
 }
 
-
-TEST(WriteDenovoPathsToFileTest, noReadsDoesntWriteFile) {
+TEST(WriteDenovoPathsToFileTest, noReadsDoesntWriteFile)
+{
     const std::string name { "test" };
     CandidateRegion candidate { Interval(0, 1), name };
     const fs::path output_directory { "/tmp" };
@@ -1091,8 +1212,8 @@ TEST(WriteDenovoPathsToFileTest, noReadsDoesntWriteFile) {
     EXPECT_FALSE(fs::exists(filepath));
 }
 
-
-TEST(WriteDenovoPathsToFileTest, twoReadsWritesTwoReadsToFile) {
+TEST(WriteDenovoPathsToFileTest, twoReadsWritesTwoReadsToFile)
+{
     const std::string name { "test" };
     CandidateRegion candidate { Interval(0, 1), name };
     const fs::path output_directory { "/tmp" };
@@ -1105,7 +1226,8 @@ TEST(WriteDenovoPathsToFileTest, twoReadsWritesTwoReadsToFile) {
     std::stringstream expected_ss;
 
     for (size_t i = 0; i < paths.size(); ++i) {
-        expected_ss << ">test." << std::to_string(i) << std::endl << paths.at(i) << std::endl;
+        expected_ss << ">test." << std::to_string(i) << std::endl
+                    << paths.at(i) << std::endl;
     }
 
     const std::string expected { expected_ss.str() };
@@ -1116,19 +1238,20 @@ TEST(WriteDenovoPathsToFileTest, twoReadsWritesTwoReadsToFile) {
     EXPECT_EQ(actual, expected);
 }
 
-TEST(ConstructPileupConstructionMapTest, emptyInEmptyOut) {
+TEST(ConstructPileupConstructionMapTest, emptyInEmptyOut)
+{
     CandidateRegions empty_candidate_regions;
     const auto actual { construct_pileup_construction_map(empty_candidate_regions) };
     PileupConstructionMap expected;
     EXPECT_EQ(actual, expected);
 }
 
-
-void compare_maps(const PileupConstructionMap &map1, const PileupConstructionMap &map2) {
+void compare_maps(const PileupConstructionMap& map1, const PileupConstructionMap& map2)
+{
     std::vector<ReadId> keys1, keys2;
-    for (const auto &item : map1)
+    for (const auto& item : map1)
         keys1.push_back(item.first);
-    for (const auto &item : map2)
+    for (const auto& item : map2)
         keys2.push_back(item.first);
 
     EXPECT_EQ(keys1, keys2);
@@ -1137,24 +1260,26 @@ void compare_maps(const PileupConstructionMap &map1, const PileupConstructionMap
         auto vector1 = map1.at(key);
         auto vector2 = map2.at(key);
 
-        //TODO: find the correct way to compare a vector of pair of pointers with google test
-        //TODO: or even better: compare the maps themselves
+        // TODO: find the correct way to compare a vector of pair of pointers with
+        // google test
+        // TODO: or even better: compare the maps themselves
         EXPECT_TRUE(vector1.size() == vector2.size());
-        EXPECT_TRUE(std::is_permutation(vector1.begin(), vector1.end(), vector2.begin(), [](const std::pair<CandidateRegion *, const ReadCoordinate *> &pair1,
-                                                        const std::pair<CandidateRegion *, const ReadCoordinate *> &pair2) {
-            return *pair1.first == *pair2.first && *pair1.second == *pair2.second;
-        }));
-
+        EXPECT_TRUE(std::is_permutation(vector1.begin(), vector1.end(), vector2.begin(),
+            [](const std::pair<CandidateRegion*, const ReadCoordinate*>& pair1,
+                const std::pair<CandidateRegion*, const ReadCoordinate*>& pair2) {
+                return *pair1.first == *pair2.first && *pair1.second == *pair2.second;
+            }));
     }
 }
 
-
-TEST(ConstructPileupConstructionMapTest, oneCandidateRegionOneReadCoordinate) {
+TEST(ConstructPileupConstructionMapTest, oneCandidateRegionOneReadCoordinate)
+{
     CandidateRegion candidate { Interval(0, 3), "test" };
     const uint32_t read_id = 0;
     ReadCoordinate read_coord { read_id, 5, 20, true };
     candidate.read_coordinates.insert(read_coord);
-    CandidateRegions candidate_regions { std::make_pair(candidate.get_id(), candidate) };
+    CandidateRegions candidate_regions { std::make_pair(
+        candidate.get_id(), candidate) };
 
     const auto actual { construct_pileup_construction_map(candidate_regions) };
     PileupConstructionMap expected;
@@ -1162,14 +1287,16 @@ TEST(ConstructPileupConstructionMapTest, oneCandidateRegionOneReadCoordinate) {
     compare_maps(actual, expected);
 }
 
-TEST(ConstructPileupConstructionMapTest, oneCandidateRegionTwoReadCoordinatesSameReadId) {
+TEST(ConstructPileupConstructionMapTest, oneCandidateRegionTwoReadCoordinatesSameReadId)
+{
     CandidateRegion candidate { Interval(0, 3), "test" };
     const uint32_t read_id = 0;
     ReadCoordinate read_coord_1 { read_id, 5, 20, true };
     candidate.read_coordinates.insert(read_coord_1);
     ReadCoordinate read_coord_2 { read_id, 50, 100, true };
     candidate.read_coordinates.insert(read_coord_2);
-    CandidateRegions candidate_regions { std::make_pair(candidate.get_id(), candidate) };
+    CandidateRegions candidate_regions { std::make_pair(
+        candidate.get_id(), candidate) };
 
     const auto actual { construct_pileup_construction_map(candidate_regions) };
     PileupConstructionMap expected;
@@ -1179,8 +1306,9 @@ TEST(ConstructPileupConstructionMapTest, oneCandidateRegionTwoReadCoordinatesSam
     compare_maps(actual, expected);
 }
 
-
-TEST(ConstructPileupConstructionMapTest, oneCandidateRegionTwoReadCoordinatesDifferentReadId) {
+TEST(ConstructPileupConstructionMapTest,
+    oneCandidateRegionTwoReadCoordinatesDifferentReadId)
+{
     CandidateRegion candidate { Interval(0, 3), "test" };
     const uint32_t read_id_1 = 0;
     ReadCoordinate read_coord_1 { read_id_1, 5, 20, true };
@@ -1188,7 +1316,8 @@ TEST(ConstructPileupConstructionMapTest, oneCandidateRegionTwoReadCoordinatesDif
     const uint32_t read_id_2 = 2;
     ReadCoordinate read_coord_2 { read_id_2, 50, 100, true };
     candidate.read_coordinates.insert(read_coord_2);
-    CandidateRegions candidate_regions { std::make_pair(candidate.get_id(), candidate) };
+    CandidateRegions candidate_regions { std::make_pair(
+        candidate.get_id(), candidate) };
 
     const auto actual { construct_pileup_construction_map(candidate_regions) };
     PileupConstructionMap expected;
@@ -1198,7 +1327,9 @@ TEST(ConstructPileupConstructionMapTest, oneCandidateRegionTwoReadCoordinatesDif
     compare_maps(actual, expected);
 }
 
-TEST(ConstructPileupConstructionMapTest, twoCandidateRegionsOneReadCoordinateEachDifferentReadId) {
+TEST(ConstructPileupConstructionMapTest,
+    twoCandidateRegionsOneReadCoordinateEachDifferentReadId)
+{
     CandidateRegion candidate_1 { Interval(0, 3), "test" };
     const uint32_t read_id_1 = 0;
     ReadCoordinate read_coord_1 { read_id_1, 5, 20, true };
@@ -1207,7 +1338,9 @@ TEST(ConstructPileupConstructionMapTest, twoCandidateRegionsOneReadCoordinateEac
     const uint32_t read_id_2 = 2;
     ReadCoordinate read_coord_2 { read_id_2, 50, 100, true };
     candidate_2.read_coordinates.insert(read_coord_2);
-    CandidateRegions candidate_regions { std::make_pair(candidate_1.get_id(), candidate_1), std::make_pair(candidate_2.get_id(), candidate_2) };
+    CandidateRegions candidate_regions { std::make_pair(
+                                             candidate_1.get_id(), candidate_1),
+        std::make_pair(candidate_2.get_id(), candidate_2) };
 
     const auto actual { construct_pileup_construction_map(candidate_regions) };
     PileupConstructionMap expected;
@@ -1217,7 +1350,9 @@ TEST(ConstructPileupConstructionMapTest, twoCandidateRegionsOneReadCoordinateEac
     compare_maps(actual, expected);
 }
 
-TEST(ConstructPileupConstructionMapTest, twoCandidateRegionsOneReadCoordinateEachSameReadId) {
+TEST(ConstructPileupConstructionMapTest,
+    twoCandidateRegionsOneReadCoordinateEachSameReadId)
+{
     CandidateRegion candidate_1 { Interval(0, 3), "test" };
     const uint32_t read_id = 0;
     ReadCoordinate read_coord_1 { read_id, 5, 20, true };
@@ -1225,7 +1360,9 @@ TEST(ConstructPileupConstructionMapTest, twoCandidateRegionsOneReadCoordinateEac
     CandidateRegion candidate_2 { Interval(10, 20), "test2" };
     ReadCoordinate read_coord_2 { read_id, 50, 100, true };
     candidate_2.read_coordinates.insert(read_coord_2);
-    CandidateRegions candidate_regions { std::make_pair(candidate_1.get_id(), candidate_1), std::make_pair(candidate_2.get_id(), candidate_2) };
+    CandidateRegions candidate_regions { std::make_pair(
+                                             candidate_1.get_id(), candidate_1),
+        std::make_pair(candidate_2.get_id(), candidate_2) };
 
     const auto actual { construct_pileup_construction_map(candidate_regions) };
     PileupConstructionMap expected;

--- a/test/denovo_discovery/candidate_region_test.cpp
+++ b/test/denovo_discovery/candidate_region_test.cpp
@@ -342,7 +342,35 @@ TEST(IdentifyLowCoverageIntervalsTest,
 
     EXPECT_EQ(actual, expected);
 }
+TEST(IdentifyLowCoverageIntervalsTest,
+    twoRegionsBelowThresholdOneSameAsMaxLengthReturnTwoIntervals)
+{
+    const auto min_len { 2 };
+    const auto max_len { 4 };
+    const auto min_covg { 3 };
+    const std::vector<uint32_t> covgs { 4, 2, 1, 1, 1, 4, 1, 2, 4 };
 
+    const auto actual { identify_low_coverage_intervals(
+        covgs, min_covg, min_len, max_len) };
+    const std::vector<Interval> expected { Interval(1, 5), Interval(6, 8) };
+
+    EXPECT_EQ(actual, expected);
+}
+
+TEST(IdentifyLowCoverageIntervalsTest,
+    twoRegionsBelowThresholdOneGreaterThanMaxLengthReturnOneInterval)
+{
+    const auto min_len { 2 };
+    const auto max_len { 4 };
+    const auto min_covg { 3 };
+    const std::vector<uint32_t> covgs { 4, 2, 1, 1, 1, 2, 4, 1, 2, 4 };
+
+    const auto actual { identify_low_coverage_intervals(
+        covgs, min_covg, min_len, max_len) };
+    const std::vector<Interval> expected { Interval(7, 9) };
+
+    EXPECT_EQ(actual, expected);
+}
 TEST(FindCandidateRegionsForPanNodeTest, emptyPanNodeReturnsNoCandidates)
 {
     const auto num_samples { 1 };

--- a/test/denovo_discovery/denovo_discovery_test.cpp
+++ b/test/denovo_discovery/denovo_discovery_test.cpp
@@ -1,31 +1,31 @@
-#include "gtest/gtest.h"
 #include "denovo_discovery/denovo_discovery.h"
+#include "gtest/gtest.h"
 
-
-TEST(ExpectedKmerCoverage, IncreasingErrorRatesDecreasingExpectedCovg) {
+TEST(ExpectedKmerCoverage, IncreasingErrorRatesDecreasingExpectedCovg)
+{
     const uint32_t read_covg { 50 };
     const uint32_t ref_length { 500 };
     const uint32_t k { 11 };
-    const std::vector<double> error_rates = { 0, 0.05, 0.1, 0.15, 0.2, 0.25, 0.3, 0.35, 0.4, 0.45, 0.5, 0.55, 0.6, 0.65,
-                                              0.7, 0.75, 0.8, 0.85, 0.9, 0.95 };
+    const std::vector<double> error_rates = { 0, 0.05, 0.1, 0.15, 0.2, 0.25, 0.3, 0.35,
+        0.4, 0.45, 0.5, 0.55, 0.6, 0.65, 0.7, 0.75, 0.8, 0.85, 0.9, 0.95 };
 
-    const std::vector<double> expected = { 49.0, 27.871204521546524, 15.376719208410002, 8.199818940791095,
-                                           4.209067950080002, 2.06952166557312, 0.9688901040699994, 0.4287883755264308,
-                                           0.17777055743999992, 0.06826304619110846, 0.02392578125,
-                                           0.0075081636759814375, 0.002055208960000001, 0.0004730908711279294,
-                                           8.680203000000014e-05, 1.1682510375976562e-05, 1.0035199999999976e-06,
-                                           4.238380371093757e-08, 4.899999999999988e-10, 2.3925781250000235e-13 };
+    const std::vector<double> expected = { 49.0, 27.871204521546524, 15.376719208410002,
+        8.199818940791095, 4.209067950080002, 2.06952166557312, 0.9688901040699994,
+        0.4287883755264308, 0.17777055743999992, 0.06826304619110846, 0.02392578125,
+        0.0075081636759814375, 0.002055208960000001, 0.0004730908711279294,
+        8.680203000000014e-05, 1.1682510375976562e-05, 1.0035199999999976e-06,
+        4.238380371093757e-08, 4.899999999999988e-10, 2.3925781250000235e-13 };
 
     for (uint32_t i = 0; i < error_rates.size(); i++) {
-        const auto &e { error_rates[i] };
+        const auto& e { error_rates[i] };
         const DenovoDiscovery denovo { k, e };
         const auto result { denovo.calculate_kmer_coverage(read_covg, ref_length) };
         EXPECT_DOUBLE_EQ(result, expected[i]);
     }
 }
 
-
-TEST(ExpectedKmerCoverage, ZeroReadCovgReturnsZero) {
+TEST(ExpectedKmerCoverage, ZeroReadCovgReturnsZero)
+{
     const uint32_t read_covg { 0 };
     const uint32_t ref_length { 500 };
     const uint32_t k { 11 };
@@ -38,8 +38,8 @@ TEST(ExpectedKmerCoverage, ZeroReadCovgReturnsZero) {
     EXPECT_DOUBLE_EQ(result, expected);
 }
 
-
-TEST(ExpectedKmerCoverage, ZeroRefLengthThrowsException) {
+TEST(ExpectedKmerCoverage, ZeroRefLengthThrowsException)
+{
     const uint32_t read_covg { 50 };
     const uint32_t ref_length { 0 };
     const uint32_t k { 11 };
@@ -50,16 +50,17 @@ TEST(ExpectedKmerCoverage, ZeroRefLengthThrowsException) {
 
     try {
         const auto result { denovo.calculate_kmer_coverage(read_covg, ref_length) };
-        FAIL() << "Expected std::invalid_argument. Instead, got result: " << std::to_string(result);
-    } catch (std::invalid_argument const &err) {
+        FAIL() << "Expected std::invalid_argument. Instead, got result: "
+               << std::to_string(result);
+    } catch (std::invalid_argument const& err) {
         EXPECT_EQ(err.what(), expected_msg);
     } catch (...) {
         FAIL() << "Expected std::invalid_argument";
     }
 }
 
-
-TEST(ExpectedKmerCoverage, ZeroKThrowsException) {
+TEST(ExpectedKmerCoverage, ZeroKThrowsException)
+{
     const uint32_t read_covg { 50 };
     const uint32_t ref_length { 500 };
     const uint32_t k { 0 };
@@ -70,16 +71,17 @@ TEST(ExpectedKmerCoverage, ZeroKThrowsException) {
 
     try {
         const auto result { denovo.calculate_kmer_coverage(read_covg, ref_length) };
-        FAIL() << "Expected std::invalid_argument. Instead, got result: " << std::to_string(result);
-    } catch (std::invalid_argument const &err) {
+        FAIL() << "Expected std::invalid_argument. Instead, got result: "
+               << std::to_string(result);
+    } catch (std::invalid_argument const& err) {
         EXPECT_EQ(err.what(), expected_msg);
     } catch (...) {
         FAIL() << "Expected std::invalid_argument";
     }
 }
 
-
-TEST(ExpectedKmerCoverage, negativeErrorRateThrowsException) {
+TEST(ExpectedKmerCoverage, negativeErrorRateThrowsException)
+{
     const uint32_t read_covg { 50 };
     const uint32_t ref_length { 500 };
     const uint32_t k { 5 };
@@ -90,16 +92,17 @@ TEST(ExpectedKmerCoverage, negativeErrorRateThrowsException) {
 
     try {
         const auto result { denovo.calculate_kmer_coverage(read_covg, ref_length) };
-        FAIL() << "Expected std::invalid_argument. Instead, got result: " << std::to_string(result);
-    } catch (std::invalid_argument const &err) {
+        FAIL() << "Expected std::invalid_argument. Instead, got result: "
+               << std::to_string(result);
+    } catch (std::invalid_argument const& err) {
         EXPECT_EQ(err.what(), expected_msg);
     } catch (...) {
         FAIL() << "Expected std::invalid_argument";
     }
 }
 
-
-TEST(FindPathsThroughCandidateRegionTest, emptyPileupReturnsEmpty) {
+TEST(FindPathsThroughCandidateRegionTest, emptyPileupReturnsEmpty)
+{
     const int k { 9 };
     const double error_rate { 0.11 };
     DenovoDiscovery denovo { k, error_rate };
@@ -109,14 +112,13 @@ TEST(FindPathsThroughCandidateRegionTest, emptyPileupReturnsEmpty) {
     denovo.find_paths_through_candidate_region(candidate_region);
 
     const DenovoPaths expected;
-    const auto &actual { candidate_region.denovo_paths };
+    const auto& actual { candidate_region.denovo_paths };
 
     EXPECT_EQ(actual, expected);
-
 }
 
-
-TEST(FindPathsThroughCandidateRegionTest, kmerSizeBiggerThanCandidateReturnsEmpty) {
+TEST(FindPathsThroughCandidateRegionTest, kmerSizeBiggerThanCandidateReturnsEmpty)
+{
     const int k { 99 };
     const double error_rate { 0.11 };
     DenovoDiscovery denovo { k, error_rate };
@@ -127,14 +129,14 @@ TEST(FindPathsThroughCandidateRegionTest, kmerSizeBiggerThanCandidateReturnsEmpt
     denovo.find_paths_through_candidate_region(candidate_region);
 
     const DenovoPaths expected;
-    const auto &actual { candidate_region.denovo_paths };
+    const auto& actual { candidate_region.denovo_paths };
 
     EXPECT_EQ(actual, expected);
-
 }
 
-
-TEST(FindPathsThroughCandidateRegionTest, passInDataThatCausesGatbErrorNoFailAndReturnsEmpty) {
+TEST(FindPathsThroughCandidateRegionTest,
+    passInDataThatCausesGatbErrorNoFailAndReturnsEmpty)
+{
     const int k { 9 };
     const double error_rate { 0.11 };
     DenovoDiscovery denovo { k, error_rate };
@@ -145,14 +147,13 @@ TEST(FindPathsThroughCandidateRegionTest, passInDataThatCausesGatbErrorNoFailAnd
     denovo.find_paths_through_candidate_region(candidate_region);
 
     const DenovoPaths expected;
-    const auto &actual { candidate_region.denovo_paths };
+    const auto& actual { candidate_region.denovo_paths };
 
     EXPECT_EQ(actual, expected);
-
 }
 
-
-TEST(FindPathsThroughCandidateRegionTest, startKmersDontExistInGraphReturnEmpty) {
+TEST(FindPathsThroughCandidateRegionTest, startKmersDontExistInGraphReturnEmpty)
+{
     const int k { 9 };
     const double error_rate { 0.11 };
     DenovoDiscovery denovo { k, error_rate };
@@ -163,13 +164,13 @@ TEST(FindPathsThroughCandidateRegionTest, startKmersDontExistInGraphReturnEmpty)
     denovo.find_paths_through_candidate_region(candidate_region);
 
     const DenovoPaths expected;
-    const auto &actual { candidate_region.denovo_paths };
+    const auto& actual { candidate_region.denovo_paths };
 
     EXPECT_EQ(actual, expected);
 }
 
-
-TEST(FindPathsThroughCandidateRegionTest, endKmersDontExistInGraphReturnEmpty) {
+TEST(FindPathsThroughCandidateRegionTest, endKmersDontExistInGraphReturnEmpty)
+{
     const int k { 9 };
     const double error_rate { 0.11 };
     DenovoDiscovery denovo { k, error_rate };
@@ -180,13 +181,13 @@ TEST(FindPathsThroughCandidateRegionTest, endKmersDontExistInGraphReturnEmpty) {
     denovo.find_paths_through_candidate_region(candidate_region);
 
     const DenovoPaths expected;
-    const auto &actual { candidate_region.denovo_paths };
+    const auto& actual { candidate_region.denovo_paths };
 
     EXPECT_EQ(actual, expected);
 }
 
-
-TEST(FindPathsThroughCandidateRegionTest, endKmerExistsInStartKmersFindPathAndCycles) {
+TEST(FindPathsThroughCandidateRegionTest, endKmerExistsInStartKmersFindPathAndCycles)
+{
     const int k { 9 };
     const double error_rate { 0.11 };
     const uint8_t max_insertion_size = 50;
@@ -198,35 +199,37 @@ TEST(FindPathsThroughCandidateRegionTest, endKmerExistsInStartKmersFindPathAndCy
     denovo.find_paths_through_candidate_region(candidate_region);
 
     const DenovoPaths expected { "ATGCGCTGACATGCGCTGA", "ATGCGCTGACATGCGCTGACATGCGCTGA",
-                                 "ATGCGCTGACATGCGCTGACATGCGCTGACATGCGCTGA",
-                                 "ATGCGCTGACATGCGCTGACATGCGCTGACATGCGCTGACATGCGCTGA",
-                                 "ATGCGCTGACATGCGCTGACATGCGCTGACATGCGCTGACATGCGCTGACATGCGCTGA",
-                                 "ATGCGCTGACATGCGCTGACATGCGCTGACATGCGCTGACATGCGCTGACATGCGCTGACATGCGCTGA" };
-    const auto &actual { candidate_region.denovo_paths };
+        "ATGCGCTGACATGCGCTGACATGCGCTGACATGCGCTGA",
+        "ATGCGCTGACATGCGCTGACATGCGCTGACATGCGCTGACATGCGCTGA",
+        "ATGCGCTGACATGCGCTGACATGCGCTGACATGCGCTGACATGCGCTGACATGCGCTGA",
+        "ATGCGCTGACATGCGCTGACATGCGCTGACATGCGCTGACATGCGCTGACATGCGCTGACATGCGCTGA" };
+    const auto& actual { candidate_region.denovo_paths };
 
     EXPECT_EQ(actual, expected);
 }
 
-
-TEST(FindPathsThroughCandidateRegionTest, doGraphCleaningtwoIdenticalReadsPlusNoiseReturnOnePath) {
+TEST(FindPathsThroughCandidateRegionTest,
+    doGraphCleaningtwoIdenticalReadsPlusNoiseReturnOnePath)
+{
     const int k { 9 };
     const double error_rate { 0.11 };
     DenovoDiscovery denovo { k, error_rate };
     denovo.clean_assembly_graph = true;
     CandidateRegion candidate_region { Interval(0, 1), "test" };
     candidate_region.max_likelihood_sequence = "ATGCGCTGAGAGTCGGACT";
-    candidate_region.pileup = { "ATGCGCTGAGAGTCGGACT", "ATGCGCTGAGAGTCGGACT", "AAATAAA", "GCGGCGCGGCC" };
+    candidate_region.pileup
+        = { "ATGCGCTGAGAGTCGGACT", "ATGCGCTGAGAGTCGGACT", "AAATAAA", "GCGGCGCGGCC" };
 
     denovo.find_paths_through_candidate_region(candidate_region);
 
     const DenovoPaths expected { "ATGCGCTGAGAGTCGGACT" };
-    const auto &actual { candidate_region.denovo_paths };
+    const auto& actual { candidate_region.denovo_paths };
 
     EXPECT_EQ(actual, expected);
 }
 
-
-TEST(FindPathsThroughCandidateRegionTest, twoIdenticalReadsReturnOnePath) {
+TEST(FindPathsThroughCandidateRegionTest, twoIdenticalReadsReturnOnePath)
+{
     const int k { 9 };
     const double error_rate { 0.11 };
     DenovoDiscovery denovo { k, error_rate };
@@ -237,13 +240,14 @@ TEST(FindPathsThroughCandidateRegionTest, twoIdenticalReadsReturnOnePath) {
     denovo.find_paths_through_candidate_region(candidate_region);
 
     const DenovoPaths expected { "ATGCGCTGAGAGTCGGACT" };
-    const auto &actual { candidate_region.denovo_paths };
+    const auto& actual { candidate_region.denovo_paths };
 
     EXPECT_EQ(actual, expected);
 }
 
-
-TEST(FindPathsThroughCandidateRegionTest, twoPossiblePathsWithLowCovgOnBothReturnsNoPath) {
+TEST(
+    FindPathsThroughCandidateRegionTest, twoPossiblePathsWithLowCovgOnBothReturnsNoPath)
+{
     const int k { 9 };
     const double error_rate { 0.11 };
     DenovoDiscovery denovo { k, error_rate };
@@ -254,46 +258,46 @@ TEST(FindPathsThroughCandidateRegionTest, twoPossiblePathsWithLowCovgOnBothRetur
     denovo.find_paths_through_candidate_region(candidate_region);
 
     const DenovoPaths expected;
-    const auto &actual { candidate_region.denovo_paths };
+    const auto& actual { candidate_region.denovo_paths };
 
     EXPECT_EQ(actual, expected);
-
 }
 
-
-TEST(FindPathsThroughCandidateRegionTest, twoPossiblePathsOneWithLowCovgOnOneReturnsOnePath) {
+TEST(FindPathsThroughCandidateRegionTest,
+    twoPossiblePathsOneWithLowCovgOnOneReturnsOnePath)
+{
     const int k { 9 };
     const double error_rate { 0.11 };
     DenovoDiscovery denovo { k, error_rate };
     CandidateRegion candidate_region { Interval(0, 1), "test" };
     candidate_region.max_likelihood_sequence = "ATGCGCTGAGAGTCGGACT";
-    candidate_region.pileup = { "ATGCGCTGAGAGTCGGACT", "ATGCGCTGAGAGTCGGACT", "ATGCGCTGATAGTCGGACT" };
+    candidate_region.pileup
+        = { "ATGCGCTGAGAGTCGGACT", "ATGCGCTGAGAGTCGGACT", "ATGCGCTGATAGTCGGACT" };
 
     denovo.find_paths_through_candidate_region(candidate_region);
 
     const DenovoPaths expected { "ATGCGCTGAGAGTCGGACT" };
-    const auto &actual { candidate_region.denovo_paths };
+    const auto& actual { candidate_region.denovo_paths };
 
     EXPECT_EQ(actual, expected);
-
 }
 
-
-TEST(FindPathsThroughCandidateRegionTest, twoPossiblePathsWithGoodCovgReturnsTwoPaths) {
+TEST(FindPathsThroughCandidateRegionTest, twoPossiblePathsWithGoodCovgReturnsTwoPaths)
+{
     const int k { 9 };
     const double error_rate { 0.11 };
     DenovoDiscovery denovo { k, error_rate };
     CandidateRegion candidate_region { Interval(0, 1), "test" };
     candidate_region.max_likelihood_sequence = "ATGCGCTGAGAGTCGGACT";
-    candidate_region.pileup = { "ATGCGCTGAGAGTCGGACT", "ATGCGCTGAGAGTCGGACT", "ATGCGCTGATAGTCGGACT",
-                                "ATGCGCTGATAGTCGGACT" };
+    candidate_region.pileup = { "ATGCGCTGAGAGTCGGACT", "ATGCGCTGAGAGTCGGACT",
+        "ATGCGCTGATAGTCGGACT", "ATGCGCTGATAGTCGGACT" };
 
     denovo.find_paths_through_candidate_region(candidate_region);
-    std::sort(candidate_region.denovo_paths.begin(), candidate_region.denovo_paths.end());
+    std::sort(
+        candidate_region.denovo_paths.begin(), candidate_region.denovo_paths.end());
 
     const DenovoPaths expected { "ATGCGCTGAGAGTCGGACT", "ATGCGCTGATAGTCGGACT" };
-    const auto &actual { candidate_region.denovo_paths };
+    const auto& actual { candidate_region.denovo_paths };
 
     EXPECT_EQ(actual, expected);
-
 }

--- a/test/denovo_discovery/local_assembly_test.cpp
+++ b/test/denovo_discovery/local_assembly_test.cpp
@@ -1,40 +1,39 @@
-#include "gtest/gtest.h"
 #include "denovo_discovery/local_assembly.h"
-#include <cstdio>
+#include "gtest/gtest.h"
 #include <algorithm>
-
+#include <cstdio>
 
 const uint32_t TEST_KMER_SIZE { 5 };
 const uint32_t g_test_max_path { 50 };
 
-
-TEST(GetNodeFromGraph, LowestKmerOfNode_KmerFoundInGraphAndNeighbour) {
+TEST(GetNodeFromGraph, LowestKmerOfNode_KmerFoundInGraphAndNeighbour)
+{
     LocalAssemblyGraph graph;
-    graph = LocalAssemblyGraph::create(new BankStrings("AATGTCAGG", NULL), "-kmer-size %d -abundance-min 1 -verbose 0",
-                                       TEST_KMER_SIZE);
+    graph = LocalAssemblyGraph::create(new BankStrings("AATGTCAGG", NULL),
+        "-kmer-size %d -abundance-min 1 -verbose 0", TEST_KMER_SIZE);
     auto kmer = "AATGT";
     Node real_node;
     bool found;
     std::tie(real_node, found) = graph.get_node(kmer);
     EXPECT_TRUE(found);
 
-    // We get the neighbors of this real node and make sure it has the neighbours we expect
+    // We get the neighbors of this real node and make sure it has the neighbours we
+    // expect
     GraphVector<Node> neighbours = graph.successors(real_node);
     EXPECT_EQ(graph.toString(neighbours[0]), "ATGTC");
 
     auto result = graph.toString(real_node);
-    auto &expected = kmer;
+    auto& expected = kmer;
 
     EXPECT_EQ(expected, result);
     remove_graph_file();
-
 }
 
-
-TEST(GetNodeFromGraph, HighestKmerOfNode_KmerFoundInGraph) {
+TEST(GetNodeFromGraph, HighestKmerOfNode_KmerFoundInGraph)
+{
     LocalAssemblyGraph graph;
-    graph = LocalAssemblyGraph::create(new BankStrings("AATGTCAGG", NULL), "-kmer-size %d -abundance-min 1 -verbose 0",
-                                       TEST_KMER_SIZE);
+    graph = LocalAssemblyGraph::create(new BankStrings("AATGTCAGG", NULL),
+        "-kmer-size %d -abundance-min 1 -verbose 0", TEST_KMER_SIZE);
     auto kmer = "ACATT";
 
     Node node;
@@ -42,17 +41,17 @@ TEST(GetNodeFromGraph, HighestKmerOfNode_KmerFoundInGraph) {
     std::tie(node, found) = graph.get_node(kmer);
 
     auto result = graph.toString(node);
-    auto &expected = kmer;
+    auto& expected = kmer;
 
     EXPECT_EQ(expected, result);
     remove_graph_file();
 }
 
-
-TEST(GetNodeFromGraph, HighestKmerOfNode_KmerFoundInGraphAndNeighbour) {
+TEST(GetNodeFromGraph, HighestKmerOfNode_KmerFoundInGraphAndNeighbour)
+{
     LocalAssemblyGraph graph;
     graph = LocalAssemblyGraph::create(new BankStrings("TCGTTGTCACT", NULL),
-                                       "-kmer-size %d -abundance-min 1 -verbose 0", TEST_KMER_SIZE);
+        "-kmer-size %d -abundance-min 1 -verbose 0", TEST_KMER_SIZE);
 
     const auto kmer { "TCGTT" };
 
@@ -63,7 +62,7 @@ TEST(GetNodeFromGraph, HighestKmerOfNode_KmerFoundInGraphAndNeighbour) {
     EXPECT_TRUE(found);
 
     const auto result = graph.toString(node);
-    const auto &expected = kmer;
+    const auto& expected = kmer;
 
     EXPECT_EQ(expected, result);
 
@@ -77,11 +76,11 @@ TEST(GetNodeFromGraph, HighestKmerOfNode_KmerFoundInGraphAndNeighbour) {
     remove_graph_file();
 }
 
-
-TEST(GetNodeFromGraph, LowestKmerOfStartNode_KmerFoundInGraphButNotNeighbourOfStart) {
+TEST(GetNodeFromGraph, LowestKmerOfStartNode_KmerFoundInGraphButNotNeighbourOfStart)
+{
     LocalAssemblyGraph graph;
     graph = LocalAssemblyGraph::create(new BankStrings("TCGTTGTCACT", NULL),
-                                       "-kmer-size %d -abundance-min 1 -verbose 0", TEST_KMER_SIZE);
+        "-kmer-size %d -abundance-min 1 -verbose 0", TEST_KMER_SIZE);
 
     const auto kmer { "AACGA" };
 
@@ -92,7 +91,7 @@ TEST(GetNodeFromGraph, LowestKmerOfStartNode_KmerFoundInGraphButNotNeighbourOfSt
     EXPECT_TRUE(found);
 
     const auto result = graph.toString(node);
-    const auto &expected = kmer;
+    const auto& expected = kmer;
 
     EXPECT_EQ(expected, result);
 
@@ -101,16 +100,16 @@ TEST(GetNodeFromGraph, LowestKmerOfStartNode_KmerFoundInGraphButNotNeighbourOfSt
     GraphVector<Node> neighbours = graph.successors(node);
     const auto result_neighbour { graph.toString(neighbours[0]) };
 
-    EXPECT_NE(result_neighbour, expected_neighbour);  // NE = not equal
+    EXPECT_NE(result_neighbour, expected_neighbour); // NE = not equal
 
     remove_graph_file();
 }
 
-
-TEST(GetNodeFromGraph, RevcompKmerOfInitialSeq_KmerFoundInGraphAndCorrectNeighbourFound) {
+TEST(GetNodeFromGraph, RevcompKmerOfInitialSeq_KmerFoundInGraphAndCorrectNeighbourFound)
+{
     LocalAssemblyGraph graph;
     graph = LocalAssemblyGraph::create(new BankStrings("TCGTTGTCACT", NULL),
-                                       "-kmer-size %d -abundance-min 1 -verbose 0", TEST_KMER_SIZE);
+        "-kmer-size %d -abundance-min 1 -verbose 0", TEST_KMER_SIZE);
 
     const auto kmer { "TGACA" };
 
@@ -121,7 +120,7 @@ TEST(GetNodeFromGraph, RevcompKmerOfInitialSeq_KmerFoundInGraphAndCorrectNeighbo
     EXPECT_TRUE(found);
 
     const auto result = graph.toString(node);
-    const auto &expected = kmer;
+    const auto& expected = kmer;
 
     EXPECT_EQ(expected, result);
 
@@ -135,11 +134,11 @@ TEST(GetNodeFromGraph, RevcompKmerOfInitialSeq_KmerFoundInGraphAndCorrectNeighbo
     remove_graph_file();
 }
 
-
-TEST(GetNodeFromGraph, NonExistentKmer_NotFoundInGraphAndNodeEmpty) {
+TEST(GetNodeFromGraph, NonExistentKmer_NotFoundInGraphAndNodeEmpty)
+{
     LocalAssemblyGraph graph;
-    graph = LocalAssemblyGraph::create(new BankStrings("AATGTCAGG", NULL), "-kmer-size %d -abundance-min 1 -verbose 0",
-                                       TEST_KMER_SIZE);
+    graph = LocalAssemblyGraph::create(new BankStrings("AATGTCAGG", NULL),
+        "-kmer-size %d -abundance-min 1 -verbose 0", TEST_KMER_SIZE);
     auto kmer = "ACTGT";
 
     Node node;
@@ -153,16 +152,16 @@ TEST(GetNodeFromGraph, NonExistentKmer_NotFoundInGraphAndNodeEmpty) {
     remove_graph_file();
 }
 
-
-TEST(GetPathsBetweenTest, OnlyReturnPathsBetweenStartAndEndKmers) {
+TEST(GetPathsBetweenTest, OnlyReturnPathsBetweenStartAndEndKmers)
+{
     const std::string s1 { "AATGTAAGGCC" };
     const std::string s2 { "AATGTCAGGCC" };
     const std::string s3 { "AATGTTAGGCC" };
     std::vector<std::string> seqs = { s1, s2, s3 };
 
     LocalAssemblyGraph graph;
-    graph = LocalAssemblyGraph::create(new BankStrings(seqs), "-kmer-size %d -abundance-min 1 -verbose 0",
-                                       TEST_KMER_SIZE);
+    graph = LocalAssemblyGraph::create(new BankStrings(seqs),
+        "-kmer-size %d -abundance-min 1 -verbose 0", TEST_KMER_SIZE);
 
     Node start_node;
     bool found;
@@ -179,19 +178,19 @@ TEST(GetPathsBetweenTest, OnlyReturnPathsBetweenStartAndEndKmers) {
     remove_graph_file();
 }
 
-
-TEST(GetPathsBetweenTest, lotsOfHighCovgCyclesReturnEmpty) {
-    std::vector<std::string> seqs { "AATGTTACATTAATGTTACATT", "AATGTTCGCCGCCGCAAACATT", "AATGTTACATTAATGTTACATT",
-                                    "AATGTTACATTAATGTTACATT", "AATGTTACATTAATGTTACATT", "AATGTTACATTAATGTTACATT",
-                                    "AATGTTACATTAATGTTACATT" };
+TEST(GetPathsBetweenTest, lotsOfHighCovgCyclesReturnEmpty)
+{
+    std::vector<std::string> seqs { "AATGTTACATTAATGTTACATT", "AATGTTCGCCGCCGCAAACATT",
+        "AATGTTACATTAATGTTACATT", "AATGTTACATTAATGTTACATT", "AATGTTACATTAATGTTACATT",
+        "AATGTTACATTAATGTTACATT", "AATGTTACATTAATGTTACATT" };
     const auto start_kmer { "AATGT" };
     const auto end_kmer { "ACATT" };
     const auto max_path_length { 55 };
     const auto expected_coverage { 4 };
 
     LocalAssemblyGraph graph;
-    graph = LocalAssemblyGraph::create(new BankStrings(seqs), "-kmer-size %d -abundance-min 1 -verbose 0",
-                                       TEST_KMER_SIZE);
+    graph = LocalAssemblyGraph::create(new BankStrings(seqs),
+        "-kmer-size %d -abundance-min 1 -verbose 0", TEST_KMER_SIZE);
 
     Node start_node;
     bool found;
@@ -200,23 +199,25 @@ TEST(GetPathsBetweenTest, lotsOfHighCovgCyclesReturnEmpty) {
     Node end_node;
     std::tie(end_node, found) = graph.get_node(end_kmer);
 
-
-    auto actual { graph.get_paths_between(start_node, end_node, max_path_length, expected_coverage).first };
+    auto actual { graph
+                      .get_paths_between(
+                          start_node, end_node, max_path_length, expected_coverage)
+                      .first };
     DenovoPaths expected;
     remove_graph_file();
 
     EXPECT_EQ(actual, expected);
 }
 
-
-TEST(DepthFirstSearchFromTest, SimpleGraphTwoNodesReturnSeqPassedIn) {
+TEST(DepthFirstSearchFromTest, SimpleGraphTwoNodesReturnSeqPassedIn)
+{
     const auto seq { "ATGCAG" };
     const auto start_kmer { "ATGCA" };
     const auto end_kmer { "TGCAG" };
 
     LocalAssemblyGraph graph;
-    graph = LocalAssemblyGraph::create(new BankStrings(seq, NULL), "-kmer-size %d -abundance-min 1 -verbose 0",
-                                       TEST_KMER_SIZE);
+    graph = LocalAssemblyGraph::create(new BankStrings(seq, NULL),
+        "-kmer-size %d -abundance-min 1 -verbose 0", TEST_KMER_SIZE);
 
     Node start_node;
     bool found;
@@ -232,15 +233,15 @@ TEST(DepthFirstSearchFromTest, SimpleGraphTwoNodesReturnSeqPassedIn) {
     remove_graph_file();
 }
 
-
-TEST(DepthFirstSearchFromTest, SimpleGraphSixNodesReturnSeqPassedIn) {
+TEST(DepthFirstSearchFromTest, SimpleGraphSixNodesReturnSeqPassedIn)
+{
     const auto seq { "ATGCAGTACA" };
     const auto start_kmer { "ATGCA" };
     const auto end_kmer { "GTACA" };
 
     LocalAssemblyGraph graph;
-    graph = LocalAssemblyGraph::create(new BankStrings(seq, NULL), "-kmer-size %d -abundance-min 1 -verbose 0",
-                                       TEST_KMER_SIZE);
+    graph = LocalAssemblyGraph::create(new BankStrings(seq, NULL),
+        "-kmer-size %d -abundance-min 1 -verbose 0", TEST_KMER_SIZE);
 
     Node start_node;
     bool found;
@@ -253,7 +254,7 @@ TEST(DepthFirstSearchFromTest, SimpleGraphSixNodesReturnSeqPassedIn) {
 
     bool original_seq_found = false;
     // make sure all paths begin and end with correct kmer
-    for (auto &path: result) {
+    for (auto& path : result) {
         EXPECT_EQ(path.substr(0, TEST_KMER_SIZE), start_kmer);
         EXPECT_EQ(path.substr(path.length() - TEST_KMER_SIZE, path.length()), end_kmer);
 
@@ -266,8 +267,8 @@ TEST(DepthFirstSearchFromTest, SimpleGraphSixNodesReturnSeqPassedIn) {
     remove_graph_file();
 }
 
-
-TEST(DepthFirstSearchFromTest, TwoReadsSameSequenceReturnOneSequence) {
+TEST(DepthFirstSearchFromTest, TwoReadsSameSequenceReturnOneSequence)
+{
     const auto seq1 { "ATGCAG" };
     const auto seq2 { "ATGCAG" };
     std::vector<std::string> seqs = { seq1, seq2 };
@@ -275,8 +276,8 @@ TEST(DepthFirstSearchFromTest, TwoReadsSameSequenceReturnOneSequence) {
     const auto end_kmer { "TGCAG" };
 
     LocalAssemblyGraph graph;
-    graph = LocalAssemblyGraph::create(new BankStrings(seqs), "-kmer-size %d -abundance-min 1 -verbose 0",
-                                       TEST_KMER_SIZE);
+    graph = LocalAssemblyGraph::create(new BankStrings(seqs),
+        "-kmer-size %d -abundance-min 1 -verbose 0", TEST_KMER_SIZE);
 
     Node start_node;
     bool found;
@@ -292,8 +293,8 @@ TEST(DepthFirstSearchFromTest, TwoReadsSameSequenceReturnOneSequence) {
     remove_graph_file();
 }
 
-
-TEST(DepthFirstSearchFromTest, TwoReadsOneVariantReturnOriginalTwoSequences) {
+TEST(DepthFirstSearchFromTest, TwoReadsOneVariantReturnOriginalTwoSequences)
+{
     const std::string seq1 { "ATGCAGTACAA" };
     const std::string seq2 { "ATGCATTACAA" };
     std::vector<std::string> seqs = { seq1, seq2 };
@@ -301,8 +302,8 @@ TEST(DepthFirstSearchFromTest, TwoReadsOneVariantReturnOriginalTwoSequences) {
     const auto end_kmer { "TACAA" };
 
     LocalAssemblyGraph graph;
-    graph = LocalAssemblyGraph::create(new BankStrings(seqs), "-kmer-size %d -abundance-min 1 -verbose 0",
-                                       TEST_KMER_SIZE);
+    graph = LocalAssemblyGraph::create(new BankStrings(seqs),
+        "-kmer-size %d -abundance-min 1 -verbose 0", TEST_KMER_SIZE);
 
     Node start_node;
     bool found;
@@ -314,7 +315,7 @@ TEST(DepthFirstSearchFromTest, TwoReadsOneVariantReturnOriginalTwoSequences) {
     auto result = graph.get_paths_between(start_node, end_node, g_test_max_path).first;
 
     int original_seq_found = 0;
-    for (auto &path: result) {
+    for (auto& path : result) {
         EXPECT_EQ(path.substr(0, TEST_KMER_SIZE), start_kmer);
         EXPECT_EQ(path.substr(path.length() - TEST_KMER_SIZE, path.length()), end_kmer);
 
@@ -327,8 +328,8 @@ TEST(DepthFirstSearchFromTest, TwoReadsOneVariantReturnOriginalTwoSequences) {
     remove_graph_file();
 }
 
-
-TEST(DepthFirstSearchFromTest, ThreeReadsTwoVariantsReturnOriginalSequences) {
+TEST(DepthFirstSearchFromTest, ThreeReadsTwoVariantsReturnOriginalSequences)
+{
     const std::string seq1 { "ATGCAGTACAA" };
     const std::string seq2 { "ATGCATTACAA" };
     const std::string seq3 { "ATGCACTACAA" };
@@ -337,8 +338,8 @@ TEST(DepthFirstSearchFromTest, ThreeReadsTwoVariantsReturnOriginalSequences) {
     const auto end_kmer { "TACAA" };
 
     LocalAssemblyGraph graph;
-    graph = LocalAssemblyGraph::create(new BankStrings(seqs), "-kmer-size %d -abundance-min 1 -verbose 0",
-                                       TEST_KMER_SIZE);
+    graph = LocalAssemblyGraph::create(new BankStrings(seqs),
+        "-kmer-size %d -abundance-min 1 -verbose 0", TEST_KMER_SIZE);
 
     Node start_node;
     bool found;
@@ -350,12 +351,13 @@ TEST(DepthFirstSearchFromTest, ThreeReadsTwoVariantsReturnOriginalSequences) {
     auto result = graph.get_paths_between(start_node, end_node, g_test_max_path).first;
 
     int original_seq_found = 0;
-    for (auto &path: result) {
+    for (auto& path : result) {
         EXPECT_EQ(path.substr(0, TEST_KMER_SIZE), start_kmer);
         EXPECT_EQ(path.substr(path.length() - TEST_KMER_SIZE, path.length()), end_kmer);
 
         if (path.length() == seq1.length()) {
-            bool path_in_expected = std::find(seqs.begin(), seqs.end(), path) != seqs.end();
+            bool path_in_expected
+                = std::find(seqs.begin(), seqs.end(), path) != seqs.end();
             if (path_in_expected) {
                 ++original_seq_found;
             }
@@ -365,8 +367,9 @@ TEST(DepthFirstSearchFromTest, ThreeReadsTwoVariantsReturnOriginalSequences) {
     remove_graph_file();
 }
 
-
-TEST(DepthFirstSearchFromTest, TwoReadsTwoVariantsReturnOriginalTwoSequencesPlusTwoMosaics) {
+TEST(DepthFirstSearchFromTest,
+    TwoReadsTwoVariantsReturnOriginalTwoSequencesPlusTwoMosaics)
+{
     const std::string seq1 { "TTGGTCATCCCATTATG" };
     const std::string seq2 { "TTGGTGATCCCGTTATG" };
     std::vector<std::string> seqs = { seq1, seq2 };
@@ -374,8 +377,8 @@ TEST(DepthFirstSearchFromTest, TwoReadsTwoVariantsReturnOriginalTwoSequencesPlus
     const auto end_kmer { "TTATG" };
 
     LocalAssemblyGraph graph;
-    graph = LocalAssemblyGraph::create(new BankStrings(seqs), "-kmer-size %d -abundance-min 1 -verbose 0",
-                                       TEST_KMER_SIZE);
+    graph = LocalAssemblyGraph::create(new BankStrings(seqs),
+        "-kmer-size %d -abundance-min 1 -verbose 0", TEST_KMER_SIZE);
 
     Node start_node;
     bool found;
@@ -387,18 +390,19 @@ TEST(DepthFirstSearchFromTest, TwoReadsTwoVariantsReturnOriginalTwoSequencesPlus
     auto result = graph.get_paths_between(start_node, end_node, g_test_max_path).first;
 
     // add other expected paths due to variants
-    std::vector<std::string> expected_seqs = { seq1, seq2, "TTGGTGATCCCATTATG", "TTGGTCATCCCGTTATG" };
+    std::vector<std::string> expected_seqs
+        = { seq1, seq2, "TTGGTGATCCCATTATG", "TTGGTCATCCCGTTATG" };
 
     std::sort(result.begin(), result.end());
     std::sort(expected_seqs.begin(), expected_seqs.end());
 
     EXPECT_EQ(result, expected_seqs);
     remove_graph_file();
-
 }
 
-
-TEST(DepthFirstSearchFromTest, ThreeReadsOneReverseComplimentReturnPathsForStrandOfStartAndEndKmers) {
+TEST(DepthFirstSearchFromTest,
+    ThreeReadsOneReverseComplimentReturnPathsForStrandOfStartAndEndKmers)
+{
     const std::string seq1 { "ATGTG" };
     const std::string seq2 { "TGTGC" };
     const std::string seq3 { "TGCAC" };
@@ -407,8 +411,8 @@ TEST(DepthFirstSearchFromTest, ThreeReadsOneReverseComplimentReturnPathsForStran
     const auto end_kmer { "GTGCA" };
 
     LocalAssemblyGraph graph;
-    graph = LocalAssemblyGraph::create(new BankStrings(seqs), "-kmer-size %d -abundance-min 1 -verbose 0",
-                                       TEST_KMER_SIZE);
+    graph = LocalAssemblyGraph::create(new BankStrings(seqs),
+        "-kmer-size %d -abundance-min 1 -verbose 0", TEST_KMER_SIZE);
 
     Node start_node;
     bool found;
@@ -425,11 +429,10 @@ TEST(DepthFirstSearchFromTest, ThreeReadsOneReverseComplimentReturnPathsForStran
     EXPECT_EQ(result.size(), 1);
     EXPECT_EQ(*result.begin(), expected_seq);
     remove_graph_file();
-
 }
 
-
-TEST(DepthFirstSearchFromTest, SimpleCycleReturnPathsOfLengthsUpToMaxPathLengthCycling) {
+TEST(DepthFirstSearchFromTest, SimpleCycleReturnPathsOfLengthsUpToMaxPathLengthCycling)
+{
     const std::string seq1 { "ATATATATA" };
     const std::string seq2 { "TATAT" };
     std::vector<std::string> seqs = { seq1, seq2 };
@@ -437,8 +440,8 @@ TEST(DepthFirstSearchFromTest, SimpleCycleReturnPathsOfLengthsUpToMaxPathLengthC
     const auto end_kmer { "TATAT" };
 
     LocalAssemblyGraph graph;
-    graph = LocalAssemblyGraph::create(new BankStrings(seqs), "-kmer-size %d -abundance-min 1 -verbose 0",
-                                       TEST_KMER_SIZE);
+    graph = LocalAssemblyGraph::create(new BankStrings(seqs),
+        "-kmer-size %d -abundance-min 1 -verbose 0", TEST_KMER_SIZE);
 
     Node start_node;
     bool found;
@@ -452,7 +455,7 @@ TEST(DepthFirstSearchFromTest, SimpleCycleReturnPathsOfLengthsUpToMaxPathLengthC
     const std::string min_expected_seq = "ATATAT";
     bool is_in = false;
 
-    for (auto &path: result) {
+    for (auto& path : result) {
         if (path == min_expected_seq) {
             is_in = true;
         }
@@ -462,72 +465,81 @@ TEST(DepthFirstSearchFromTest, SimpleCycleReturnPathsOfLengthsUpToMaxPathLengthC
     remove_graph_file();
 }
 
-
-TEST(StringEndsWithTest, endsWithReturnTrue) {
+TEST(StringEndsWithTest, endsWithReturnTrue)
+{
     std::string test = "binary";
     std::string ending = "nary";
 
     EXPECT_TRUE(string_ends_with(test, ending));
 }
 
-
-TEST(StringEndsWithTest, doesNotHaveEndingReturnFalse) {
+TEST(StringEndsWithTest, doesNotHaveEndingReturnFalse)
+{
     std::string test = "tertiary";
     std::string ending = "nary";
 
     EXPECT_FALSE(string_ends_with(test, ending));
 }
 
-
-TEST(StringEndsWithTest, endingLongerThanQueryReturnFalse) {
+TEST(StringEndsWithTest, endingLongerThanQueryReturnFalse)
+{
     std::string test = "ry";
     std::string ending = "nary";
 
     EXPECT_FALSE(string_ends_with(test, ending));
 }
 
-
-TEST(ReverseComplementTest, SingleBaseReturnCompliment) {
+TEST(ReverseComplementTest, SingleBaseReturnCompliment)
+{
     const auto seq = "A";
     const auto expected = "T";
     auto result = reverse_complement(seq);
     EXPECT_EQ(expected, result);
 }
 
-
-TEST(ReverseComplementTest, TwoBasesReturnCompliment) {
+TEST(ReverseComplementTest, TwoBasesReturnCompliment)
+{
     const auto seq = "AA";
     const auto expected = "TT";
     auto result = reverse_complement(seq);
     EXPECT_EQ(expected, result);
 }
 
-
-TEST(ReverseComplementTest, AllBasesReturnCompliment) {
+TEST(ReverseComplementTest, AllBasesReturnCompliment)
+{
     const auto seq = "ACTGCA";
     const auto expected = "TGCAGT";
     auto result = reverse_complement(seq);
     EXPECT_EQ(expected, result);
 }
 
-
-TEST(ReverseComplementTest, PalindromeReturnCompliment) {
+TEST(ReverseComplementTest, PalindromeReturnCompliment)
+{
     const auto seq = "ACGT";
     const auto expected = "ACGT";
     auto result = reverse_complement(seq);
     EXPECT_EQ(expected, result);
 }
 
-
-TEST(GraphCleaningTest, simpleTipRemove) {
+TEST(GraphCleaningTest, simpleTipRemove)
+{
     const int kmer_size { 21 };
     const std::vector<std::string> sequences {
-            //>works well for k=21; part of genome10K.fasta
-            "CATCGATGCGAGACGCCTGTCGCGGGGAATTGTGGGGCGGACCACGCTCTGGCTAACGAGCTACCGTTTCCTTTAACCTGCCAGACGGTGACCAGGGCCGTTCGGCGTTGCATCGAGCGGTGTCGCTAGCGCAATGCGCAAGATTTTGACATTTACAAGGCAACATTGCAGCGTCCGATGGTCCGGTGGCCTCCAGATAGTGTCCAGTCGCTCTAACTGTATGGAGACCATAGGCATTTACCTTATTCTCATCGCCACGCCCCAAGATCTTTAGGACCCAGCATTCCTTTAACCACTAACATAACGCGTGTCATCTAGTTCAACAACC",
-            "TGTCATCTAGTTCAACAACCAAAAAAA", //>that's the tip
-            "TGTCATCTAGTTCAACAACCGTTATGCCGTCCGACTCTTGCGCTCGGATGTCCGCAATGGGTTATCCCTATGTTCCGGTAATCTCTCATCTACTAAGCGCCCTAAAGGTCGTATGGTTGGAGGGCGGTTACACACCCTTAAGTACCGAACGATAGAGCACCCGTCTAGGAGGGCGTGCAGGGTCTCCCGCTAGCTAATGGTCACGGCCTCTCTGGGAAAGCTGAACAACGGATGATACCCATACTGCCACTCCAGTACCTGGGCCGCGTGTTGTACGCTGTGTATCTTGAGAGCGTTTCCAGCAGATAGAACAGGATCACATGTACATG" //>remaining part
+        //>works well for k=21; part of genome10K.fasta
+        "CATCGATGCGAGACGCCTGTCGCGGGGAATTGTGGGGCGGACCACGCTCTGGCTAACGAGCTACCGTTTCCTTTAACC"
+        "TGCCAGACGGTGACCAGGGCCGTTCGGCGTTGCATCGAGCGGTGTCGCTAGCGCAATGCGCAAGATTTTGACATTTAC"
+        "AAGGCAACATTGCAGCGTCCGATGGTCCGGTGGCCTCCAGATAGTGTCCAGTCGCTCTAACTGTATGGAGACCATAGG"
+        "CATTTACCTTATTCTCATCGCCACGCCCCAAGATCTTTAGGACCCAGCATTCCTTTAACCACTAACATAACGCGTGTC"
+        "ATCTAGTTCAACAACC",
+        "TGTCATCTAGTTCAACAACCAAAAAAA", //>that's the tip
+        "TGTCATCTAGTTCAACAACCGTTATGCCGTCCGACTCTTGCGCTCGGATGTCCGCAATGGGTTATCCCTATGTTCCGG"
+        "TAATCTCTCATCTACTAAGCGCCCTAAAGGTCGTATGGTTGGAGGGCGGTTACACACCCTTAAGTACCGAACGATAGA"
+        "GCACCCGTCTAGGAGGGCGTGCAGGGTCTCCCGCTAGCTAATGGTCACGGCCTCTCTGGGAAAGCTGAACAACGGATG"
+        "ATACCCATACTGCCACTCCAGTACCTGGGCCGCGTGTTGTACGCTGTGTATCTTGAGAGCGTTTCCAGCAGATAGAAC"
+        "AGGATCACATGTACATG" //>remaining part
     };
-    Graph graph = Graph::create(new BankStrings(sequences), "-kmer-size %d -abundance-min 1 -verbose 0", kmer_size);
+    Graph graph = Graph::create(new BankStrings(sequences),
+        "-kmer-size %d -abundance-min 1 -verbose 0", kmer_size);
     clean(graph);
 
     unsigned int num_non_deleted_nodes { 0 };
@@ -545,11 +557,10 @@ TEST(GraphCleaningTest, simpleTipRemove) {
     EXPECT_EQ(num_nodes, 624);
     EXPECT_EQ(num_non_deleted_nodes, 617);
     remove_graph_file();
-
 }
 
-
-TEST(GenerateStartKmersTest, kmerSizeGreaterThanSeqLengthReturnEmpty) {
+TEST(GenerateStartKmersTest, kmerSizeGreaterThanSeqLengthReturnEmpty)
+{
     const std::string sequence { "ACGTGCGATGCAT" };
     const auto k { 44 };
     const auto n { 1 };
@@ -560,8 +571,8 @@ TEST(GenerateStartKmersTest, kmerSizeGreaterThanSeqLengthReturnEmpty) {
     EXPECT_EQ(expected, actual);
 }
 
-
-TEST(GenerateStartKmersTest, GenerateOneKmerReturnFirstKCharacters) {
+TEST(GenerateStartKmersTest, GenerateOneKmerReturnFirstKCharacters)
+{
     const std::string sequence { "ACGTGCGATGCAT" };
     const auto k { 4 };
     const auto n { 1 };
@@ -572,8 +583,8 @@ TEST(GenerateStartKmersTest, GenerateOneKmerReturnFirstKCharacters) {
     EXPECT_EQ(result, expected);
 }
 
-
-TEST(GenerateStartKmersTest, GenerateTwoKmersReturnFirstTwoKmers) {
+TEST(GenerateStartKmersTest, GenerateTwoKmersReturnFirstTwoKmers)
+{
     const std::string sequence { "ACGTGCGATGCAT" };
     const auto k { 4 };
     const auto n { 2 };
@@ -584,8 +595,8 @@ TEST(GenerateStartKmersTest, GenerateTwoKmersReturnFirstTwoKmers) {
     EXPECT_EQ(result, expected);
 }
 
-
-TEST(GenerateStartKmersTest, GenerateMaxPossibleNumKmersReturnWholeSeqAsKmers) {
+TEST(GenerateStartKmersTest, GenerateMaxPossibleNumKmersReturnWholeSeqAsKmers)
+{
     const std::string sequence { "ACGTGCGA" };
     const auto k { 4 };
     const auto n { 5 };
@@ -596,8 +607,8 @@ TEST(GenerateStartKmersTest, GenerateMaxPossibleNumKmersReturnWholeSeqAsKmers) {
     EXPECT_EQ(result, expected);
 }
 
-
-TEST(GenerateStartKmersTest, GenerateTooManyKmersReturnWholeSeqAsKmers) {
+TEST(GenerateStartKmersTest, GenerateTooManyKmersReturnWholeSeqAsKmers)
+{
     const std::string sequence { "ACGTGCGA" };
     const auto k { 4 };
     const auto n { 20 };
@@ -608,8 +619,8 @@ TEST(GenerateStartKmersTest, GenerateTooManyKmersReturnWholeSeqAsKmers) {
     EXPECT_EQ(result, expected);
 }
 
-
-TEST(GenerateStartKmersTest, GenerateNoKmersReturnEmptySet) {
+TEST(GenerateStartKmersTest, GenerateNoKmersReturnEmptySet)
+{
     const std::string sequence { "ACGTACGT" };
     const auto k { 4 };
     const auto n { 0 };
@@ -620,8 +631,8 @@ TEST(GenerateStartKmersTest, GenerateNoKmersReturnEmptySet) {
     EXPECT_EQ(result, expected);
 }
 
-
-TEST(GenerateEndKmersTest, kmerSizeGreaterThanSeqLengthReturnEmpty) {
+TEST(GenerateEndKmersTest, kmerSizeGreaterThanSeqLengthReturnEmpty)
+{
     const std::string sequence { "ACGTGCGATGCAT" };
     const auto k { 44 };
     const auto n { 1 };
@@ -632,8 +643,8 @@ TEST(GenerateEndKmersTest, kmerSizeGreaterThanSeqLengthReturnEmpty) {
     EXPECT_EQ(expected, actual);
 }
 
-
-TEST(GenerateEndKmersTest, GenerateOneKmerReturnLastKCharacters) {
+TEST(GenerateEndKmersTest, GenerateOneKmerReturnLastKCharacters)
+{
     const std::string sequence { "ACGTGCGATGCAT" };
     const auto k { 4 };
     const auto n { 1 };
@@ -644,8 +655,8 @@ TEST(GenerateEndKmersTest, GenerateOneKmerReturnLastKCharacters) {
     EXPECT_EQ(expected, actual);
 }
 
-
-TEST(GenerateEndKmersTest, GenerateTwoKmersReturnLastTwoKmers) {
+TEST(GenerateEndKmersTest, GenerateTwoKmersReturnLastTwoKmers)
+{
     const std::string sequence { "ACGTGCGATGCAT" };
     const auto k { 4 };
     const auto n { 2 };
@@ -656,8 +667,8 @@ TEST(GenerateEndKmersTest, GenerateTwoKmersReturnLastTwoKmers) {
     EXPECT_EQ(result, expected);
 }
 
-
-TEST(GenerateEndKmersTest, GenerateMaxPossibleNumKmersReturnWholeSeqAsKmers) {
+TEST(GenerateEndKmersTest, GenerateMaxPossibleNumKmersReturnWholeSeqAsKmers)
+{
     const std::string sequence { "ACGTGCGA" };
     const auto k { 4 };
     const auto n { 5 };
@@ -668,8 +679,8 @@ TEST(GenerateEndKmersTest, GenerateMaxPossibleNumKmersReturnWholeSeqAsKmers) {
     EXPECT_EQ(result, expected);
 }
 
-
-TEST(GenerateEndKmersTest, GenerateTooManyKmersReturnWholeSeqAsKmers) {
+TEST(GenerateEndKmersTest, GenerateTooManyKmersReturnWholeSeqAsKmers)
+{
     const std::string sequence { "ACGTGCGA" };
     const auto k { 4 };
     const auto n { 20 };
@@ -680,8 +691,8 @@ TEST(GenerateEndKmersTest, GenerateTooManyKmersReturnWholeSeqAsKmers) {
     EXPECT_EQ(result, expected);
 }
 
-
-TEST(GenerateEndKmersTest, SequenceHasRepeatKmersReturnOnlyUniqueKmers) {
+TEST(GenerateEndKmersTest, SequenceHasRepeatKmersReturnOnlyUniqueKmers)
+{
     const std::string sequence { "ACGTACGT" };
     const auto k { 4 };
     const auto n { 20 };
@@ -692,8 +703,8 @@ TEST(GenerateEndKmersTest, SequenceHasRepeatKmersReturnOnlyUniqueKmers) {
     EXPECT_EQ(result, expected);
 }
 
-
-TEST(GenerateEndKmersTest, GenerateNoKmersReturnEmptySet) {
+TEST(GenerateEndKmersTest, GenerateNoKmersReturnEmptySet)
+{
     const std::string sequence { "ACGTACGT" };
     const auto k { 4 };
     const auto n { 0 };
@@ -704,44 +715,50 @@ TEST(GenerateEndKmersTest, GenerateNoKmersReturnEmptySet) {
     EXPECT_EQ(result, expected);
 }
 
-
-TEST(QueryAbundance, oneKmer_ReturnOne) {
-    Graph graph = Graph::create(new BankStrings("AATGT", NULL), "-kmer-size 5 -abundance-min 1 -verbose 0");
+TEST(QueryAbundance, oneKmer_ReturnOne)
+{
+    Graph graph = Graph::create(
+        new BankStrings("AATGT", NULL), "-kmer-size 5 -abundance-min 1 -verbose 0");
     auto kmer = "AATGT";
     auto node { graph.buildNode(kmer) };
     const auto covg { graph.queryAbundance(node) };
 
-    // We get the neighbors of this real node and make sure it has the neighbours we expect
+    // We get the neighbors of this real node and make sure it has the neighbours we
+    // expect
     EXPECT_EQ(covg, 1);
     remove_graph_file();
 }
 
-
-TEST(QueryAbundance, twoKmers_ReturnTwo) {
-    Graph graph = Graph::create(new BankStrings("AATGTAATGT", NULL), "-kmer-size 5 -abundance-min 1 -verbose 0");
+TEST(QueryAbundance, twoKmers_ReturnTwo)
+{
+    Graph graph = Graph::create(new BankStrings("AATGTAATGT", NULL),
+        "-kmer-size 5 -abundance-min 1 -verbose 0");
     auto kmer = "AATGT";
     auto node { graph.buildNode(kmer) };
     const auto covg { graph.queryAbundance(node) };
 
-    // We get the neighbors of this real node and make sure it has the neighbours we expect
+    // We get the neighbors of this real node and make sure it has the neighbours we
+    // expect
     EXPECT_EQ(covg, 2);
     remove_graph_file();
 }
 
-
-TEST(QueryAbundance, fakeKmer_ReturnZero) {
-    Graph graph = Graph::create(new BankStrings("AATGT", NULL), "-kmer-size 5 -abundance-min 1 -verbose 0");
+TEST(QueryAbundance, fakeKmer_ReturnZero)
+{
+    Graph graph = Graph::create(
+        new BankStrings("AATGT", NULL), "-kmer-size 5 -abundance-min 1 -verbose 0");
     auto kmer = "CCCCC";
     auto node { graph.buildNode(kmer) };
     const auto covg { graph.queryAbundance(node) };
 
-    // We get the neighbors of this real node and make sure it has the neighbours we expect
+    // We get the neighbors of this real node and make sure it has the neighbours we
+    // expect
     EXPECT_EQ(covg, 0);
     remove_graph_file();
 }
 
-
-TEST(AllKmersInTest, emptyQueryReturnsEmpty) {
+TEST(AllKmersInTest, emptyQueryReturnsEmpty)
+{
     const std::string query { "" };
     const auto k_size { 3 };
 
@@ -751,8 +768,8 @@ TEST(AllKmersInTest, emptyQueryReturnsEmpty) {
     EXPECT_EQ(actual, expected);
 }
 
-
-TEST(AllKmersInTest, queryShorterThanKsizeReturnsEmpty) {
+TEST(AllKmersInTest, queryShorterThanKsizeReturnsEmpty)
+{
     const std::string query { "q" };
     const auto k_size { 3 };
 
@@ -762,8 +779,8 @@ TEST(AllKmersInTest, queryShorterThanKsizeReturnsEmpty) {
     EXPECT_EQ(actual, expected);
 }
 
-
-TEST(AllKmersInTest, querySameLengthAsKsizeReturnsQuery) {
+TEST(AllKmersInTest, querySameLengthAsKsizeReturnsQuery)
+{
     const std::string query { "q" };
     const auto k_size { 1 };
 
@@ -773,8 +790,8 @@ TEST(AllKmersInTest, querySameLengthAsKsizeReturnsQuery) {
     EXPECT_EQ(actual, expected);
 }
 
-
-TEST(AllKmersInTest, queryLongerThanKsizeReturnsAllKmers) {
+TEST(AllKmersInTest, queryLongerThanKsizeReturnsAllKmers)
+{
     const std::string query { "every" };
     const auto k_size { 3 };
 

--- a/test/denovo_discovery/local_assembly_test.cpp
+++ b/test/denovo_discovery/local_assembly_test.cpp
@@ -172,7 +172,7 @@ TEST(GetPathsBetweenTest, OnlyReturnPathsBetweenStartAndEndKmers) {
     const auto end_kmer { "AGGCC" };
     std::tie(end_node, found) = graph.get_node(end_kmer);
 
-    auto result = graph.get_paths_between(start_node, end_node, g_test_max_path);
+    auto result = graph.get_paths_between(start_node, end_node, g_test_max_path).first;
 
     DenovoPaths expected_seqs(seqs.begin(), seqs.end());
     EXPECT_EQ(result, expected_seqs);
@@ -201,7 +201,7 @@ TEST(GetPathsBetweenTest, lotsOfHighCovgCyclesReturnEmpty) {
     std::tie(end_node, found) = graph.get_node(end_kmer);
 
 
-    auto actual { graph.get_paths_between(start_node, end_node, max_path_length, expected_coverage) };
+    auto actual { graph.get_paths_between(start_node, end_node, max_path_length, expected_coverage).first };
     DenovoPaths expected;
     remove_graph_file();
 
@@ -225,7 +225,7 @@ TEST(DepthFirstSearchFromTest, SimpleGraphTwoNodesReturnSeqPassedIn) {
     Node end_node;
     std::tie(end_node, found) = graph.get_node(end_kmer);
 
-    auto result = graph.get_paths_between(start_node, end_node, g_test_max_path);
+    auto result = graph.get_paths_between(start_node, end_node, g_test_max_path).first;
 
     EXPECT_EQ(result.size(), 1);
     EXPECT_EQ(*result.begin(), seq);
@@ -249,7 +249,7 @@ TEST(DepthFirstSearchFromTest, SimpleGraphSixNodesReturnSeqPassedIn) {
     Node end_node;
     std::tie(end_node, found) = graph.get_node(end_kmer);
 
-    auto result = graph.get_paths_between(start_node, end_node, g_test_max_path);
+    auto result = graph.get_paths_between(start_node, end_node, g_test_max_path).first;
 
     bool original_seq_found = false;
     // make sure all paths begin and end with correct kmer
@@ -285,7 +285,7 @@ TEST(DepthFirstSearchFromTest, TwoReadsSameSequenceReturnOneSequence) {
     Node end_node;
     std::tie(end_node, found) = graph.get_node(end_kmer);
 
-    auto result = graph.get_paths_between(start_node, end_node, g_test_max_path);
+    auto result = graph.get_paths_between(start_node, end_node, g_test_max_path).first;
 
     EXPECT_EQ(result.size(), 1);
     EXPECT_EQ(*result.begin(), seq1);
@@ -311,7 +311,7 @@ TEST(DepthFirstSearchFromTest, TwoReadsOneVariantReturnOriginalTwoSequences) {
     Node end_node;
     std::tie(end_node, found) = graph.get_node(end_kmer);
 
-    auto result = graph.get_paths_between(start_node, end_node, g_test_max_path);
+    auto result = graph.get_paths_between(start_node, end_node, g_test_max_path).first;
 
     int original_seq_found = 0;
     for (auto &path: result) {
@@ -347,7 +347,7 @@ TEST(DepthFirstSearchFromTest, ThreeReadsTwoVariantsReturnOriginalSequences) {
     Node end_node;
     std::tie(end_node, found) = graph.get_node(end_kmer);
 
-    auto result = graph.get_paths_between(start_node, end_node, g_test_max_path);
+    auto result = graph.get_paths_between(start_node, end_node, g_test_max_path).first;
 
     int original_seq_found = 0;
     for (auto &path: result) {
@@ -384,7 +384,7 @@ TEST(DepthFirstSearchFromTest, TwoReadsTwoVariantsReturnOriginalTwoSequencesPlus
     Node end_node;
     std::tie(end_node, found) = graph.get_node(end_kmer);
 
-    auto result = graph.get_paths_between(start_node, end_node, g_test_max_path);
+    auto result = graph.get_paths_between(start_node, end_node, g_test_max_path).first;
 
     // add other expected paths due to variants
     std::vector<std::string> expected_seqs = { seq1, seq2, "TTGGTGATCCCATTATG", "TTGGTCATCCCGTTATG" };
@@ -417,7 +417,7 @@ TEST(DepthFirstSearchFromTest, ThreeReadsOneReverseComplimentReturnPathsForStran
     Node end_node;
     std::tie(end_node, found) = graph.get_node(end_kmer);
 
-    auto result = graph.get_paths_between(start_node, end_node, g_test_max_path);
+    auto result = graph.get_paths_between(start_node, end_node, g_test_max_path).first;
 
     // add other expected paths due to variants
     const std::string expected_seq = "ATGTGCA";
@@ -447,7 +447,7 @@ TEST(DepthFirstSearchFromTest, SimpleCycleReturnPathsOfLengthsUpToMaxPathLengthC
     Node end_node;
     std::tie(end_node, found) = graph.get_node(end_kmer);
 
-    auto result = graph.get_paths_between(start_node, end_node, g_test_max_path);
+    auto result = graph.get_paths_between(start_node, end_node, g_test_max_path).first;
 
     const std::string min_expected_seq = "ATATAT";
     bool is_in = false;


### PR DESCRIPTION
Firstly, apologies this PR is so big. I didn't realise I already had commits on my fork at hadn't been merged in `dev` so this PR has two main themes.

1. Some optimisations for path enumeration in de novo discovery. Before exploring a node, we check if the shortest path from that node to the end kmer is less or equal to max_path_length - path_accumulator.length(). If it is not, no need to explore this path. 

2. Add a maximum length parameter to the function that finds low coverage intervals for candidate regions. This closes #182 

In addition, I have made separated commits that reformat all files touched by these changes re: #154 