### PR TITLE
Reformat project with `clang-format`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,12 +10,23 @@ include:
         packages:
           - clang-format-8
 
-before_install:
-  - find src/ include/ test/ -type f \( -iname \*.h -o -iname \*.cpp \) | xargs -I _ clang-format -style=file -output-replacements-xml _ | grep -c "<replacement " >/dev/null
-  - if [ $? -ne 1 ]; then echo "Not all source and header files are formatted with clang-format"; exit 1; fi
+jobs:
+  include:
+    - stage: "Lint"                # naming the Tests stage
+      name: "Format"            # names the first Tests stage job
+      script:
+        - find src/ include/ test/ -type f \( -iname \*.h -o -iname \*.cpp \) | xargs -I _ clang-format -style=file -output-replacements-xml _ | grep -c "<replacement " >/dev/null
+        - if [ $? -ne 1 ]; then echo "Not all source and header files are formatted with clang-format"; exit 1; fi
+    - stage: "Build"
+      script: echo "This is where we build Pandora"
+    - stage: "Test"
+      name: "Unit tests"
+      script: echo "This is where we run the unit tests"
 
-script:
-  - bash install.sh
+stages:
+  - "Lint"
+  - "Build"
+  - "Test"
 
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,22 @@
 language: cpp
-compiler: g++
+compiler: gcc
+os: linux
+dist: bionic
+
+include:
+  - os: linux
+    addons:
+      apt:
+        packages:
+          - clang-format-8
 
 before_install:
-- sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
-- sudo apt-get update -qq
-
-install:
-- sudo apt-get install -qq g++-4.8
-- export CXX="g++-4.8"
+  - find src/ include/ test/ -type f \( -iname \*.h -o -iname \*.cpp \) | xargs -I _ clang-format -style=file -output-replacements-xml _ | grep -c "<replacement " >/dev/null
+  - if [ $? -ne 1 ]; then echo "Not all source and header files are formatted with clang-format"; exit 1 fi
 
 script:
   - bash install.sh
 
 notifications:
   email: false
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,11 +22,15 @@ jobs:
     - stage: "Test"
       name: "Unit tests"
       script: echo "This is where we run the unit tests"
+    - stage: "Deploy"
+      name: "DockerHub"
+      script: echo "This is where we deploy a container to Docker Hub"
 
 stages:
   - "Lint"
   - "Build"
   - "Test"
+  - "Deploy"
 
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ include:
 
 before_install:
   - find src/ include/ test/ -type f \( -iname \*.h -o -iname \*.cpp \) | xargs -I _ clang-format -style=file -output-replacements-xml _ | grep -c "<replacement " >/dev/null
-  - if [ $? -ne 1 ]; then echo "Not all source and header files are formatted with clang-format"; exit 1 fi
+  - if [ $? -ne 1 ]; then echo "Not all source and header files are formatted with clang-format"; exit 1; fi
 
 script:
   - bash install.sh

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,7 +32,7 @@ if (${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
 else ()
     find_package(OpenMP 4.0 REQUIRED)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fopenmp")
-endif()
+endif ()
 
 #print CMAKE debug and release flags to know what we are exactly doing
 #message("CMAKE_CXX_FLAGS_DEBUG is ${CMAKE_CXX_FLAGS_DEBUG}")
@@ -82,8 +82,7 @@ target_link_libraries(${PROJECT_NAME}
         ${ZLIB_LIBRARY})
 
 
-
-if(BUILD_COMPARE_INDEXES)
+if (BUILD_COMPARE_INDEXES)
     #Build compare_indexes
     set(SRC_FILES_COMPARE_INDEXES ${SRC_FILES})
     list(REMOVE_ITEM SRC_FILES_COMPARE_INDEXES ${PROJECT_SOURCE_DIR}/src/main.cpp)
@@ -100,7 +99,7 @@ if(BUILD_COMPARE_INDEXES)
             ${EXTERNAL_LIBS}
             ${CMAKE_DL_LIBS}
             ${ZLIB_LIBRARY})
-endif(BUILD_COMPARE_INDEXES)
+endif (BUILD_COMPARE_INDEXES)
 
 
 enable_testing()

--- a/include/de_bruijn/graph.h
+++ b/include/de_bruijn/graph.h
@@ -1,30 +1,30 @@
-#ifndef __DBGRAPH_H_INCLUDED__   // if de_bruijn/graph.h hasn't been included yet...
+#ifndef __DBGRAPH_H_INCLUDED__ // if de_bruijn/graph.h hasn't been included yet...
 #define __DBGRAPH_H_INCLUDED__
 
+#include "de_bruijn/node.h"
+#include "de_bruijn/ns.cpp"
 #include <cstdint>
 #include <deque>
+#include <iostream>
 #include <memory>
+#include <set>
 #include <unordered_map>
 #include <unordered_set>
-#include <set>
-#include <iostream>
-#include "de_bruijn/ns.cpp"
-#include "de_bruijn/node.h"
-
 
 class debruijn::Graph {
 protected:
     uint32_t next_id;
+
 public:
     uint8_t size;
-    sequence_of_genes_to_data_map <std::deque<uint_least32_t>, uint32_t> node_hash;
+    sequence_of_genes_to_data_map<std::deque<uint_least32_t>, uint32_t> node_hash;
     std::unordered_map<uint32_t, NodePtr> nodes;
 
     Graph(uint8_t);
 
     ~Graph();
 
-    OrientedNodePtr add_node(const std::deque<uint_least32_t> &, uint32_t);
+    OrientedNodePtr add_node(const std::deque<uint_least32_t>&, uint32_t);
 
     void add_edge(OrientedNodePtr, OrientedNodePtr);
 
@@ -38,17 +38,17 @@ public:
 
     std::set<std::deque<uint32_t>> get_unitigs();
 
-    void extend_unitig(std::deque<uint32_t> &);
+    void extend_unitig(std::deque<uint32_t>&);
 
     bool found_in_out_nodes(const NodePtr, const NodePtr) const;
 
     bool found_in_in_nodes(const NodePtr, const NodePtr) const;
 
-    bool operator==(const Graph &y) const;
+    bool operator==(const Graph& y) const;
 
-    bool operator!=(const Graph &y) const;
+    bool operator!=(const Graph& y) const;
 
-    friend std::ostream &operator<<(std::ostream &, const Graph &);
+    friend std::ostream& operator<<(std::ostream&, const Graph&);
 };
 
 #endif

--- a/include/de_bruijn/node.h
+++ b/include/de_bruijn/node.h
@@ -1,12 +1,11 @@
-#ifndef __DBNODE_H_INCLUDED__   // if de_bruijn/node.h hasn't been included yet...
+#ifndef __DBNODE_H_INCLUDED__ // if de_bruijn/node.h hasn't been included yet...
 #define __DBNODE_H_INCLUDED__
 
+#include "de_bruijn/ns.cpp"
 #include <cstdint>
 #include <deque>
-#include <unordered_set>
 #include <memory>
-#include "de_bruijn/ns.cpp"
-
+#include <unordered_set>
 
 class debruijn::Node {
 public:
@@ -16,13 +15,13 @@ public:
     std::unordered_set<uint32_t> out_nodes;
     std::unordered_set<uint32_t> in_nodes;
 
-    Node(const uint32_t, const std::deque<uint_least32_t> &, const uint32_t);
+    Node(const uint32_t, const std::deque<uint_least32_t>&, const uint32_t);
 
-    bool operator==(const Node &y) const;
+    bool operator==(const Node& y) const;
 
-    bool operator!=(const Node &y) const;
+    bool operator!=(const Node& y) const;
 
-    friend std::ostream &operator<<(std::ostream &, const Node &);
+    friend std::ostream& operator<<(std::ostream&, const Node&);
 };
 
 #endif

--- a/include/denovo_discovery/denovo_utils.h
+++ b/include/denovo_discovery/denovo_utils.h
@@ -1,29 +1,27 @@
 #ifndef __EXTRACT_READS_H_INCLUDED__
 #define __EXTRACT_READS_H_INCLUDED__
 
-#include <set>
-#include <algorithm>
-#include <memory>
-#include <cassert>
-#include <utility>
-#include <vector>
-#include "localnode.h"
-#include "minihits.h"
 #include "denovo_discovery/local_assembly.h"
+#include "fastaq.h"
+#include "fastaq_handler.h"
 #include "interval.h"
+#include "localPRG.h"
+#include "localnode.h"
 #include "minihit.h"
+#include "minihits.h"
 #include "pangenome/ns.cpp"
 #include "pangenome/pannode.h"
 #include "pangenome/panread.h"
-#include "localPRG.h"
-#include "fastaq_handler.h"
-#include "fastaq.h"
-#include "utils.h"
 #include "prg/path.h"
-
+#include "utils.h"
+#include <algorithm>
+#include <cassert>
+#include <memory>
+#include <set>
+#include <utility>
+#include <vector>
 
 using PanNodePtr = std::shared_ptr<pangenome::Node>;
-
 
 struct ReadCoordinate {
     uint32_t id;
@@ -33,21 +31,18 @@ struct ReadCoordinate {
 
     ReadCoordinate(uint32_t id, uint32_t start, uint32_t end, bool is_forward);
 
-    bool operator<(const ReadCoordinate &y) const;
+    bool operator<(const ReadCoordinate& y) const;
 
-    bool operator==(const ReadCoordinate &y) const;
+    bool operator==(const ReadCoordinate& y) const;
 
-    bool operator!=(const ReadCoordinate &y) const;
+    bool operator!=(const ReadCoordinate& y) const;
 
-    friend std::ostream &operator<<(std::ostream &, ReadCoordinate const &);
+    friend std::ostream& operator<<(std::ostream&, ReadCoordinate const&);
 };
 
-
-template<>
-struct std::hash<ReadCoordinate> {
-    size_t operator()(const ReadCoordinate &coordinate) const;
+template <> struct std::hash<ReadCoordinate> {
+    size_t operator()(const ReadCoordinate& coordinate) const;
 };
-
 
 struct PathComponents {
     prg::Path flank_left;
@@ -58,16 +53,15 @@ struct PathComponents {
 
     PathComponents(prg::Path flank_left, prg::Path slice, prg::Path flank_right);
 
-    bool operator==(const PathComponents &other) const;
+    bool operator==(const PathComponents& other) const;
 
-    bool operator!=(const PathComponents &other) const;
+    bool operator!=(const PathComponents& other) const;
 };
 
+PathComponents find_interval_and_flanks_in_localpath(const Interval& interval,
+    const std::vector<LocalNodePtr>& local_node_max_likelihood_path);
 
-PathComponents find_interval_and_flanks_in_localpath(const Interval &interval,
-                                                     const std::vector<LocalNodePtr> &local_node_max_likelihood_path);
-
-std::vector<MinimizerHitPtr>
-find_hits_inside_path(const std::vector<MinimizerHitPtr> &read_hits, const prg::Path &local_path);
+std::vector<MinimizerHitPtr> find_hits_inside_path(
+    const std::vector<MinimizerHitPtr>& read_hits, const prg::Path& local_path);
 
 #endif

--- a/include/estimate_parameters.h
+++ b/include/estimate_parameters.h
@@ -5,6 +5,7 @@
 #include <boost/filesystem.hpp>
 #include <cstdint>
 #include <cstring>
+#include <pangenome/pangraph.h>
 
 namespace fs = boost::filesystem;
 

--- a/include/estimate_parameters.h
+++ b/include/estimate_parameters.h
@@ -1,25 +1,24 @@
-#ifndef __ESTIMATEPARAMETERS_H_INCLUDED__   // if estimate_parameters.h hasn't been included yet...
+#ifndef __ESTIMATEPARAMETERS_H_INCLUDED__ // if estimate_parameters.h hasn't been
+                                          // included yet...
 #define __ESTIMATEPARAMETERS_H_INCLUDED__
 
-#include <cstring>
-#include <cstdint>
 #include <boost/filesystem.hpp>
-
+#include <cstdint>
+#include <cstring>
 
 namespace fs = boost::filesystem;
 
-double fit_mean_covg(const std::vector<uint32_t> &, const uint8_t);
+double fit_mean_covg(const std::vector<uint32_t>&, const uint8_t);
 
-double fit_variance_covg(const std::vector<uint32_t> &, double &, const uint8_t);
+double fit_variance_covg(const std::vector<uint32_t>&, double&, const uint8_t);
 
-void fit_negative_binomial(double &, double &, float &, float &);
+void fit_negative_binomial(double&, double&, float&, float&);
 
-uint32_t find_mean_covg(std::vector<uint32_t> &);
+uint32_t find_mean_covg(std::vector<uint32_t>&);
 
-int find_prob_thresh(std::vector<uint32_t> &);
+int find_prob_thresh(std::vector<uint32_t>&);
 
-uint32_t estimate_parameters(std::shared_ptr<pangenome::Graph>, const std::string &, const uint32_t, float &,
-                         const uint32_t,
-                         bool &bin, const uint32_t &sample_id);
+uint32_t estimate_parameters(std::shared_ptr<pangenome::Graph>, const std::string&,
+    const uint32_t, float&, const uint32_t, bool& bin, const uint32_t& sample_id);
 
 #endif

--- a/include/fastaq.h
+++ b/include/fastaq.h
@@ -1,11 +1,10 @@
-#ifndef __FASTAQ_H_INCLUDED__   // if fastaq.h hasn't been included yet...
+#ifndef __FASTAQ_H_INCLUDED__ // if fastaq.h hasn't been included yet...
 #define __FASTAQ_H_INCLUDED__
 
-#include <vector>
-#include <unordered_map>
-#include <iostream>
 #include <cmath>
-
+#include <iostream>
+#include <unordered_map>
+#include <vector>
 
 struct Fastaq {
     bool gzipped;
@@ -17,26 +16,28 @@ struct Fastaq {
 
     Fastaq(bool gz = false, bool fq = false);
 
-    char covg_to_score(const uint_least16_t &, const uint_least16_t &, const bool &alt = false);
+    char covg_to_score(
+        const uint_least16_t&, const uint_least16_t&, const bool& alt = false);
 
-    char alt_covg_to_score(const uint_least16_t &covg);
+    char alt_covg_to_score(const uint_least16_t& covg);
 
-    void add_entry(const std::string &, const std::string &, const std::vector<uint32_t> &,
-                   const uint_least16_t, const std::string header = "");
+    void add_entry(const std::string&, const std::string&, const std::vector<uint32_t>&,
+        const uint_least16_t, const std::string header = "");
 
-    void add_entry(const std::string &, const std::string &, const std::string header = "");
+    void add_entry(
+        const std::string&, const std::string&, const std::string header = "");
 
     void clear();
 
-    void save(const std::string &);
+    void save(const std::string&);
 
-    bool operator==(const Fastaq &y) const;
+    bool operator==(const Fastaq& y) const;
 
-    bool operator!=(const Fastaq &y) const;
+    bool operator!=(const Fastaq& y) const;
 
-    friend std::ostream &operator<<(std::ostream &out, const Fastaq &m);
+    friend std::ostream& operator<<(std::ostream& out, const Fastaq& m);
 
-    friend std::istream &operator>>(std::istream &in, Fastaq &m);
+    friend std::istream& operator>>(std::istream& in, Fastaq& m);
 };
 
 #endif

--- a/include/fastaq_handler.h
+++ b/include/fastaq_handler.h
@@ -1,14 +1,13 @@
-#ifndef __FASTAQ_HANDLER_H_INCLUDED__   // if fastaq_handler.h hasn't been included yet...
+#ifndef __FASTAQ_HANDLER_H_INCLUDED__ // if fastaq_handler.h hasn't been included yet...
 #define __FASTAQ_HANDLER_H_INCLUDED__
 
-#include <string>
-#include <cstdint>
-#include <fstream>
 #include <boost/iostreams/filtering_streambuf.hpp>
 #include <boost/log/core.hpp>
-#include <boost/log/trivial.hpp>
 #include <boost/log/expressions.hpp>
-
+#include <boost/log/trivial.hpp>
+#include <cstdint>
+#include <fstream>
+#include <string>
 
 namespace logging = boost::log;
 
@@ -22,7 +21,7 @@ struct FastaqHandler {
     std::string read;
     uint32_t num_reads_parsed;
 
-    FastaqHandler(const std::string &);
+    FastaqHandler(const std::string&);
 
     ~FastaqHandler();
 
@@ -32,7 +31,7 @@ struct FastaqHandler {
 
     void skip_next();
 
-    void get_id(const uint32_t &);
+    void get_id(const uint32_t&);
 
     void close();
 };

--- a/include/index.h
+++ b/include/index.h
@@ -1,49 +1,48 @@
-#ifndef __INDEX_H_INCLUDED__   // if index.h hasn't been included yet...
+#ifndef __INDEX_H_INCLUDED__ // if index.h hasn't been included yet...
 #define __INDEX_H_INCLUDED__
 
-#include <cstring>
-#include <cstdint>
-#include <vector>
-#include <unordered_map>
-#include <memory>
 #include "minirecord.h"
 #include "prg/path.h"
 #include "utils.h"
-
+#include <cstdint>
+#include <cstring>
+#include <memory>
+#include <unordered_map>
+#include <vector>
 
 class Index {
 public:
-    std::unordered_map<uint64_t, std::vector<MiniRecord> *> minhash; //map of minimizers to MiniRecords - for each minimizer, records some information of it
+    std::unordered_map<uint64_t, std::vector<MiniRecord>*>
+        minhash; // map of minimizers to MiniRecords - for each minimizer, records some
+                 // information of it
 
-    //declares all default constructors, destructors and assignment operators explicitly
-    Index() = default; //default constructor
-    Index(const Index &other) = default; //copy default constructor
-    Index(Index &&other) = default; //move default constructor
-    Index& operator=(const Index& other) = default; //copy assignment operator
-    Index& operator=(Index&& other) = default; //move assignment operator
-    virtual ~Index() = default; //destructor
+    // declares all default constructors, destructors and assignment operators
+    // explicitly
+    Index() = default; // default constructor
+    Index(const Index& other) = default; // copy default constructor
+    Index(Index&& other) = default; // move default constructor
+    Index& operator=(const Index& other) = default; // copy assignment operator
+    Index& operator=(Index&& other) = default; // move assignment operator
+    virtual ~Index() = default; // destructor
 
-    void add_record(const uint64_t, const uint32_t, const prg::Path &, const uint32_t, const bool);
+    void add_record(
+        const uint64_t, const uint32_t, const prg::Path&, const uint32_t, const bool);
 
-    void save(const std::string &prgfile, uint32_t w, uint32_t k);
+    void save(const std::string& prgfile, uint32_t w, uint32_t k);
 
-    void save(const std::string &indexfile);
+    void save(const std::string& indexfile);
 
-    void load(const std::string &prgfile, uint32_t w, uint32_t k);
+    void load(const std::string& prgfile, uint32_t w, uint32_t k);
 
-    void load(const std::string &indexfile);
+    void load(const std::string& indexfile);
 
     void clear();
 
-    bool operator==(const Index &other) const;
+    bool operator==(const Index& other) const;
 
-    bool operator!=(const Index &other) const;
+    bool operator!=(const Index& other) const;
 };
 
-void index_prgs(std::vector<std::shared_ptr<LocalPRG>> &,
-                std::shared_ptr<Index> &,
-                const uint32_t,
-                const uint32_t,
-                const std::string &,
-                uint32_t threads=1);
+void index_prgs(std::vector<std::shared_ptr<LocalPRG>>&, std::shared_ptr<Index>&,
+    const uint32_t, const uint32_t, const std::string&, uint32_t threads = 1);
 #endif

--- a/include/interval.h
+++ b/include/interval.h
@@ -1,28 +1,27 @@
-#ifndef __INTERVAL_H_INCLUDED__   // if interval.h hasn't been included yet...
+#ifndef __INTERVAL_H_INCLUDED__ // if interval.h hasn't been included yet...
 #define __INTERVAL_H_INCLUDED__
 
 #include <cstdint>
 #include <iostream>
 
-
 struct Interval {
     uint32_t start;
     uint32_t length;
-    //in pilot, longest prg was 208,562 characters long
+    // in pilot, longest prg was 208,562 characters long
 
-    Interval(uint32_t= 0, uint32_t= 0);
+    Interval(uint32_t = 0, uint32_t = 0);
 
     uint32_t get_end() const;
 
-    friend std::ostream &operator<<(std::ostream &out, const Interval &i);
+    friend std::ostream& operator<<(std::ostream& out, const Interval& i);
 
-    friend std::istream &operator>>(std::istream &in, Interval &i);
+    friend std::istream& operator>>(std::istream& in, Interval& i);
 
-    bool operator==(const Interval &y) const;
+    bool operator==(const Interval& y) const;
 
-    bool operator!=(const Interval &y) const;
+    bool operator!=(const Interval& y) const;
 
-    bool operator<(const Interval &y) const;
+    bool operator<(const Interval& y) const;
 
     bool empty() const;
 };

--- a/include/inthash.h
+++ b/include/inthash.h
@@ -1,21 +1,22 @@
-#ifndef __INTHASH_H_INCLUDED__   // if inthash.h hasn't been included yet...
+#ifndef __INTHASH_H_INCLUDED__ // if inthash.h hasn't been included yet...
 #define __INTHASH_H_INCLUDED__
 
-#include <cstring>
 #include <cstdint>
+#include <cstring>
 #include <unordered_map>
-
 
 uint32_t nt4(char);
 
-uint64_t hash64(uint64_t key, const uint64_t &mask);
+uint64_t hash64(uint64_t key, const uint64_t& mask);
 
 void test_table();
 
 class KmerHash {
-    std::unordered_map<std::string, std::pair<uint64_t, uint64_t>> lookup; //TODO: replace by GATB's MPHF? -> Hashes a string to two values due to forward and RC
+    std::unordered_map<std::string, std::pair<uint64_t, uint64_t>>
+        lookup; // TODO: replace by GATB's MPHF? -> Hashes a string to two values due to
+                // forward and RC
 public:
-    std::pair<uint64_t, uint64_t> kmerhash(const std::string &s, const uint32_t k);
+    std::pair<uint64_t, uint64_t> kmerhash(const std::string& s, const uint32_t k);
 };
 
 #endif

--- a/include/kmergraph.h
+++ b/include/kmergraph.h
@@ -1,21 +1,20 @@
-#ifndef __KMERGRAPH_H_INCLUDED__   // if kmergraph.h hasn't been included yet...
+#ifndef __KMERGRAPH_H_INCLUDED__ // if kmergraph.h hasn't been included yet...
 #define __KMERGRAPH_H_INCLUDED__
 
 class LocalPRG;
 
-#include <cstdint>
-#include <vector>
-#include <iostream>
-#include <set>
-#include "prg/path.h"
 #include "kmernode.h"
 #include "pangenome/ns.cpp"
-
+#include "prg/path.h"
+#include <cstdint>
+#include <iostream>
+#include <set>
+#include <vector>
 
 struct condition {
     prg::Path q;
 
-    condition(const prg::Path &);
+    condition(const prg::Path&);
 
     bool operator()(const KmerNodePtr) const;
 };
@@ -23,7 +22,6 @@ struct condition {
 struct pCompKmerNode {
     bool operator()(KmerNodePtr, KmerNodePtr);
 };
-
 
 class KmerGraph {
 private:
@@ -33,21 +31,23 @@ private:
 public:
     uint32_t shortest_path_length;
     std::vector<KmerNodePtr> nodes;
-    std::set<KmerNodePtr, pCompKmerNode> sorted_nodes; // representing ordering of the nodes compatible with dp
+    std::set<KmerNodePtr, pCompKmerNode>
+        sorted_nodes; // representing ordering of the nodes compatible with dp
 
     KmerGraph();
 
-    KmerGraph(const KmerGraph &);
+    KmerGraph(const KmerGraph&);
 
-    KmerGraph &operator=(const KmerGraph &);
+    KmerGraph& operator=(const KmerGraph&);
 
     virtual ~KmerGraph() = default;
 
     void clear();
 
-    KmerNodePtr add_node(const prg::Path &);
+    KmerNodePtr add_node(const prg::Path&);
 
-    KmerNodePtr add_node_with_kh(const prg::Path &, const uint64_t &, const uint8_t &num = 0);
+    KmerNodePtr add_node_with_kh(
+        const prg::Path&, const uint64_t&, const uint8_t& num = 0);
 
     void add_edge(KmerNodePtr, KmerNodePtr);
 
@@ -59,19 +59,18 @@ public:
 
     uint32_t min_path_length();
 
-    void save(const std::string &, const std::shared_ptr<LocalPRG> = nullptr);
-    void load(const std::string &);
+    void save(const std::string&, const std::shared_ptr<LocalPRG> = nullptr);
+    void load(const std::string&);
 
-    bool operator==(const KmerGraph &other_graph) const;
+    bool operator==(const KmerGraph& other_graph) const;
 
-    friend std::ostream &operator<<(std::ostream &out, KmerGraph const &data);
+    friend std::ostream& operator<<(std::ostream& out, KmerGraph const& data);
 
-    friend uint32_t
-    estimate_parameters(std::shared_ptr<pangenome::Graph>, const std::string &, const uint32_t, float &, const uint32_t,
-                        bool &, const uint32_t &sample_id);
+    friend uint32_t estimate_parameters(std::shared_ptr<pangenome::Graph>,
+        const std::string&, const uint32_t, float&, const uint32_t, bool&,
+        const uint32_t& sample_id);
 
-
-    //friends
+    // friends
     friend struct condition;
     friend class KmerGraphWithCoverage;
 

--- a/include/kmergraphwithcoverage.h
+++ b/include/kmergraphwithcoverage.h
@@ -8,6 +8,7 @@ class LocalPRG;
 #include "kmernode.h"
 #include "pangenome/ns.cpp"
 #include "prg/path.h"
+#include <cassert>
 #include <cstdint>
 #include <iostream>
 #include <vector>

--- a/include/kmergraphwithcoverage.h
+++ b/include/kmergraphwithcoverage.h
@@ -1,28 +1,33 @@
-#ifndef __KMERGRAPHWITHCOVERAGE_H_INCLUDED__   // if kmergraphwithcoverage.h hasn't been included yet...
+#ifndef __KMERGRAPHWITHCOVERAGE_H_INCLUDED__ // if kmergraphwithcoverage.h hasn't been
+                                             // included yet...
 #define __KMERGRAPHWITHCOVERAGE_H_INCLUDED__
 
 class LocalPRG;
 
-#include <cstdint>
-#include <vector>
-#include <iostream>
-#include "prg/path.h"
-#include "kmernode.h"
 #include "kmergraph.h"
+#include "kmernode.h"
 #include "pangenome/ns.cpp"
+#include "prg/path.h"
+#include <cstdint>
+#include <iostream>
+#include <vector>
 
 /**
- * Represents an annotated KmerGraph, where the annotation is only the coverage on the nodes
- * This is more lightweight than copying a whole k-mer graph and changing the coverage of each node
+ * Represents an annotated KmerGraph, where the annotation is only the coverage on the
+ * nodes This is more lightweight than copying a whole k-mer graph and changing the
+ * coverage of each node
  * TODO: generalize it to general annotations?
- * NOTE: representing as composition instead of inheritance because one KmerGraph can be referenced by several KmerGraphWithCoverage,
- * thus KmerGraph's life cycle does not depend on KmerGraphWithCoverage's life cycle
+ * NOTE: representing as composition instead of inheritance because one KmerGraph can be
+ * referenced by several KmerGraphWithCoverage, thus KmerGraph's life cycle does not
+ * depend on KmerGraphWithCoverage's life cycle
  */
 class KmerGraphWithCoverage {
 private:
-    //each coverage is represented as a std::vector, each position of the vector representing the coverage of a sample
-    //each coverage of a sample is represented by a std::pair, for the forward and reverse reads coverage of that sample
-    std::vector<std::vector<std::pair<uint16_t, uint16_t>>> node_index_to_sample_coverage;
+    // each coverage is represented as a std::vector, each position of the vector
+    // representing the coverage of a sample each coverage of a sample is represented by
+    // a std::pair, for the forward and reverse reads coverage of that sample
+    std::vector<std::vector<std::pair<uint16_t, uint16_t>>>
+        node_index_to_sample_coverage;
     uint32_t exp_depth_covg;
     float binomial_parameter_p;
     float negative_binomial_parameter_p;
@@ -32,85 +37,103 @@ private:
     uint32_t num_reads;
 
 public:
-    KmerGraph * kmer_prg; //the underlying KmerGraph - TODO: it is dangerous to leave this public, make it private? - this should be const
+    KmerGraph* kmer_prg; // the underlying KmerGraph - TODO: it is dangerous to leave
+                         // this public, make it private? - this should be const
 
-    //constructor, destructors, etc
-    KmerGraphWithCoverage(KmerGraph * kmer_prg, uint32_t total_number_samples=1) :
-            node_index_to_sample_coverage(kmer_prg->nodes.size()),
-            exp_depth_covg{0}, binomial_parameter_p{1}, negative_binomial_parameter_p{0.015}, negative_binomial_parameter_r{2}, thresh{-25}, total_number_samples{total_number_samples}, num_reads{0}, kmer_prg{kmer_prg} {
+    // constructor, destructors, etc
+    KmerGraphWithCoverage(KmerGraph* kmer_prg, uint32_t total_number_samples = 1)
+        : node_index_to_sample_coverage(kmer_prg->nodes.size())
+        , exp_depth_covg { 0 }
+        , binomial_parameter_p { 1 }
+        , negative_binomial_parameter_p { 0.015 }
+        , negative_binomial_parameter_r { 2 }
+        , thresh { -25 }
+        , total_number_samples { total_number_samples }
+        , num_reads { 0 }
+        , kmer_prg { kmer_prg }
+    {
         assert(kmer_prg != nullptr);
         zeroCoverages();
     }
-    KmerGraphWithCoverage(const KmerGraphWithCoverage &other) = default; //copy default constructor
-    KmerGraphWithCoverage(KmerGraphWithCoverage &&other) = default; //move default constructor
-    KmerGraphWithCoverage& operator=(const KmerGraphWithCoverage& other) = default; //copy assignment operator
-    KmerGraphWithCoverage& operator=(KmerGraphWithCoverage&& other) = default; //move assignment operator
+    KmerGraphWithCoverage(const KmerGraphWithCoverage& other)
+        = default; // copy default constructor
+    KmerGraphWithCoverage(KmerGraphWithCoverage&& other)
+        = default; // move default constructor
+    KmerGraphWithCoverage& operator=(const KmerGraphWithCoverage& other)
+        = default; // copy assignment operator
+    KmerGraphWithCoverage& operator=(KmerGraphWithCoverage&& other)
+        = default; // move assignment operator
     virtual ~KmerGraphWithCoverage() = default;
 
-    //getters
+    // getters
     /*
-    TODO: we should return a uint16_t instead of a uint32_t, but I did not want to change the interface, as it can be dangerous
-    WARNING: some parts of the code accumulates under the type of this return value,
-                     so it might be dangerous to change to uint16_t without careful analysis.
-             e.g.: I can see summing a bunch of coverage and potentially getting a value larger than 65535,
-                     which would incur overflow and bugs.
-    NOTE: converting uint16_t to uint32_t is safe anyway, so it is fine to leave like this
-    NOTE: the advantage of returning a uint16_t here is a negligible improvement in RAM usage, so I don't think it is
-             worth the risk now
+    TODO: we should return a uint16_t instead of a uint32_t, but I did not want to
+    change the interface, as it can be dangerous WARNING: some parts of the code
+    accumulates under the type of this return value, so it might be dangerous to change
+    to uint16_t without careful analysis. e.g.: I can see summing a bunch of coverage
+    and potentially getting a value larger than 65535, which would incur overflow and
+    bugs. NOTE: converting uint16_t to uint32_t is safe anyway, so it is fine to leave
+    like this NOTE: the advantage of returning a uint16_t here is a negligible
+    improvement in RAM usage, so I don't think it is worth the risk now
     TODO: leaving return type as uint32_t to be safe for now, need a recheck later
      */
     uint32_t get_covg(uint32_t node_id, bool is_forward, uint32_t sample_id) const;
     uint32_t get_num_reads() const { return num_reads; }
-    uint32_t get_total_number_samples() const {return total_number_samples; }
+    uint32_t get_total_number_samples() const { return total_number_samples; }
 
-    //setters
+    // setters
     void increment_covg(uint32_t node_id, bool is_forward, uint32_t sample_id);
-    void set_covg(uint32_t node_id, uint16_t value, bool is_forward, uint32_t sample_id);
+    void set_covg(
+        uint32_t node_id, uint16_t value, bool is_forward, uint32_t sample_id);
     void set_exp_depth_covg(const uint32_t);
     void set_binomial_parameter_p(const float);
-    void set_negative_binomial_parameters(const float &, const float &);
-    void set_thresh (int thresh) { this->thresh = thresh; }
+    void set_negative_binomial_parameters(const float&, const float&);
+    void set_thresh(int thresh) { this->thresh = thresh; }
     void set_num_reads(uint32_t num_reads) { this->num_reads = num_reads; }
 
-    void zeroCoverages() {
-        for (auto &sampleCoverage: node_index_to_sample_coverage) {
-            sampleCoverage = std::vector<std::pair<uint16_t, uint16_t>>(total_number_samples);
-            sampleCoverage.shrink_to_fit(); //tries to make this information as compact as possible (TODO: use sdsl?)
+    void zeroCoverages()
+    {
+        for (auto& sampleCoverage : node_index_to_sample_coverage) {
+            sampleCoverage
+                = std::vector<std::pair<uint16_t, uint16_t>>(total_number_samples);
+            sampleCoverage.shrink_to_fit(); // tries to make this information as compact
+                                            // as possible (TODO: use sdsl?)
         }
-
     }
 
-    float nbin_prob(uint32_t, const uint32_t &sample_id);
+    float nbin_prob(uint32_t, const uint32_t& sample_id);
 
-    float lin_prob(uint32_t, const uint32_t &sample_id);
+    float lin_prob(uint32_t, const uint32_t& sample_id);
 
-    float bin_prob(uint32_t, const uint32_t &sample_id);
+    float bin_prob(uint32_t, const uint32_t& sample_id);
 
-    float bin_prob(const uint32_t &, const uint32_t &, const uint32_t &sample_id);
+    float bin_prob(const uint32_t&, const uint32_t&, const uint32_t& sample_id);
 
-    float get_prob(const std::string& prob_model, const uint32_t &node_id, const uint32_t &sample_id);
+    float get_prob(const std::string& prob_model, const uint32_t& node_id,
+        const uint32_t& sample_id);
 
     bool coverage_is_zeroes(const uint32_t&);
 
-    float find_max_path(std::vector<KmerNodePtr> &maxpath, const std::string& prob_model,
-                        const uint32_t &max_num_kmers_to_average, const uint32_t &sample_id);
+    float find_max_path(std::vector<KmerNodePtr>& maxpath,
+        const std::string& prob_model, const uint32_t& max_num_kmers_to_average,
+        const uint32_t& sample_id);
 
-    std::vector<std::vector<KmerNodePtr>> find_max_paths(uint32_t, const uint32_t &sample_id);
+    std::vector<std::vector<KmerNodePtr>> find_max_paths(
+        uint32_t, const uint32_t& sample_id);
 
-    void save_covg_dist(const std::string &);
+    void save_covg_dist(const std::string&);
 
     std::vector<std::vector<KmerNodePtr>> get_random_paths(uint32_t);
 
-    float prob_path(const std::vector<KmerNodePtr> &kpath, const uint32_t &sample_id, const std::string& prob_model);
+    float prob_path(const std::vector<KmerNodePtr>& kpath, const uint32_t& sample_id,
+        const std::string& prob_model);
 
-    float prob_paths(const std::vector<std::vector<KmerNodePtr>> &);
+    float prob_paths(const std::vector<std::vector<KmerNodePtr>>&);
 
+    void save(const std::string&, const std::shared_ptr<LocalPRG> = nullptr);
+    void load(const std::string&);
 
-    void save(const std::string &, const std::shared_ptr<LocalPRG> = nullptr);
-    void load(const std::string &);
-
-
-    //test friends
+    // test friends
     friend class KmerGraphWithCoverageTest_set_exp_depth_covg_Test;
     friend class KmerGraphWithCoverageTest_set_p_Test;
     friend class KmerGraphWithCoverageTest_set_nb_Test;

--- a/include/kmernode.h
+++ b/include/kmernode.h
@@ -1,79 +1,88 @@
-#ifndef __KMERNODE_H_INCLUDED__   // if kmernode.h hasn't been included yet...
+#ifndef __KMERNODE_H_INCLUDED__ // if kmernode.h hasn't been included yet...
 #define __KMERNODE_H_INCLUDED__
 
 class KmerNode;
 
-#include <cstring>
-#include <cstdint>
-#include <vector>
-#include <ostream>
-#include <memory>
 #include <algorithm>
+#include <cstdint>
+#include <cstring>
+#include <memory>
+#include <ostream>
+#include <vector>
 
-#include "prg/path.h"
 #include "pangenome/ns.cpp"
-
+#include "prg/path.h"
 
 typedef std::shared_ptr<KmerNode> KmerNodePtr;
 typedef std::weak_ptr<KmerNode> WeakKmerNodePtr;
 
-class KmerNode { //represent a kmer-minimizer in the KmerGraph
+class KmerNode { // represent a kmer-minimizer in the KmerGraph
 private:
-    //finder helpers
-    std::vector<WeakKmerNodePtr>::const_iterator findNodePtrInNodesVector(const std::vector<WeakKmerNodePtr> &nodesVector, const KmerNodePtr &rhs) const {
-        return find_if(nodesVector.begin(), nodesVector.end(), [&rhs](const WeakKmerNodePtr &lhs) {
-            return lhs.lock() == rhs;
-        });
+    // finder helpers
+    std::vector<WeakKmerNodePtr>::const_iterator findNodePtrInNodesVector(
+        const std::vector<WeakKmerNodePtr>& nodesVector, const KmerNodePtr& rhs) const
+    {
+        return find_if(nodesVector.begin(), nodesVector.end(),
+            [&rhs](const WeakKmerNodePtr& lhs) { return lhs.lock() == rhs; });
     }
-    std::vector<WeakKmerNodePtr>::const_iterator findNodeInNodesVector(const std::vector<WeakKmerNodePtr> &nodesVector, const KmerNode &rhs) const {
-        return find_if(nodesVector.begin(), nodesVector.end(), [&rhs](const WeakKmerNodePtr &lhs) {
-            return *(lhs.lock()) == rhs;
-        });
+    std::vector<WeakKmerNodePtr>::const_iterator findNodeInNodesVector(
+        const std::vector<WeakKmerNodePtr>& nodesVector, const KmerNode& rhs) const
+    {
+        return find_if(nodesVector.begin(), nodesVector.end(),
+            [&rhs](const WeakKmerNodePtr& lhs) { return *(lhs.lock()) == rhs; });
     }
-    //finder helpers
-
-
+    // finder helpers
 
 public:
-    //attributes (TODO: protect these? only this class should operate in these attributes, move logic that change them to here?)
+    // attributes (TODO: protect these? only this class should operate in these
+    // attributes, move logic that change them to here?)
     uint32_t id;
-    prg::Path path; //the path of the kmer in the LocalPRG
-    std::vector<WeakKmerNodePtr> out_nodes; // representing edges from this node to the nodes in the vector
-    std::vector<WeakKmerNodePtr> in_nodes; // representing edges from other nodes to this node
-    uint64_t khash; //the kmer hash value
+    prg::Path path; // the path of the kmer in the LocalPRG
+    std::vector<WeakKmerNodePtr>
+        out_nodes; // representing edges from this node to the nodes in the vector
+    std::vector<WeakKmerNodePtr>
+        in_nodes; // representing edges from other nodes to this node
+    uint64_t khash; // the kmer hash value
     uint8_t num_AT; // the number of As and Ts in this kmer
 
-    //finders of nodes in out/in nodes lists
-    std::vector<WeakKmerNodePtr>::const_iterator find_node_ptr_in_out_nodes(const KmerNodePtr &rhs) const {
+    // finders of nodes in out/in nodes lists
+    std::vector<WeakKmerNodePtr>::const_iterator find_node_ptr_in_out_nodes(
+        const KmerNodePtr& rhs) const
+    {
         return findNodePtrInNodesVector(out_nodes, rhs);
     }
-    std::vector<WeakKmerNodePtr>::const_iterator find_node_ptr_in_in_nodes(const KmerNodePtr &rhs) const {
+    std::vector<WeakKmerNodePtr>::const_iterator find_node_ptr_in_in_nodes(
+        const KmerNodePtr& rhs) const
+    {
         return findNodePtrInNodesVector(in_nodes, rhs);
     }
-    std::vector<WeakKmerNodePtr>::const_iterator find_node_in_out_nodes(const KmerNode &rhs) const {
+    std::vector<WeakKmerNodePtr>::const_iterator find_node_in_out_nodes(
+        const KmerNode& rhs) const
+    {
         return findNodeInNodesVector(out_nodes, rhs);
     }
 
-    std::vector<WeakKmerNodePtr>::const_iterator find_node_in_in_nodes(const KmerNode &rhs) const {
+    std::vector<WeakKmerNodePtr>::const_iterator find_node_in_in_nodes(
+        const KmerNode& rhs) const
+    {
         return findNodeInNodesVector(in_nodes, rhs);
     }
 
-    //constructors and assignment operators
-    KmerNode(uint32_t, const prg::Path &);
-    KmerNode(const KmerNode &);
-    KmerNode &operator=(const KmerNode &);
-    bool operator==(const KmerNode &y) const;
+    // constructors and assignment operators
+    KmerNode(uint32_t, const prg::Path&);
+    KmerNode(const KmerNode&);
+    KmerNode& operator=(const KmerNode&);
+    bool operator==(const KmerNode& y) const;
 
-
-    //friends
-    friend std::ostream &operator<<(std::ostream &, const KmerNode &);
+    // friends
+    friend std::ostream& operator<<(std::ostream&, const KmerNode&);
     friend class KmerGraph;
     friend struct condition;
     friend struct pCompKmerNode;
     friend class LocalPRG;
     friend class pangenome::Graph;
     friend class pangenome::Node;
-    friend int pandora_check_kmergraph(int argc, char *argv[]);
+    friend int pandora_check_kmergraph(int argc, char* argv[]);
 };
 
 #endif

--- a/include/localPRG.h
+++ b/include/localPRG.h
@@ -1,22 +1,21 @@
-#ifndef __LOCALPRG_H_INCLUDED__   // if localPRG.h hasn't been included yet...
+#ifndef __LOCALPRG_H_INCLUDED__ // if localPRG.h hasn't been included yet...
 #define __LOCALPRG_H_INCLUDED__
 
-#include <cstring>
-#include <cstdint>
-#include <vector>
-#include <iostream>
-#include <memory>
-#include "interval.h"
+#include "fastaq.h"
 #include "index.h"
-#include "localgraph.h"
-#include "prg/path.h"
-#include "pangenome/pannode.h"
+#include "interval.h"
 #include "kmergraph.h"
 #include "kmergraphwithcoverage.h"
+#include "localgraph.h"
+#include "pangenome/pannode.h"
+#include "prg/path.h"
 #include "vcf.h"
-#include "fastaq.h"
 #include <boost/filesystem.hpp>
-
+#include <cstdint>
+#include <cstring>
+#include <iostream>
+#include <memory>
+#include <vector>
 
 using PanNodePtr = std::shared_ptr<pangenome::Node>;
 namespace fs = boost::filesystem;
@@ -26,119 +25,123 @@ namespace fs = boost::filesystem;
  */
 class LocalPRG {
 private:
-    uint32_t next_id; //TODO: this should be definitely removed - it is a variable that works only in a method, not an object variable
-    std::string buff; //TODO: this should be definitely removed - it is a variable that works only in a method, not an object variable
-    std::vector<LocalNodePtr> nodes_along_path_core(const prg::Path &) const;
+    uint32_t next_id; // TODO: this should be definitely removed - it is a variable that
+                      // works only in a method, not an object variable
+    std::string buff; // TODO: this should be definitely removed - it is a variable that
+                      // works only in a method, not an object variable
+    std::vector<LocalNodePtr> nodes_along_path_core(const prg::Path&) const;
 
 public:
-    uint32_t next_site; //denotes the id of the next variant site to be processed - TODO: maybe this should not be an object variable
-    uint32_t id; //id of this LocalPRG in the full graph (first gene is 0, second is 1, and so on...)
-    std::string name; //name (fasta comment)
-    std::string seq; //seq of LocalPRG (the PRG as string itself)
-    LocalGraph prg; //the graph that represents this LocalPRG
-    KmerGraph kmer_prg; //the kmer sketch graph
-    //VCF vcf;
+    uint32_t next_site; // denotes the id of the next variant site to be processed -
+                        // TODO: maybe this should not be an object variable
+    uint32_t id; // id of this LocalPRG in the full graph (first gene is 0, second is 1,
+                 // and so on...)
+    std::string name; // name (fasta comment)
+    std::string seq; // seq of LocalPRG (the PRG as string itself)
+    LocalGraph prg; // the graph that represents this LocalPRG
+    KmerGraph kmer_prg; // the kmer sketch graph
+    // VCF vcf;
     std::vector<uint32_t> num_hits;
 
     static bool do_path_memoization_in_nodes_along_path_method;
 
-    LocalPRG(uint32_t id, const std::string &name, const std::string &seq);
+    LocalPRG(uint32_t id, const std::string& name, const std::string& seq);
 
     // functions used to create LocalGraph from PRG string, and to sketch graph
-    bool isalpha_string(const std::string &) const;
+    bool isalpha_string(const std::string&) const;
 
-    std::string string_along_path(const prg::Path &) const;
+    std::string string_along_path(const prg::Path&) const;
 
-    static std::string string_along_path(const std::vector<LocalNodePtr> &);
+    static std::string string_along_path(const std::vector<LocalNodePtr>&);
 
-    std::vector<LocalNodePtr> nodes_along_path(prg::Path &) const;
+    std::vector<LocalNodePtr> nodes_along_path(prg::Path&) const;
 
-    std::vector<Interval> split_by_site(const Interval &) const;
+    std::vector<Interval> split_by_site(const Interval&) const;
 
-    std::vector<uint32_t> build_graph(const Interval &,
-                                      const std::vector<uint32_t> &,
-                                      uint32_t current_level = 0);
+    std::vector<uint32_t> build_graph(
+        const Interval&, const std::vector<uint32_t>&, uint32_t current_level = 0);
 
     std::vector<PathPtr> shift(prg::Path) const;
 
-    void minimizer_sketch(const std::shared_ptr<Index> &index, const uint32_t w, const uint32_t k, double percentageDone=-1.0);
+    void minimizer_sketch(const std::shared_ptr<Index>& index, const uint32_t w,
+        const uint32_t k, double percentageDone = -1.0);
 
     // functions used once hits have been collected against the PRG
-    std::vector<KmerNodePtr> kmernode_path_from_localnode_path(const std::vector<LocalNodePtr> &) const;
+    std::vector<KmerNodePtr> kmernode_path_from_localnode_path(
+        const std::vector<LocalNodePtr>&) const;
 
-    std::vector<LocalNodePtr>
-    localnode_path_from_kmernode_path(const std::vector<KmerNodePtr> &, const uint32_t w = 0) const;
+    std::vector<LocalNodePtr> localnode_path_from_kmernode_path(
+        const std::vector<KmerNodePtr>&, const uint32_t w = 0) const;
 
-    void write_covgs_to_file(const boost::filesystem::path &, const std::vector<uint32_t> &) const;
+    void write_covgs_to_file(
+        const boost::filesystem::path&, const std::vector<uint32_t>&) const;
 
-    void write_path_to_fasta(const boost::filesystem::path &, const std::vector<LocalNodePtr> &, const float &) const;
+    void write_path_to_fasta(const boost::filesystem::path&,
+        const std::vector<LocalNodePtr>&, const float&) const;
 
-    void append_path_to_fasta(const boost::filesystem::path &, const std::vector<LocalNodePtr> &, const float &) const;
+    void append_path_to_fasta(const boost::filesystem::path&,
+        const std::vector<LocalNodePtr>&, const float&) const;
 
-    void write_aligned_path_to_fasta(const boost::filesystem::path &,
-                                     const std::vector<LocalNodePtr> &,
-                                     const float &) const;
+    void write_aligned_path_to_fasta(const boost::filesystem::path&,
+        const std::vector<LocalNodePtr>&, const float&) const;
 
-    void add_sample_gt_to_vcf(VCF &,
-                              const std::vector<LocalNodePtr> &,
-                              const std::vector<LocalNodePtr> &,
-                              const std::string &sample_name = "sample") const;
+    void add_sample_gt_to_vcf(VCF&, const std::vector<LocalNodePtr>&,
+        const std::vector<LocalNodePtr>&,
+        const std::string& sample_name = "sample") const;
 
-    std::vector<LocalNodePtr> find_alt_path(const std::vector<LocalNodePtr> &,
-                                            const uint32_t,
-                                            const std::string &,
-                                            const std::string &) const;
+    std::vector<LocalNodePtr> find_alt_path(const std::vector<LocalNodePtr>&,
+        const uint32_t, const std::string&, const std::string&) const;
 
     std::string random_path();
 
-    //TODO: I really feel like these methods are not responsability of a LocalPRG
-    //TODO: many of them should be in VCF class, or in the KmerGraphWithCoverage or Fastaq
-    void build_vcf(VCF &, const std::vector<LocalNodePtr> &) const;
-
+    // TODO: I really feel like these methods are not responsability of a LocalPRG
+    // TODO: many of them should be in VCF class, or in the KmerGraphWithCoverage or
+    // Fastaq
+    void build_vcf(VCF&, const std::vector<LocalNodePtr>&) const;
 
     virtual std::pair<std::vector<uint32_t>, std::vector<uint32_t>>
-    get_forward_and_reverse_kmer_coverages_in_range(const KmerGraphWithCoverage &kmer_graph_with_coverage,
-                                                    const std::vector<KmerNodePtr> &kmer_path,
-                                                    const std::vector<LocalNodePtr> &local_path, const uint32_t &range_pos_start,
-                                                    const uint32_t &range_pos_end, const uint32_t &sample_id) const;
+    get_forward_and_reverse_kmer_coverages_in_range(
+        const KmerGraphWithCoverage& kmer_graph_with_coverage,
+        const std::vector<KmerNodePtr>& kmer_path,
+        const std::vector<LocalNodePtr>& local_path, const uint32_t& range_pos_start,
+        const uint32_t& range_pos_end, const uint32_t& sample_id) const;
 
-protected: //helper methods of get_forward_and_reverse_kmer_coverages_in_range():
-    virtual uint32_t
-    get_number_of_bases_in_local_path_before_a_given_position(const std::vector<LocalNodePtr> &local_path,
-                                                              uint32_t position) const;
+protected: // helper methods of get_forward_and_reverse_kmer_coverages_in_range():
+    virtual uint32_t get_number_of_bases_in_local_path_before_a_given_position(
+        const std::vector<LocalNodePtr>& local_path, uint32_t position) const;
 
-    virtual uint32_t
-    get_number_of_bases_that_are_exclusively_in_the_previous_kmer_node(const KmerNodePtr &previous_kmer_node,
-                                                                       const KmerNodePtr &current_kmer_node) const;
+    virtual uint32_t get_number_of_bases_that_are_exclusively_in_the_previous_kmer_node(
+        const KmerNodePtr& previous_kmer_node,
+        const KmerNodePtr& current_kmer_node) const;
 
 public:
+    void add_sample_covgs_to_vcf(VCF&, const KmerGraphWithCoverage&,
+        const std::vector<LocalNodePtr>&, const uint32_t& min_kmer_covg,
+        const std::string& sample_name = "sample", const uint32_t& sample_id = 0) const;
 
-    void add_sample_covgs_to_vcf(VCF &, const KmerGraphWithCoverage &, const std::vector<LocalNodePtr> &,
-                                     const uint32_t &min_kmer_covg, const std::string &sample_name="sample",
-                                     const uint32_t &sample_id=0) const;
+    void add_consensus_path_to_fastaq(Fastaq&, PanNodePtr, std::vector<KmerNodePtr>&,
+        std::vector<LocalNodePtr>&, const uint32_t, const bool, const uint32_t,
+        const uint32_t& max_num_kmers_to_average, const uint32_t& sample_id) const;
+    std::vector<LocalNodePtr> get_valid_vcf_reference(const std::string&) const;
 
-    void add_consensus_path_to_fastaq(Fastaq &, PanNodePtr, std::vector<KmerNodePtr> &, std::vector<LocalNodePtr> &,
-                                          const uint32_t, const bool, const uint32_t,
-                                          const uint32_t &max_num_kmers_to_average, const uint32_t &sample_id) const;
-    std::vector<LocalNodePtr> get_valid_vcf_reference(const std::string &) const;
+    void add_variants_to_vcf(VCF&, PanNodePtr, const std::string&,
+        const std::vector<KmerNodePtr>&, const std::vector<LocalNodePtr>&,
+        const uint32_t& min_kmer_covg, const uint32_t& sample_id = 0,
+        const std::string& sample_name = "sample");
 
-    void add_variants_to_vcf(VCF &, PanNodePtr, const std::string &, const std::vector<KmerNodePtr> &,
-                                 const std::vector<LocalNodePtr> &, const uint32_t &min_kmer_covg,
-                                 const uint32_t &sample_id=0, const std::string &sample_name="sample");
-
-
-    //friends definitions
-    friend std::ostream &operator<<(std::ostream &out, const LocalPRG &data);
-    friend class prg::Path; //for memoization
+    // friends definitions
+    friend std::ostream& operator<<(std::ostream& out, const LocalPRG& data);
+    friend class prg::Path; // for memoization
 };
 
-bool operator<(const std::pair<std::vector<LocalNodePtr>, float> &p1,
-               const std::pair<std::vector<LocalNodePtr>, float> &p2);
+bool operator<(const std::pair<std::vector<LocalNodePtr>, float>& p1,
+    const std::pair<std::vector<LocalNodePtr>, float>& p2);
 
-bool operator!=(const std::vector<KmerNodePtr> &lhs, const std::vector<KmerNodePtr> &rhs);
+bool operator!=(
+    const std::vector<KmerNodePtr>& lhs, const std::vector<KmerNodePtr>& rhs);
 
-std::vector<uint32_t>
-get_covgs_along_localnode_path(const PanNodePtr, const std::vector<LocalNodePtr> &, const std::vector<KmerNodePtr> &,
-                               const uint32_t &sample_id);
+std::vector<uint32_t> get_covgs_along_localnode_path(const PanNodePtr,
+    const std::vector<LocalNodePtr>&, const std::vector<KmerNodePtr>&,
+    const uint32_t& sample_id);
 
 #endif

--- a/include/localgraph.h
+++ b/include/localgraph.h
@@ -1,22 +1,20 @@
-#ifndef __LOCALGRAPH_H_INCLUDED__   // if localgraph.h hasn't been included yet...
+#ifndef __LOCALGRAPH_H_INCLUDED__ // if localgraph.h hasn't been included yet...
 #define __LOCALGRAPH_H_INCLUDED__
 
+#include "IITree.h"
+#include "interval.h"
+#include "localnode.h"
+#include "prg/path.h"
+#include <cstdint>
+#include <cstring>
+#include <iostream>
 #include <map>
 #include <vector>
-#include <iostream>
-#include <cstring>
-#include <cstdint>
-#include "interval.h"
-#include "prg/path.h"
-#include "localnode.h"
-#include "IITree.h"
-
-
 
 class LocalGraph {
 public:
     std::map<uint32_t, LocalNodePtr> nodes; // representing nodes in graph
-    IITree<uint32_t, LocalNodePtr> intervalTree; //TODO: move to private
+    IITree<uint32_t, LocalNodePtr> intervalTree; // TODO: move to private
     std::map<uint32_t, LocalNodePtr> startIndexOfZeroLengthIntervals;
     std::map<uint32_t, LocalNodePtr> startIndexOfAllIntervals;
 
@@ -24,31 +22,33 @@ public:
 
     ~LocalGraph();
 
-    void add_node(const uint32_t &id, const std::string &seq, const Interval &pos);
+    void add_node(const uint32_t& id, const std::string& seq, const Interval& pos);
 
-    void add_edge(const uint32_t &, const uint32_t &);
+    void add_edge(const uint32_t&, const uint32_t&);
 
-    void write_gfa(const std::string &) const;
+    void write_gfa(const std::string&) const;
 
-    void read_gfa(const std::string &);
+    void read_gfa(const std::string&);
 
-    std::vector<PathPtr> walk(const uint32_t &, const uint32_t &, const uint32_t &) const;
+    std::vector<PathPtr> walk(const uint32_t&, const uint32_t&, const uint32_t&) const;
 
-    std::vector<PathPtr> walk_back(const uint32_t &, const uint32_t &, const uint32_t &) const;
+    std::vector<PathPtr> walk_back(
+        const uint32_t&, const uint32_t&, const uint32_t&) const;
 
     LocalNodePtr get_previous_node(const LocalNodePtr) const;
 
-    std::vector<LocalNodePtr> nodes_along_string(const std::string &, bool end_to_end = false) const;
+    std::vector<LocalNodePtr> nodes_along_string(
+        const std::string&, bool end_to_end = false) const;
 
     std::vector<LocalNodePtr> top_path() const;
 
     std::vector<LocalNodePtr> bottom_path() const;
 
-    bool operator==(const LocalGraph &y) const;
+    bool operator==(const LocalGraph& y) const;
 
-    bool operator!=(const LocalGraph &y) const;
+    bool operator!=(const LocalGraph& y) const;
 
-    friend std::ostream &operator<<(std::ostream &out, LocalGraph const &data);
+    friend std::ostream& operator<<(std::ostream& out, LocalGraph const& data);
 };
 
 #endif

--- a/include/localnode.h
+++ b/include/localnode.h
@@ -1,16 +1,15 @@
-#ifndef __LOCALNODE_H_INCLUDED__   // if localnode.h hasn't been included yet...
+#ifndef __LOCALNODE_H_INCLUDED__ // if localnode.h hasn't been included yet...
 #define __LOCALNODE_H_INCLUDED__
 
-#include <cstring>
-#include <cstdint>
-#include <vector>
-#include <unordered_set>
-#include <ostream>
-#include <memory>
 #include "interval.h"
-#include "prg/path.h"
 #include "kmernode.h"
-
+#include "prg/path.h"
+#include <cstdint>
+#include <cstring>
+#include <memory>
+#include <ostream>
+#include <unordered_set>
+#include <vector>
 
 class LocalNode;
 
@@ -18,26 +17,28 @@ typedef std::shared_ptr<LocalNode> LocalNodePtr;
 
 class LocalNode {
     std::unordered_set<KmerNodePtr> prev_kmer_paths;
+
 public:
     std::string seq;
-    Interval pos; //pos in the prg
+    Interval pos; // pos in the prg
     uint32_t id;
     uint32_t covg; // covg by hits - initially has the size of the interval
-    uint32_t sketch_next; // used by minimizer_sketch function in localPRG.cpp - the next position to sketch?
-    bool skip; //used by minimizer_sketch function in localPRG.cpp
+    uint32_t sketch_next; // used by minimizer_sketch function in localPRG.cpp - the
+                          // next position to sketch?
+    bool skip; // used by minimizer_sketch function in localPRG.cpp
 
-    std::vector<LocalNodePtr> outNodes; // representing edges from this node to the nodes in the vector
+    std::vector<LocalNodePtr>
+        outNodes; // representing edges from this node to the nodes in the vector
 
     LocalNode(std::string, Interval, uint32_t);
 
-    bool operator==(const LocalNode &y) const;
+    bool operator==(const LocalNode& y) const;
 
-    friend std::ostream &operator<<(std::ostream &out, const LocalNode &n);
+    friend std::ostream& operator<<(std::ostream& out, const LocalNode& n);
 
     friend class LocalGraph;
 
     friend class LocalPRG;
 };
-
 
 #endif

--- a/include/minihit.h
+++ b/include/minihit.h
@@ -1,39 +1,48 @@
-#ifndef __MINIHIT_H_INCLUDED__   // if minihit.h hasn't been included yet...
+#ifndef __MINIHIT_H_INCLUDED__ // if minihit.h hasn't been included yet...
 #define __MINIHIT_H_INCLUDED__
 
-#include <ostream>
-#include <cstdint>
 #include "minimizer.h"
 #include "minirecord.h"
+#include <cstdint>
+#include <ostream>
 
 /**
  * Describes a hit between a read an a minimizer from the PRG
- * TODO: Possible improvement (memory): here we have one MinimizerHit for each (read_id, read_start_position, read_strand) and MiniRecord
- * TODO: Possible improvement (memory): we could make one (read_id, read_start_position, read_strand) and a vector of MiniRecords
+ * TODO: Possible improvement (memory): here we have one MinimizerHit for each (read_id,
+ * read_start_position, read_strand) and MiniRecord
+ * TODO: Possible improvement (memory): we could make one (read_id, read_start_position,
+ * read_strand) and a vector of MiniRecords
  */
 struct MinimizerHit {
 private:
-    uint32_t read_id; //TODO: Possible improvement (memory): this can be made a template and change depending on the maximum number of reads
-    uint32_t read_start_position; //TODO: Possible improvement (memory): this can be made a template and change depending on the maximum read length
+    uint32_t read_id; // TODO: Possible improvement (memory): this can be made a
+                      // template and change depending on the maximum number of reads
+    uint32_t
+        read_start_position; // TODO: Possible improvement (memory): this can be made a
+                             // template and change depending on the maximum read length
     bool read_strand;
-    const MiniRecord &minimizer_from_PRG;
+    const MiniRecord& minimizer_from_PRG;
 
 public:
     inline uint32_t get_read_id() const { return read_id; }
-    inline uint32_t get_read_start_position() const  { return read_start_position; }
-    inline uint32_t get_prg_id () const { return minimizer_from_PRG.prg_id; }
-    inline const prg::Path & get_prg_path() const { return minimizer_from_PRG.path; }
+    inline uint32_t get_read_start_position() const { return read_start_position; }
+    inline uint32_t get_prg_id() const { return minimizer_from_PRG.prg_id; }
+    inline const prg::Path& get_prg_path() const { return minimizer_from_PRG.path; }
     inline uint32_t get_kmer_node_id() const { return minimizer_from_PRG.knode_id; }
-    inline bool is_forward() const { return read_strand == minimizer_from_PRG.strand ;} //TODO: the name of this method is very misleading, should be same_strands() or sth like this
+    inline bool is_forward() const
+    {
+        return read_strand == minimizer_from_PRG.strand;
+    } // TODO: the name of this method is very misleading, should be same_strands() or
+      // sth like this
 
-    MinimizerHit(const uint32_t i, const Minimizer &minimizer_from_read, const MiniRecord &minimizer_from_PRG);
+    MinimizerHit(const uint32_t i, const Minimizer& minimizer_from_read,
+        const MiniRecord& minimizer_from_PRG);
 
-    bool operator<(const MinimizerHit &y) const;
+    bool operator<(const MinimizerHit& y) const;
 
-    bool operator==(const MinimizerHit &y) const;
+    bool operator==(const MinimizerHit& y) const;
 
-    friend std::ostream &operator<<(std::ostream &out, const MinimizerHit &m);
+    friend std::ostream& operator<<(std::ostream& out, const MinimizerHit& m);
 };
-
 
 #endif

--- a/include/minihits.h
+++ b/include/minihits.h
@@ -1,12 +1,11 @@
-#ifndef __MINIHITS_H_INCLUDED__   // if minihits.h hasn't been included yet...
+#ifndef __MINIHITS_H_INCLUDED__ // if minihits.h hasn't been included yet...
 #define __MINIHITS_H_INCLUDED__
 
-#include <set>
-#include <unordered_set>
-#include <memory>
 #include "minimizer.h"
 #include "minirecord.h"
-
+#include <memory>
+#include <set>
+#include <unordered_set>
 
 struct MinimizerHit;
 struct pComp;
@@ -14,19 +13,19 @@ typedef std::shared_ptr<MinimizerHit> MinimizerHitPtr;
 typedef std::set<MinimizerHitPtr, pComp> MinimizerHitCluster;
 
 struct pComp {
-    bool operator()(const MinimizerHitPtr &lhs, const MinimizerHitPtr &rhs);
+    bool operator()(const MinimizerHitPtr& lhs, const MinimizerHitPtr& rhs);
 };
 
 struct pEq {
-    bool operator()(const MinimizerHitPtr &lhs, const MinimizerHitPtr &rhs) const;
+    bool operator()(const MinimizerHitPtr& lhs, const MinimizerHitPtr& rhs) const;
 };
 
 struct Hash {
-    size_t operator()(const MinimizerHit *mh) const;
+    size_t operator()(const MinimizerHit* mh) const;
 };
 
 struct pComp_path {
-    bool operator()(const MinimizerHitPtr &lhs, const MinimizerHitPtr &rhs);
+    bool operator()(const MinimizerHitPtr& lhs, const MinimizerHitPtr& rhs);
 };
 
 struct clusterComp {
@@ -44,11 +43,12 @@ public:
 
     std::set<MinimizerHitPtr, pComp> hits;
 
-    void add_hit(const uint32_t i, const Minimizer &minimizer_from_read, const MiniRecord &minimizer_from_PRG);
+    void add_hit(const uint32_t i, const Minimizer& minimizer_from_read,
+        const MiniRecord& minimizer_from_PRG);
 
-    void clear () { hits.clear(); }
+    void clear() { hits.clear(); }
 
-    //friend std::ostream &operator<<(std::ostream &out, const MinimizerHits &m);
+    // friend std::ostream &operator<<(std::ostream &out, const MinimizerHits &m);
 };
 
 #endif

--- a/include/minimizer.h
+++ b/include/minimizer.h
@@ -1,9 +1,9 @@
-#ifndef __MINIMIZER_H_INCLUDED__   // if minimizer.h hasn't been included yet...
+#ifndef __MINIMIZER_H_INCLUDED__ // if minimizer.h hasn't been included yet...
 #define __MINIMIZER_H_INCLUDED__
 
-#include <ostream>
-#include <cstdint>
 #include "interval.h"
+#include <cstdint>
+#include <ostream>
 
 /**
  * Represents a minimizer from a read or sequence (not from a graph, as MiniRecord)
@@ -19,11 +19,11 @@ struct Minimizer {
 
     ~Minimizer();
 
-    bool operator<(const Minimizer &y) const;
+    bool operator<(const Minimizer& y) const;
 
-    bool operator==(const Minimizer &y) const;
+    bool operator==(const Minimizer& y) const;
 
-    friend std::ostream &operator<<(std::ostream &out, const Minimizer &m);
+    friend std::ostream& operator<<(std::ostream& out, const Minimizer& m);
 };
 
 #endif

--- a/include/minirecord.h
+++ b/include/minirecord.h
@@ -1,16 +1,16 @@
-#ifndef __MINIRECORD_H_INCLUDED__   // if minirecord.h hasn't been included yet...
+#ifndef __MINIRECORD_H_INCLUDED__ // if minirecord.h hasn't been included yet...
 #define __MINIRECORD_H_INCLUDED__
 
-#include <iostream>
-#include <cstdint>
 #include "prg/path.h"
+#include <cstdint>
+#include <iostream>
 
-//Minimizer Record - stores information about a minimizer
+// Minimizer Record - stores information about a minimizer
 struct MiniRecord {
-    uint32_t prg_id; //prg id of the minimizer
-    prg::Path path; //kmer path of the minimizer in the PRG
-    uint32_t knode_id; //node id of this record in the KmerGraph
-    bool strand; //strand of this kmer
+    uint32_t prg_id; // prg id of the minimizer
+    prg::Path path; // kmer path of the minimizer in the PRG
+    uint32_t knode_id; // node id of this record in the KmerGraph
+    bool strand; // strand of this kmer
 
     MiniRecord();
 
@@ -18,11 +18,11 @@ struct MiniRecord {
 
     ~MiniRecord();
 
-    bool operator==(const MiniRecord &y) const;
+    bool operator==(const MiniRecord& y) const;
 
-    friend std::ostream &operator<<(std::ostream &out, const MiniRecord &m);
+    friend std::ostream& operator<<(std::ostream& out, const MiniRecord& m);
 
-    friend std::istream &operator>>(std::istream &in, MiniRecord &m);
+    friend std::istream& operator>>(std::istream& in, MiniRecord& m);
 };
 
 #endif

--- a/include/noise_filtering.h
+++ b/include/noise_filtering.h
@@ -1,46 +1,49 @@
-#ifndef __NOISEFILTERING_H_INCLUDED__   // if noise_filtering.h hasn't been included yet...
+#ifndef __NOISEFILTERING_H_INCLUDED__ // if noise_filtering.h hasn't been included
+                                      // yet...
 #define __NOISEFILTERING_H_INCLUDED__
 
-#include <string>
-#include <cstdint>
-#include "pangenome/pangraph.h"
 #include "de_bruijn/graph.h"
-
+#include "pangenome/pangraph.h"
+#include <cstdint>
+#include <string>
 
 #define assert_msg(x) !(std::cerr << "Assertion failed: " << x << std::endl)
 
 uint_least32_t node_plus_orientation_to_num(const uint_least32_t, const bool);
 
-void num_to_node_plus_orientation(uint_least32_t &, bool &, const uint_least32_t);
+void num_to_node_plus_orientation(uint_least32_t&, bool&, const uint_least32_t);
 
-uint_least32_t rc_num(const uint_least32_t &);
+uint_least32_t rc_num(const uint_least32_t&);
 
-void hashed_node_ids_to_ids_and_orientations(const std::deque<uint_least32_t> &, std::vector<uint_least32_t> &,
-                                             std::vector<bool> &);
+void hashed_node_ids_to_ids_and_orientations(const std::deque<uint_least32_t>&,
+    std::vector<uint_least32_t>&, std::vector<bool>&);
 
-bool overlap_forwards(const std::deque<uint_least32_t> &, const std::deque<uint_least32_t> &);
+bool overlap_forwards(
+    const std::deque<uint_least32_t>&, const std::deque<uint_least32_t>&);
 
-bool overlap_backwards(const std::deque<uint_least32_t> &, const std::deque<uint_least32_t> &);
+bool overlap_backwards(
+    const std::deque<uint_least32_t>&, const std::deque<uint_least32_t>&);
 
-std::deque<uint_least32_t> rc_hashed_node_ids(const std::deque<uint_least32_t> &);
+std::deque<uint_least32_t> rc_hashed_node_ids(const std::deque<uint_least32_t>&);
 
-void
-dbg_node_ids_to_ids_and_orientations(const debruijn::Graph &, const std::deque<uint32_t> &,
-                                     std::vector<uint_least32_t> &,
-                                     std::vector<bool> &);
+void dbg_node_ids_to_ids_and_orientations(const debruijn::Graph&,
+    const std::deque<uint32_t>&, std::vector<uint_least32_t>&, std::vector<bool>&);
 
-void construct_debruijn_graph(std::shared_ptr<pangenome::Graph> pangraph, debruijn::Graph &dbg);
+void construct_debruijn_graph(
+    std::shared_ptr<pangenome::Graph> pangraph, debruijn::Graph& dbg);
 
-void remove_leaves(std::shared_ptr<pangenome::Graph>, debruijn::Graph &, uint_least32_t covg_thresh = 1);
+void remove_leaves(std::shared_ptr<pangenome::Graph>, debruijn::Graph&,
+    uint_least32_t covg_thresh = 1);
 
-void filter_unitigs(std::shared_ptr<pangenome::Graph>, debruijn::Graph &, const uint_least32_t &);
+void filter_unitigs(
+    std::shared_ptr<pangenome::Graph>, debruijn::Graph&, const uint_least32_t&);
 
-void detangle_pangraph_with_debruijn_graph(std::shared_ptr<pangenome::Graph>, debruijn::Graph &);
+void detangle_pangraph_with_debruijn_graph(
+    std::shared_ptr<pangenome::Graph>, debruijn::Graph&);
 
-void
-clean_pangraph_with_debruijn_graph(std::shared_ptr<pangenome::Graph>, const uint_least32_t, const uint_least32_t,
-                                   const bool illumina = false);
+void clean_pangraph_with_debruijn_graph(std::shared_ptr<pangenome::Graph>,
+    const uint_least32_t, const uint_least32_t, const bool illumina = false);
 
-void write_pangraph_gfa(const std::string &, std::shared_ptr<pangenome::Graph>);
+void write_pangraph_gfa(const std::string&, std::shared_ptr<pangenome::Graph>);
 
 #endif

--- a/include/pangenome/pangraph.h
+++ b/include/pangenome/pangraph.h
@@ -1,4 +1,4 @@
-#ifndef __PANGRAPH_H_INCLUDED__   // if pangraph.h hasn't been included yet...
+#ifndef __PANGRAPH_H_INCLUDED__ // if pangraph.h hasn't been included yet...
 #define __PANGRAPH_H_INCLUDED__
 
 struct MinimizerHit;
@@ -7,155 +7,163 @@ class LocalPRG;
 
 class KmerNode;
 
-#include <string>
 #include <cstdint>
-#include <unordered_map>
 #include <ostream>
+#include <string>
+#include <unordered_map>
 #include <vector>
 
-#include "minihits.h"
 #include "localPRG.h"
+#include "minihits.h"
 #include "pangenome/ns.cpp"
-
 
 using KmerNodePtr = std::shared_ptr<KmerNode>;
 using ReadId = uint32_t;
 using NodeId = uint32_t;
 
-//TODO: refactor this
+// TODO: refactor this
 using SampleIdText = std::string;
 using SampleFpath = std::string;
 
-
-
 class pangenome::Graph {
 protected:
-    std::unordered_map<std::string, SamplePtr> samples; //the samples this pangraph has information
+    std::unordered_map<std::string, SamplePtr>
+        samples; // the samples this pangraph has information
     uint32_t next_id;
 
 public:
-    //TODO: move all attributes to private
+    // TODO: move all attributes to private
     std::map<ReadId, ReadPtr> reads;
     std::unordered_map<NodeId, NodePtr> nodes;
 
     ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-    //declares all default constructors, destructors and assignment operators explicitly
-    //constructor - builds a pangraph to hold information about the given samples
-    Graph(const std::vector<std::string> &sample_names = {"sample_1"});
-    virtual ~Graph() = default; //destructor
-    Graph(const Graph &other) = default; //copy default constructor
-    Graph(Graph &&other) = default; //move default constructor
-    Graph& operator=(const Graph& other) = default; //copy assignment operator
-    Graph& operator=(Graph&& other) = default; //move assignment operator
+    // declares all default constructors, destructors and assignment operators
+    // explicitly constructor - builds a pangraph to hold information about the given
+    // samples
+    Graph(const std::vector<std::string>& sample_names = { "sample_1" });
+    virtual ~Graph() = default; // destructor
+    Graph(const Graph& other) = default; // copy default constructor
+    Graph(Graph&& other) = default; // move default constructor
+    Graph& operator=(const Graph& other) = default; // copy assignment operator
+    Graph& operator=(Graph&& other) = default; // move assignment operator
     ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
-
+    ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+    // getters
+    const NodePtr& get_node(const NodeId& node_id) const { return nodes.at(node_id); }
+    const NodePtr& get_node(const std::shared_ptr<LocalPRG>& prg) const
+    {
+        return nodes.at(prg->id);
+    }
+    const SamplePtr& get_sample(const std::string& sample_name) const
+    {
+        return samples.at(sample_name);
+    }
+    const ReadPtr& get_read(const uint32_t& read_id) const { return reads.at(read_id); }
+    ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
     ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-    //getters
-    const NodePtr& get_node(const NodeId &node_id) const { return nodes.at(node_id); }
-    const NodePtr& get_node(const std::shared_ptr<LocalPRG> &prg) const { return nodes.at(prg->id); }
-    const SamplePtr& get_sample(const std::string &sample_name) const { return samples.at(sample_name); }
-    const ReadPtr & get_read(const uint32_t &read_id) const { return reads.at(read_id); }
-    ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-
-
-    ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-    //adders
+    // adders
     /**
      * Adds a new node to represent the localPRG given by the parameter.
      * Used by pandora compare.
      * @param prg
      */
-    void add_node(const std::shared_ptr<LocalPRG> &prg) { add_node(prg, prg->id); }
+    void add_node(const std::shared_ptr<LocalPRG>& prg) { add_node(prg, prg->id); }
     /**
      * Adds a new node to represent the localPRG given by the parameter.
      * Used by pandora compare.
      * @param prg
-     * @param node_id : sometimes we need more than 1 node representing a single PRG. node_id provides uniqueness to each node, so that is why we have an over
+     * @param node_id : sometimes we need more than 1 node representing a single PRG.
+     * node_id provides uniqueness to each node, so that is why we have an over
      */
-    void add_node(const std::shared_ptr<LocalPRG> &prg, uint32_t node_id);
+    void add_node(const std::shared_ptr<LocalPRG>& prg, uint32_t node_id);
 
     /**
      * Adds a cluster of hits between the given PRG and the given Read.
      * This adds a node corresponding to the PRG and reads accordingly.
-     * This is called when the pangraph represents a sample - the coverage of the PRG/node is the number of reads
-     * containing it.
+     * This is called when the pangraph represents a sample - the coverage of the
+     * PRG/node is the number of reads containing it.
      * @param prg
      * @param read_id
      * @param cluster
      */
     void add_hits_between_PRG_and_read(
-            const std::shared_ptr<LocalPRG> &prg, //the prg from where this cluster of hits come
-            const uint32_t read_id, //the read id from where this cluster of reads come
-            std::set<MinimizerHitPtr, pComp> &cluster //the cluster itself
+        const std::shared_ptr<LocalPRG>&
+            prg, // the prg from where this cluster of hits come
+        const uint32_t read_id, // the read id from where this cluster of reads come
+        std::set<MinimizerHitPtr, pComp>& cluster // the cluster itself
     );
 
-
     /**
-     * Adds hits between the given PRG and sample described as a path of minimizer kmers from the consensus path.
-     * This is just used in the global pangraph in pandora compare.
-     * For each sample, we go to each PRG/node and get the consensus path (i.e. the path in the PRG with the best read support from that sample).
-     * From this consensus path, we get the minimizer kmers, and we add this minimizer kmer path here.
-     * This is called when the pangraph represents a COLLECTION of samples - the coverage of the PRG/node is the samples mapping to this PRG/node
+     * Adds hits between the given PRG and sample described as a path of minimizer kmers
+     * from the consensus path. This is just used in the global pangraph in pandora
+     * compare. For each sample, we go to each PRG/node and get the consensus path (i.e.
+     * the path in the PRG with the best read support from that sample). From this
+     * consensus path, we get the minimizer kmers, and we add this minimizer kmer path
+     * here. This is called when the pangraph represents a COLLECTION of samples - the
+     * coverage of the PRG/node is the samples mapping to this PRG/node
      * @param node
      * @param sample
      * @param kmp : the minimizer kmers node path
      */
-    void add_hits_between_PRG_and_sample (const NodePtr& node, const SamplePtr &sample, const std::vector<KmerNodePtr> &kmp);
-    void add_hits_between_PRG_and_sample (uint32_t node_id, const std::string &sample_name, const std::vector<KmerNodePtr> &kmp) {
-        add_hits_between_PRG_and_sample(get_node(node_id), get_sample(sample_name), kmp);
+    void add_hits_between_PRG_and_sample(const NodePtr& node, const SamplePtr& sample,
+        const std::vector<KmerNodePtr>& kmp);
+    void add_hits_between_PRG_and_sample(uint32_t node_id,
+        const std::string& sample_name, const std::vector<KmerNodePtr>& kmp)
+    {
+        add_hits_between_PRG_and_sample(
+            get_node(node_id), get_sample(sample_name), kmp);
     }
 
     /**
      * Adds a new read to this pan graph
      * @param read_id
      */
-    void add_read(const uint32_t &read_id);
+    void add_read(const uint32_t& read_id);
     ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-
 
     /**
      * Remove nodes with covg <= thresh from graph
-    * @param thresh
-    */
-    void remove_low_covg_nodes(const uint32_t &thresh);
+     * @param thresh
+     */
+    void remove_low_covg_nodes(const uint32_t& thresh);
 
-
-    //TODO: possibly refactor the methods below
+    // TODO: possibly refactor the methods below
     std::unordered_map<uint32_t, NodePtr>::iterator remove_node(NodePtr);
     void remove_read(const uint32_t);
-    std::vector<WeakNodePtr>::iterator remove_node_from_read(std::vector<WeakNodePtr>::iterator, ReadPtr);
+    std::vector<WeakNodePtr>::iterator remove_node_from_read(
+        std::vector<WeakNodePtr>::iterator, ReadPtr);
 
-    void split_node_by_reads(std::unordered_set<ReadPtr> &, std::vector<uint_least32_t> &, const std::vector<bool> &,
-                             const uint_least32_t);
+    void split_node_by_reads(std::unordered_set<ReadPtr>&, std::vector<uint_least32_t>&,
+        const std::vector<bool>&, const uint_least32_t);
 
+    void add_hits_to_kmergraphs(
+        const std::vector<std::shared_ptr<LocalPRG>>&, const uint32_t& sample_id = 0);
 
-    void add_hits_to_kmergraphs(const std::vector<std::shared_ptr<LocalPRG>> &, const uint32_t &sample_id = 0);
-
-
-    void copy_coverages_to_kmergraphs(const Graph &, const uint32_t &);
-    std::vector<LocalNodePtr>
-    infer_node_vcf_reference_path(const Node &, const std::shared_ptr<LocalPRG> &, const uint32_t &,
-                                  const std::unordered_map<std::string, std::string> &, const uint32_t&) const;
-    std::vector<LocalNodePtr>
-    get_node_closest_vcf_reference(const Node &, const uint32_t &, const LocalPRG &, const uint32_t& max_num_kmers_to_average) const;
+    void copy_coverages_to_kmergraphs(const Graph&, const uint32_t&);
+    std::vector<LocalNodePtr> infer_node_vcf_reference_path(const Node&,
+        const std::shared_ptr<LocalPRG>&, const uint32_t&,
+        const std::unordered_map<std::string, std::string>&, const uint32_t&) const;
+    std::vector<LocalNodePtr> get_node_closest_vcf_reference(const Node&,
+        const uint32_t&, const LocalPRG&,
+        const uint32_t& max_num_kmers_to_average) const;
     // graph comparison
-    bool operator==(const Graph &y) const;
-    bool operator!=(const Graph &y) const;
+    bool operator==(const Graph& y) const;
+    bool operator!=(const Graph& y) const;
     // graph read/write
-    void save_matrix(const std::string &, const std::vector<std::string> &);
-    void save_mapped_read_strings(const std::string &read_filepath, const std::string &outprefix, const int buff = 0);
-    friend std::ostream &operator<<(std::ostream &out, const Graph &m);
+    void save_matrix(const std::string&, const std::vector<std::string>&);
+    void save_mapped_read_strings(const std::string& read_filepath,
+        const std::string& outprefix, const int buff = 0);
+    friend std::ostream& operator<<(std::ostream& out, const Graph& m);
 };
 
 struct same_prg_id {
     uint32_t q;
 
-    same_prg_id(const pangenome::NodePtr &);
+    same_prg_id(const pangenome::NodePtr&);
 
-    bool operator()(const std::pair<uint32_t, pangenome::NodePtr> &) const;
+    bool operator()(const std::pair<uint32_t, pangenome::NodePtr>&) const;
 };
 
 #endif
-

--- a/include/pangenome/pannode.h
+++ b/include/pangenome/pannode.h
@@ -1,84 +1,83 @@
-#ifndef __PANNODE_H_INCLUDED__   // if pannode.h hasn't been included yet...
+#ifndef __PANNODE_H_INCLUDED__ // if pannode.h hasn't been included yet...
 #define __PANNODE_H_INCLUDED__
 
-#include <string>
-#include <cstdint>
-#include <unordered_set>
-#include <vector>
+#include "denovo_discovery/denovo_utils.h"
 #include "kmergraph.h"
 #include "kmergraphwithcoverage.h"
 #include "localPRG.h"
 #include "pangenome/ns.cpp"
-#include "vcf.h"
-#include "denovo_discovery/denovo_utils.h"
 #include "pansample.h"
-
+#include "vcf.h"
+#include <cstdint>
+#include <string>
+#include <unordered_set>
+#include <vector>
 
 class LocalPRG;
 struct ReadCoordinate;
 using PanReadPtr = std::shared_ptr<pangenome::Read>;
 
-
 class pangenome::Node {
 public:
     std::unordered_multiset<ReadPtr> reads;
     std::set<SamplePtr, SamplePtrSorterBySampleId> samples;
-    const uint32_t prg_id; // corresponding the the LocalPRG id - TODO: this is not needed - we point to the LocalPRG, which has this info
-    const uint32_t node_id; // unique node id, so can have multiple copies of a localPRG in graph
-    const std::string name; //TODO: this is not needed - we point to the LocalPRG, which has this info
-    mutable uint32_t covg; //TODO: this is not needed - it is reads.size()
-    std::shared_ptr<LocalPRG> prg; //TODO: this should be made const
+    const uint32_t prg_id; // corresponding the the LocalPRG id - TODO: this is not
+                           // needed - we point to the LocalPRG, which has this info
+    const uint32_t
+        node_id; // unique node id, so can have multiple copies of a localPRG in graph
+    const std::string name; // TODO: this is not needed - we point to the LocalPRG,
+                            // which has this info
+    mutable uint32_t covg; // TODO: this is not needed - it is reads.size()
+    std::shared_ptr<LocalPRG> prg; // TODO: this should be made const
     KmerGraphWithCoverage kmer_prg_with_coverage;
 
-    //main constructor
-    Node(const std::shared_ptr<LocalPRG> &prg,
-         uint32_t node_id,
-         uint32_t total_number_samples=1 //total number of samples that we have in this node
+    // main constructor
+    Node(const std::shared_ptr<LocalPRG>& prg, uint32_t node_id,
+        uint32_t total_number_samples
+        = 1 // total number of samples that we have in this node
     );
 
-    //convenience constructors
-    Node(const std::shared_ptr<LocalPRG> &prg);
+    // convenience constructors
+    Node(const std::shared_ptr<LocalPRG>& prg);
 
-    //Node(const Node&);
-    //Node& operator=(const Node&);
+    // Node(const Node&);
+    // Node& operator=(const Node&);
 
     void remove_read(ReadPtr);
 
     std::string get_name() const;
 
-    void add_path(const std::vector<KmerNodePtr> &, const uint32_t &sample_id);
+    void add_path(const std::vector<KmerNodePtr>&, const uint32_t& sample_id);
 
-    void get_read_overlap_coordinates(std::vector<std::vector<uint32_t>> &);
+    void get_read_overlap_coordinates(std::vector<std::vector<uint32_t>>&);
 
-    std::set<ReadCoordinate>
-    get_read_overlap_coordinates(const prg::Path &local_path, const uint32_t &min_number_hits = 2);
+    std::set<ReadCoordinate> get_read_overlap_coordinates(
+        const prg::Path& local_path, const uint32_t& min_number_hits = 2);
 
-    void
-    construct_multisample_vcf(VCF &master_vcf,
-                         const std::vector<LocalNodePtr> &vcf_reference_path,
-                         const std::shared_ptr<LocalPRG> &prg, const uint32_t w,
-                         const uint32_t &min_kmer_covg);
+    void construct_multisample_vcf(VCF& master_vcf,
+        const std::vector<LocalNodePtr>& vcf_reference_path,
+        const std::shared_ptr<LocalPRG>& prg, const uint32_t w,
+        const uint32_t& min_kmer_covg);
 
-    bool operator==(const Node &y) const;
+    bool operator==(const Node& y) const;
 
-    bool operator!=(const Node &y) const;
+    bool operator!=(const Node& y) const;
 
-    bool operator<(const Node &y) const;
+    bool operator<(const Node& y) const;
 
-    friend std::ostream &operator<<(std::ostream &out, const Node &n);
-
+    friend std::ostream& operator<<(std::ostream& out, const Node& n);
 
     friend class pangenome::Graph;
-
 
     friend class pangenome::Read;
 };
 
 struct EqualComparatorWeakNodePtr {
-    bool operator()(const pangenome::WeakNodePtr &lhs, const pangenome::WeakNodePtr &rhs) {
+    bool operator()(
+        const pangenome::WeakNodePtr& lhs, const pangenome::WeakNodePtr& rhs)
+    {
         return *(lhs.lock()) == *(rhs.lock());
     }
 };
-
 
 #endif

--- a/include/pangenome/panread.h
+++ b/include/pangenome/panread.h
@@ -1,81 +1,81 @@
-#ifndef __PANREAD_H_INCLUDED__   // if panread.h hasn't been included yet...
+#ifndef __PANREAD_H_INCLUDED__ // if panread.h hasn't been included yet...
 #define __PANREAD_H_INCLUDED__
 
-#include <string>
-#include <cstdint>
-#include <vector>
-#include <iostream>
-#include <unordered_map>
-#include <minihit.h>
 #include "minihits.h"
 #include "pangenome/ns.cpp"
-
+#include <cstdint>
+#include <iostream>
+#include <minihit.h>
+#include <string>
+#include <unordered_map>
+#include <vector>
 
 class pangenome::Read {
 private:
-    //TODO: derive this from MinimizerHits?
-    //TODO: or maybe keep it here but without the read id, since it is duplicated?
-    std::vector<MinimizerHit*> hits; //store all Minimizer Hits mapping to this read
+    // TODO: derive this from MinimizerHits?
+    // TODO: or maybe keep it here but without the read id, since it is duplicated?
+    std::vector<MinimizerHit*> hits; // store all Minimizer Hits mapping to this read
     std::vector<WeakNodePtr> nodes;
 
 public:
-    const uint32_t id; //read id
+    const uint32_t id; // read id
     std::vector<bool> node_orientations;
 
-    //constructor/destructors
+    // constructor/destructors
     Read(const uint32_t);
     virtual ~Read();
 
+    // TODO: this can be a source of time inneficiency at the cost of using less memory
+    // TODO: check if we should fallback to representing hits as
+    // std::unordered_map<uint32_t, std::vector<MinimizerHitPtr>> directly
+    std::unordered_map<uint32_t, std::vector<MinimizerHitPtr>>
+    get_hits_as_unordered_map() const;
 
-    //TODO: this can be a source of time inneficiency at the cost of using less memory
-    //TODO: check if we should fallback to representing hits as std::unordered_map<uint32_t, std::vector<MinimizerHitPtr>> directly
-    std::unordered_map<uint32_t, std::vector<MinimizerHitPtr>> get_hits_as_unordered_map() const;
+    const std::vector<WeakNodePtr>& get_nodes() const { return nodes; }
+    // TODO: this getter allows the caller to the private attribute nodes, use with
+    // care...
+    // TODO: replace/remove this?
+    std::vector<WeakNodePtr>& get_nodes() { return nodes; }
 
-    const std::vector<WeakNodePtr>& get_nodes() const {
-        return nodes;
-    }
-    //TODO: this getter allows the caller to the private attribute nodes, use with care...
-    //TODO: replace/remove this?
-    std::vector<WeakNodePtr>& get_nodes() {
-        return nodes;
-    }
+    // TODO: just used in tests, move to private and friend the test class
+    void set_nodes(const std::vector<WeakNodePtr>& nodes) { this->nodes = nodes; }
 
-    //TODO: just used in tests, move to private and friend the test class
-    void set_nodes(const std::vector<WeakNodePtr> &nodes) { this->nodes = nodes; }
+    std::vector<WeakNodePtr>::iterator find_node_by_id(uint32_t node_id);
 
-    std::vector<WeakNodePtr>::iterator find_node_by_id (uint32_t node_id);
-
-    //modifiers
-    void add_node(const NodePtr &nodePtr) {
+    // modifiers
+    void add_node(const NodePtr& nodePtr)
+    {
         nodes.push_back(nodePtr);
         nodes.shrink_to_fit();
     }
-    void add_orientation(bool orientation) {
+    void add_orientation(bool orientation)
+    {
         node_orientations.push_back(orientation);
         node_orientations.shrink_to_fit();
     }
 
+    void add_hits(
+        const NodePtr& node_ptr, const std::set<MinimizerHitPtr, pComp>& cluster);
 
-    void add_hits(const NodePtr &node_ptr, const std::set<MinimizerHitPtr, pComp> &cluster);
-
-    std::pair<uint32_t, uint32_t>
-    find_position(const std::vector<uint_least32_t> &, const std::vector<bool> &, const uint16_t min_overlap = 1);
+    std::pair<uint32_t, uint32_t> find_position(const std::vector<uint_least32_t>&,
+        const std::vector<bool>&, const uint16_t min_overlap = 1);
 
     // remove nodes
     void remove_all_nodes_with_this_id(uint32_t node_id);
-    std::vector<WeakNodePtr>::iterator remove_node_with_iterator(std::vector<WeakNodePtr>::iterator nit);
+    std::vector<WeakNodePtr>::iterator remove_node_with_iterator(
+        std::vector<WeakNodePtr>::iterator nit);
 
     // replace nodes
-    void replace_node_with_iterator(std::vector<WeakNodePtr>::iterator n_original, NodePtr n);
+    void replace_node_with_iterator(
+        std::vector<WeakNodePtr>::iterator n_original, NodePtr n);
 
+    bool operator==(const Read& y) const;
 
-    bool operator==(const Read &y) const;
+    bool operator!=(const Read& y) const;
 
-    bool operator!=(const Read &y) const;
+    bool operator<(const Read& y) const;
 
-    bool operator<(const Read &y) const;
-
-    friend std::ostream &operator<<(std::ostream &out, const Read &r);
+    friend std::ostream& operator<<(std::ostream& out, const Read& r);
 
     friend class pangenome::Graph;
 

--- a/include/pangenome/pansample.h
+++ b/include/pangenome/pansample.h
@@ -1,12 +1,11 @@
-#ifndef __PANSAMPLE_H_INCLUDED__   // if pansample.h hasn't been included yet...
+#ifndef __PANSAMPLE_H_INCLUDED__ // if pansample.h hasn't been included yet...
 #define __PANSAMPLE_H_INCLUDED__
 
-#include <string>
-#include <cstdint>
-#include <vector>
-#include <unordered_map>
 #include "pangenome/ns.cpp"
-
+#include <cstdint>
+#include <string>
+#include <unordered_map>
+#include <vector>
 
 class KmerNode;
 
@@ -18,23 +17,25 @@ public:
     const uint32_t sample_id;
     std::vector<WeakNodePtr> nodes;
     std::vector<bool> node_orientations;
-    std::unordered_map<uint32_t, std::vector<std::vector<KmerNodePtr>>> paths; // from prg id (or unique id) to kmernnode path(s) through each node
+    std::unordered_map<uint32_t, std::vector<std::vector<KmerNodePtr>>>
+        paths; // from prg id (or unique id) to kmernnode path(s) through each node
 
-    Sample(const std::string &, const uint32_t &id);
+    Sample(const std::string&, const uint32_t& id);
 
-    void add_path(const uint32_t, const std::vector<KmerNodePtr> &);
+    void add_path(const uint32_t, const std::vector<KmerNodePtr>&);
 
-    bool operator==(const Sample &y) const;
+    bool operator==(const Sample& y) const;
 
-    bool operator!=(const Sample &y) const;
+    bool operator!=(const Sample& y) const;
 
-    bool operator<(const Sample &y) const;
+    bool operator<(const Sample& y) const;
 
-    friend std::ostream &operator<<(std::ostream &out, const Sample &s);
+    friend std::ostream& operator<<(std::ostream& out, const Sample& s);
 };
 
 struct pangenome::SamplePtrSorterBySampleId {
-    bool operator()(const pangenome::SamplePtr &lhs, const pangenome::SamplePtr &rhs) const;
+    bool operator()(
+        const pangenome::SamplePtr& lhs, const pangenome::SamplePtr& rhs) const;
 };
 
 #endif

--- a/include/prg/path.h
+++ b/include/prg/path.h
@@ -1,107 +1,126 @@
-#ifndef __PATH_H_INCLUDED__   // if path.h hasn't been included yet...
+#ifndef __PATH_H_INCLUDED__ // if path.h hasn't been included yet...
 #define __PATH_H_INCLUDED__
 
-#include <deque>
-#include <vector>
-#include <iostream>
-#include <cstdint>
 #include "interval.h"
 #include "prg/ns.cpp"
+#include <cstdint>
+#include <deque>
+#include <iostream>
 #include <memory>
+#include <vector>
 
 class LocalPRG;
 class LocalNode;
-typedef std::shared_ptr<LocalNode> LocalNodePtr; //TODO: this is replicated from localnode.h and I really don't like it, fix
+typedef std::shared_ptr<LocalNode>
+    LocalNodePtr; // TODO: this is replicated from localnode.h and I really don't like
+                  // it, fix
 
 class prg::Path {
 private:
-    std::vector<Interval> path; //the interval path - we control acess to this variable now
+    std::vector<Interval>
+        path; // the interval path - we control acess to this variable now
 
-
-    //variables for memoization:
-    bool isMemoized; //flag that indicated if the first memoization was already done
-    std::vector<LocalNodePtr> memoizedLocalNodePath; //the memoized local node path
-    bool memoizedDirty; //was this path modified and thus memoizedLocalNodePath needs to be recomputed?
-    uint32_t localPRGIdOfMemoizedLocalNodePath; //just to make sure we don't memoize one interval for one localPRG and return it to a different localPRg
+    // variables for memoization:
+    bool isMemoized; // flag that indicated if the first memoization was already done
+    std::vector<LocalNodePtr> memoizedLocalNodePath; // the memoized local node path
+    bool memoizedDirty; // was this path modified and thus memoizedLocalNodePath needs
+                        // to be recomputed?
+    uint32_t localPRGIdOfMemoizedLocalNodePath; // just to make sure we don't memoize
+                                                // one interval for one localPRG and
+                                                // return it to a different localPRg
 
 public:
-    //constructors
+    // constructors
     Path()
-            : path{}, isMemoized{false}, memoizedLocalNodePath{}, memoizedDirty{true},
-              localPRGIdOfMemoizedLocalNodePath{0} {} //default constructor
-    Path(const Path &other) = default; //copy default constructor
-    Path(Path &&other) { //move constructor
+        : path {}
+        , isMemoized { false }
+        , memoizedLocalNodePath {}
+        , memoizedDirty { true }
+        , localPRGIdOfMemoizedLocalNodePath { 0 }
+    {
+    } // default constructor
+    Path(const Path& other) = default; // copy default constructor
+    Path(Path&& other)
+    { // move constructor
         *this = std::move(other);
     }
 
-    //assignment operators
-    Path &operator=(const Path &other) = default; //copy assignment operator
-    Path &operator=(Path &&other) {
+    // assignment operators
+    Path& operator=(const Path& other) = default; // copy assignment operator
+    Path& operator=(Path&& other)
+    {
         if (this != &other) {
             this->path = std::move(other.path);
             this->isMemoized = std::move(other.isMemoized);
             this->memoizedLocalNodePath = std::move(other.memoizedLocalNodePath);
             this->memoizedDirty = std::move(other.memoizedDirty);
-            this->localPRGIdOfMemoizedLocalNodePath = std::move(other.localPRGIdOfMemoizedLocalNodePath);
+            this->localPRGIdOfMemoizedLocalNodePath
+                = std::move(other.localPRGIdOfMemoizedLocalNodePath);
         }
         return *this;
     }
 
-    //destructor
+    // destructor
     virtual ~Path() = default;
 
-
     ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-    //DIRTY METHODS - THAT CAN MODIFY path - memoization must be redone
+    // DIRTY METHODS - THAT CAN MODIFY path - memoization must be redone
     ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-    //delegated std::vector methods
-    void push_back(const Interval &interval) {
+    // delegated std::vector methods
+    void push_back(const Interval& interval)
+    {
         memoizedDirty = true;
         path.push_back(interval);
     }
 
-    void clear() {
+    void clear()
+    {
         memoizedDirty = true;
         path.clear();
     }
 
-    //add all intervals in the given range to the end of the path
-    template<class Iterator>
-    void insert_to_the_end(const Iterator &begin, const Iterator &end) {
+    // add all intervals in the given range to the end of the path
+    template <class Iterator>
+    void insert_to_the_end(const Iterator& begin, const Iterator& end)
+    {
         memoizedDirty = true;
         path.insert(path.end(), begin, end);
     }
 
-    Interval getAndRemoveLastInterval() {
+    Interval getAndRemoveLastInterval()
+    {
         memoizedDirty = true;
         Interval interval = path.back();
         path.pop_back();
         return interval;
     }
 
-
     /////////////////////////////
-    //initializers
-    //this was not before, but it is the most generic way of intializing (just give any two iterators)
-    template<class Iterator>
-    void initialize(const Iterator &begin, const Iterator &end, uint32_t reservedSize = 16) {
+    // initializers
+    // this was not before, but it is the most generic way of intializing (just give any
+    // two iterators)
+    template <class Iterator>
+    void initialize(
+        const Iterator& begin, const Iterator& end, uint32_t reservedSize = 16)
+    {
         memoizedDirty = true;
         path.clear();
         path.reserve(reservedSize);
         insert_to_the_end(begin, end);
     }
 
-    //some other convenience initializers, also because these are spread out in the code
-    //initialize with a single interval
-    void initialize(const Interval &i) {
+    // some other convenience initializers, also because these are spread out in the
+    // code initialize with a single interval
+    void initialize(const Interval& i)
+    {
         memoizedDirty = true;
-        std::vector<Interval> vectorOfInterval = {i};
+        std::vector<Interval> vectorOfInterval = { i };
         initialize(vectorOfInterval.begin(), vectorOfInterval.end());
     }
 
-    //initializes this path with the intervals in the container
-    template<class ContainerType>
-    void initialize(const ContainerType &container) {
+    // initializes this path with the intervals in the container
+    template <class ContainerType> void initialize(const ContainerType& container)
+    {
         /* TODO: keep this?
         if (container.empty())
             return;
@@ -110,41 +129,46 @@ public:
         initialize(container.begin(), container.end(), container.size() + 5);
     }
 
-    //initializes from a previous path
-    void initialize(const prg::Path &p) {
+    // initializes from a previous path
+    void initialize(const prg::Path& p)
+    {
         memoizedDirty = true;
         initialize(p.path);
     }
 
-    //add an interval to the end
-    void add_end_interval(const Interval &);
+    // add an interval to the end
+    void add_end_interval(const Interval&);
     /////////////////////////////
     ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-    //DIRTY METHODS - THAT CAN MODIFY path
+    // DIRTY METHODS - THAT CAN MODIFY path
     ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
-
-
     ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-    //CONST METHODS - THAT CANNOT MODIFY path - memoization does not need to be redone in these cases
+    // CONST METHODS - THAT CANNOT MODIFY path - memoization does not need to be redone
+    // in these cases
     ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-    //delegated std::vector methods
+    // delegated std::vector methods
     bool empty() const { return path.empty(); }
 
-    std::vector<Interval>::const_iterator
-    begin() const noexcept { return path.cbegin(); } //iteration on path always use constant iterator for now (no changes to intervals using iterators)
-    std::vector<Interval>::const_iterator
-    end() const noexcept { return path.cend(); } //iteration on path always use constant iterator for now (no changes to intervals using iterators)
-    const Interval &operator[](size_t n) const { return path[n]; }
+    std::vector<Interval>::const_iterator begin() const noexcept
+    {
+        return path.cbegin();
+    } // iteration on path always use constant iterator for now (no changes to intervals
+      // using iterators)
+    std::vector<Interval>::const_iterator end() const noexcept
+    {
+        return path.cend();
+    } // iteration on path always use constant iterator for now (no changes to intervals
+      // using iterators)
+    const Interval& operator[](size_t n) const { return path[n]; }
 
-    const Interval &back() const { return path.back(); }
+    const Interval& back() const { return path.back(); }
 
     size_t size() const { return path.size(); }
 
-    const std::vector<Interval> &getPath() const { return path; }
+    const std::vector<Interval>& getPath() const { return path; }
 
-
-    //some getters
+    // some getters
     uint32_t get_start() const;
 
     uint32_t get_end() const;
@@ -153,55 +177,49 @@ public:
 
     Path subpath(const uint32_t, const uint32_t) const;
 
-    bool is_branching(const Path &) const;
+    bool is_branching(const Path&) const;
 
-    bool is_subpath(const Path &) const;
+    bool is_subpath(const Path&) const;
 
-    //comparators
-    bool operator<(const Path &y) const;
+    // comparators
+    bool operator<(const Path& y) const;
 
-    bool operator==(const Path &y) const;
+    bool operator==(const Path& y) const;
 
-    bool operator!=(const Path &y) const;
+    bool operator!=(const Path& y) const;
     ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-    //CONST METHODS - THAT CANNOT MODIFY path
-    ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-
-
-
-
-    ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-    //MEMOIZATION METHOD
-    //the method responsible for memoization itself
-    std::vector<LocalNodePtr> nodes_along_path(const LocalPRG &localPrg);
+    // CONST METHODS - THAT CANNOT MODIFY path
     ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
-
-
+    ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+    // MEMOIZATION METHOD
+    // the method responsible for memoization itself
+    std::vector<LocalNodePtr> nodes_along_path(const LocalPRG& localPrg);
+    ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
     ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-    //friend methods
+    // friend methods
     ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-    friend std::ostream &operator<<(std::ostream &out, const Path &p);
+    friend std::ostream& operator<<(std::ostream& out, const Path& p);
 
-    friend std::istream &operator>>(std::istream &in, Path &p);
+    friend std::istream& operator>>(std::istream& in, Path& p);
 
-    friend Path get_union(const Path &, const Path &);
+    friend Path get_union(const Path&, const Path&);
 
-    friend bool equal_except_null_nodes(const Path &, const Path &);
+    friend bool equal_except_null_nodes(const Path&, const Path&);
     ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-    //friend methods
+    // friend methods
     ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 };
 
-bool equal_except_null_nodes(const prg::Path &, const prg::Path &);
+bool equal_except_null_nodes(const prg::Path&, const prg::Path&);
 
 typedef std::shared_ptr<prg::Path> PathPtr;
 struct ComparePathPtr {
-    bool operator()(const PathPtr &p1, const PathPtr &p2) const {
+    bool operator()(const PathPtr& p1, const PathPtr& p2) const
+    {
         return (*p1) == (*p2);
     }
 };
-
 
 #endif

--- a/include/seq.h
+++ b/include/seq.h
@@ -1,12 +1,11 @@
-#ifndef __SEQ_H_INCLUDED__   // if seq.h hasn't been included yet...
+#ifndef __SEQ_H_INCLUDED__ // if seq.h hasn't been included yet...
 #define __SEQ_H_INCLUDED__
 
-#include <string>
-#include <cstdint>
-#include <set>
-#include <ostream>
 #include "minimizer.h"
-
+#include <cstdint>
+#include <ostream>
+#include <set>
+#include <string>
 
 class Seq {
 public:
@@ -15,24 +14,25 @@ public:
     std::string seq;
     std::set<Minimizer> sketch;
 
-    Seq(uint32_t, const std::string &, const std::string &, uint32_t, uint32_t);
+    Seq(uint32_t, const std::string&, const std::string&, uint32_t, uint32_t);
 
     ~Seq();
 
-    void initialize(uint32_t, const std::string &, const std::string &, uint32_t, uint32_t);
+    void initialize(
+        uint32_t, const std::string&, const std::string&, uint32_t, uint32_t);
 
-    bool add_letter_to_get_next_kmer(const char &, const uint64_t &, const uint64_t &, uint32_t &, uint64_t (&)[2],
-                                     uint64_t (&)[2]);
+    bool add_letter_to_get_next_kmer(const char&, const uint64_t&, const uint64_t&,
+        uint32_t&, uint64_t (&)[2], uint64_t (&)[2]);
 
-    void add_minimizing_kmers_to_sketch(const std::vector<Minimizer> &, const uint64_t &);
+    void add_minimizing_kmers_to_sketch(const std::vector<Minimizer>&, const uint64_t&);
 
-    void minimize_window(std::vector<Minimizer> &, uint64_t &);
+    void minimize_window(std::vector<Minimizer>&, uint64_t&);
 
-    void add_new_smallest_minimizer(std::vector<Minimizer> &, uint64_t &);
+    void add_new_smallest_minimizer(std::vector<Minimizer>&, uint64_t&);
 
     void minimizer_sketch(const uint32_t w, const uint32_t k);
 
-    friend std::ostream &operator<<(std::ostream &out, const Seq &data);
+    friend std::ostream& operator<<(std::ostream& out, const Seq& data);
 };
 
 #endif

--- a/include/seq.h
+++ b/include/seq.h
@@ -6,6 +6,7 @@
 #include <ostream>
 #include <set>
 #include <string>
+#include <vector>
 
 class Seq {
 public:

--- a/include/utils.h
+++ b/include/utils.h
@@ -1,16 +1,15 @@
-#ifndef __UTILS_H_INCLUDED__   // if utils.h hasn't been included yet...
+#ifndef __UTILS_H_INCLUDED__ // if utils.h hasn't been included yet...
 #define __UTILS_H_INCLUDED__
 
-#include <vector>
-#include <set>
-#include <memory>
-#include <unordered_map>
-#include <cstdint>
-#include <string>
-#include <limits>
 #include "minihits.h"
 #include "pangenome/ns.cpp"
-
+#include <cstdint>
+#include <limits>
+#include <memory>
+#include <set>
+#include <string>
+#include <unordered_map>
+#include <vector>
 
 class Index;
 
@@ -22,22 +21,16 @@ class Seq;
 
 typedef std::unordered_map<std::string, std::string> VCFRefs;
 
-template<typename T>
-struct pointer_values_equal {
-    const T *to_find;
+template <typename T> struct pointer_values_equal {
+    const T* to_find;
 
-    bool operator()(const T *other) const {
-        return *to_find == *other;
-    }
+    bool operator()(const T* other) const { return *to_find == *other; }
 };
 
-template<typename T>
-struct spointer_values_equal {
+template <typename T> struct spointer_values_equal {
     const std::shared_ptr<T> to_find;
 
-    bool operator()(const std::shared_ptr<T> other) const {
-        return *to_find == *other;
-    }
+    bool operator()(const std::shared_ptr<T> other) const { return *to_find == *other; }
 };
 
 // utility functions
@@ -45,7 +38,7 @@ std::string now();
 
 std::string int_to_string(const int number);
 
-std::vector<std::string> split(const std::string &, const std::string &);
+std::vector<std::string> split(const std::string&, const std::string&);
 
 char complement(char);
 
@@ -53,46 +46,43 @@ std::string rev_complement(std::string);
 
 float lognchoosek2(uint32_t, uint32_t, uint32_t);
 
-//probably should be moved to map_main.cpp
-void read_prg_file(std::vector<std::shared_ptr<LocalPRG>> &,
-                   const std::string &, uint32_t id=0);
+// probably should be moved to map_main.cpp
+void read_prg_file(
+    std::vector<std::shared_ptr<LocalPRG>>&, const std::string&, uint32_t id = 0);
 
-void
-load_PRG_kmergraphs(std::vector<std::shared_ptr<LocalPRG>> &, const uint32_t &, const uint32_t &, const std::string &);
+void load_PRG_kmergraphs(std::vector<std::shared_ptr<LocalPRG>>&, const uint32_t&,
+    const uint32_t&, const std::string&);
 
-void load_vcf_refs_file(const std::string &, VCFRefs &);
+void load_vcf_refs_file(const std::string&, VCFRefs&);
 
-void add_read_hits(const Seq &, const std::shared_ptr<MinimizerHits> &, const Index &);
+void add_read_hits(const Seq&, const std::shared_ptr<MinimizerHits>&, const Index&);
 
-void define_clusters(std::set<std::set<MinimizerHitPtr, pComp>, clusterComp> &,
-                     const std::vector<std::shared_ptr<LocalPRG>> &,
-                     std::shared_ptr<MinimizerHits>, const int, const float &, const uint32_t, const uint32_t);
+void define_clusters(std::set<std::set<MinimizerHitPtr, pComp>, clusterComp>&,
+    const std::vector<std::shared_ptr<LocalPRG>>&, std::shared_ptr<MinimizerHits>,
+    const int, const float&, const uint32_t, const uint32_t);
 
-void filter_clusters(std::set<std::set<MinimizerHitPtr, pComp>, clusterComp> &);
+void filter_clusters(std::set<std::set<MinimizerHitPtr, pComp>, clusterComp>&);
 
-void filter_clusters2(std::set<std::set<MinimizerHitPtr, pComp>, clusterComp> &, const uint32_t &);
+void filter_clusters2(
+    std::set<std::set<MinimizerHitPtr, pComp>, clusterComp>&, const uint32_t&);
 
-void
-infer_localPRG_order_for_reads(const std::vector<std::shared_ptr<LocalPRG>> &prgs, std::shared_ptr<MinimizerHits> minimizer_hits,
-                               std::shared_ptr<pangenome::Graph>,
-                               const int,
-                               const uint32_t &, const float &, const uint32_t min_cluster_size = 10,
-                               const uint32_t expected_number_kmers_in_short_read_sketch = std::numeric_limits<uint32_t>::max());
+void infer_localPRG_order_for_reads(const std::vector<std::shared_ptr<LocalPRG>>& prgs,
+    std::shared_ptr<MinimizerHits> minimizer_hits, std::shared_ptr<pangenome::Graph>,
+    const int, const uint32_t&, const float&, const uint32_t min_cluster_size = 10,
+    const uint32_t expected_number_kmers_in_short_read_sketch
+    = std::numeric_limits<uint32_t>::max());
 
-uint32_t pangraph_from_read_file(const std::string &, std::shared_ptr<pangenome::Graph>,
-                                 std::shared_ptr<Index>,
-                                 const std::vector<std::shared_ptr<LocalPRG>> &,
-                                 const uint32_t, const uint32_t, const int, const float &,
-                                 const uint32_t min_cluster_size = 10,
-                                 const uint32_t genome_size = 5000000, const bool illumina = false,
-                                 const bool clean = false,
-                                 const uint32_t max_covg = 300,
-                                 uint32_t threads=1);
+uint32_t pangraph_from_read_file(const std::string&, std::shared_ptr<pangenome::Graph>,
+    std::shared_ptr<Index>, const std::vector<std::shared_ptr<LocalPRG>>&,
+    const uint32_t, const uint32_t, const int, const float&,
+    const uint32_t min_cluster_size = 10, const uint32_t genome_size = 5000000,
+    const bool illumina = false, const bool clean = false,
+    const uint32_t max_covg = 300, uint32_t threads = 1);
 
 //, const uint32_t, const float&, bool);
-void infer_most_likely_prg_path_for_pannode(const std::vector<std::shared_ptr<LocalPRG>> &, PanNode *, uint32_t, float);
+void infer_most_likely_prg_path_for_pannode(
+    const std::vector<std::shared_ptr<LocalPRG>>&, PanNode*, uint32_t, float);
 
-
-void fatalError (const std::string &message);
+void fatalError(const std::string& message);
 
 #endif

--- a/include/vcf.h
+++ b/include/vcf.h
@@ -1,15 +1,14 @@
-#ifndef __VCF_H_INCLUDED__   // if vcf.h hasn't been included yet...
+#ifndef __VCF_H_INCLUDED__ // if vcf.h hasn't been included yet...
 #define __VCF_H_INCLUDED__
 
-#include <ostream>
-#include <vector>
-#include <memory>
-#include <string>
-#include <cstdint>
-#include "vcfrecord.h"
 #include "IITree.h"
+#include "vcfrecord.h"
+#include <cstdint>
 #include <map>
-
+#include <memory>
+#include <ostream>
+#include <string>
+#include <vector>
 
 class LocalNode;
 
@@ -17,82 +16,96 @@ typedef std::shared_ptr<LocalNode> LocalNodePtr;
 
 class VCF {
 private:
-    /* will contain, for each chromosome, an interval tree containing VCF records interval and a pointer to the VCF Record itself to allow
+    /* will contain, for each chromosome, an interval tree containing VCF records
+       interval and a pointer to the VCF Record itself to allow
        VCF::make_gt_compatible() to execute a lot faster than serial search */
     std::map<std::string, IITree<uint32_t, VCFRecord*>> chrom2recordIntervalTree;
 
-    //add a VCF record to this VCF
-    void add_record_core(const VCFRecord &vr);
+    // add a VCF record to this VCF
+    void add_record_core(const VCFRecord& vr);
 
-    //find a VCRRecord in records
-    std::vector<std::shared_ptr<VCFRecord>>::iterator find_record_in_records(const VCFRecord &vr) {
-        return find_if(records.begin(), records.end(), [&vr](const std::shared_ptr<VCFRecord> &record) { return *record==vr; });
+    // find a VCRRecord in records
+    std::vector<std::shared_ptr<VCFRecord>>::iterator find_record_in_records(
+        const VCFRecord& vr)
+    {
+        return find_if(records.begin(), records.end(),
+            [&vr](const std::shared_ptr<VCFRecord>& record) { return *record == vr; });
     }
-    std::vector<std::shared_ptr<VCFRecord>>::const_iterator find_record_in_records(const VCFRecord &vr) const {
-        return find_if(records.begin(), records.end(), [&vr](const std::shared_ptr<VCFRecord> &record) { return *record==vr; });
+    std::vector<std::shared_ptr<VCFRecord>>::const_iterator find_record_in_records(
+        const VCFRecord& vr) const
+    {
+        return find_if(records.begin(), records.end(),
+            [&vr](const std::shared_ptr<VCFRecord>& record) { return *record == vr; });
     }
-
 
 public:
     std::vector<std::shared_ptr<VCFRecord>> records;
     std::vector<std::string> samples;
 
-    //constructor/destructors
+    // constructor/destructors
     VCF() = default;
     virtual ~VCF() = default;
 
-    void add_record(std::string c, uint32_t p, std::string r, std::string a, std::string i = ".", std::string g = "");
+    void add_record(std::string c, uint32_t p, std::string r, std::string a,
+        std::string i = ".", std::string g = "");
 
-    VCFRecord &add_record(VCFRecord &, const std::vector<std::string> &sample_names);
+    VCFRecord& add_record(VCFRecord&, const std::vector<std::string>& sample_names);
 
     void add_samples(const std::vector<std::string>);
 
-    void add_formats(const std::vector<std::string> &);
+    void add_formats(const std::vector<std::string>&);
 
-    ptrdiff_t get_sample_index(const std::string &);
+    ptrdiff_t get_sample_index(const std::string&);
 
-    void add_sample_gt(const std::string &name, const std::string &c, const uint32_t p, const std::string &r,
-                       const std::string &a);
+    void add_sample_gt(const std::string& name, const std::string& c, const uint32_t p,
+        const std::string& r, const std::string& a);
 
-    void add_sample_ref_alleles(const std::string &, const std::string &, const uint32_t &, const uint32_t &);
+    void add_sample_ref_alleles(
+        const std::string&, const std::string&, const uint32_t&, const uint32_t&);
 
-    void append_vcf(const VCF &);
+    void append_vcf(const VCF&);
 
     void sort_records();
 
-    bool pos_in_range(const uint32_t, const uint32_t, const std::string &) const;
+    bool pos_in_range(const uint32_t, const uint32_t, const std::string&) const;
 
-    void genotype(const std::vector<uint32_t> &, const float &, const uint16_t, const uint32_t &min_allele_covg,
-                  const float &min_fraction_allele_covg, const uint32_t &min_site_total_covg,
-                  const uint32_t &min_site_diff_covg, bool snps_only);
+    void genotype(const std::vector<uint32_t>&, const float&, const uint16_t,
+        const uint32_t& min_allele_covg, const float& min_fraction_allele_covg,
+        const uint32_t& min_site_total_covg, const uint32_t& min_site_diff_covg,
+        bool snps_only);
 
     void clean();
 
     void merge_multi_allelic(uint32_t max_allele_length = 10000);
 
-    void correct_dot_alleles(const std::string &, const std::string &);
+    void correct_dot_alleles(const std::string&, const std::string&);
 
     void make_gt_compatible();
 
     std::string header();
 
-    void save(const std::string &, bool simple = false, bool complexgraph = false, bool toomanyalts = false,
-              bool snp = false, bool indel = false, bool phsnps = false, bool complexvar = false);
+    void save(const std::string&, bool simple = false, bool complexgraph = false,
+        bool toomanyalts = false, bool snp = false, bool indel = false,
+        bool phsnps = false, bool complexvar = false);
 
-    void load(const std::string &);
+    void load(const std::string&);
 
-    bool operator==(const VCF &y) const;
+    bool operator==(const VCF& y) const;
 
-    bool operator!=(const VCF &y) const;
+    bool operator!=(const VCF& y) const;
 
     /**
-     * Concatenate several VCF files that were previously written to disk as .vcfs into a single VCF file
-     * @param VCFPathsToBeConcatenated : vector containing paths to the .vcfs to be concatenated
+     * Concatenate several VCF files that were previously written to disk as .vcfs into
+     * a single VCF file
+     * @param VCFPathsToBeConcatenated : vector containing paths to the .vcfs to be
+     * concatenated
      * @param sink : where to put the concatenated VCFs
      */
-    static void concatenateVCFs(const std::vector<std::string> &VCFPathsToBeConcatenated, const std::string &sink);
+    static void concatenateVCFs(
+        const std::vector<std::string>& VCFPathsToBeConcatenated,
+        const std::string& sink);
 
-    friend std::ostream &operator<<(std::ostream &out, const VCF &m);
+    friend std::ostream& operator<<(std::ostream& out, const VCF& m);
 };
 
 #endif

--- a/include/vcfrecord.h
+++ b/include/vcfrecord.h
@@ -1,12 +1,11 @@
-#ifndef __VCFRECORD_H_INCLUDED__   // if vcfrecord.h hasn't been included yet...
+#ifndef __VCFRECORD_H_INCLUDED__ // if vcfrecord.h hasn't been included yet...
 #define __VCFRECORD_H_INCLUDED__
 
-#include <iostream>
-#include <vector>
-#include <string>
 #include <cstdint>
+#include <iostream>
+#include <string>
 #include <unordered_map>
-
+#include <vector>
 
 struct VCFRecord {
     //#CHROM POS ID REF ALT QUAL FILTER INFO FORMAT
@@ -18,17 +17,20 @@ struct VCFRecord {
     std::string qual; // not used
     std::string filter; // not used
     std::string info;
-    std::vector<std::string> format; //e.g. "GT"
-    std::vector<std::unordered_map<std::string, std::vector<uint16_t>>> samples;      // should have an entry for each sample in vcf,
-    std::vector<std::unordered_map<std::string, std::vector<float>>> regt_samples;   // in the same order
+    std::vector<std::string> format; // e.g. "GT"
+    std::vector<std::unordered_map<std::string, std::vector<uint16_t>>>
+        samples; // should have an entry for each sample in vcf,
+    std::vector<std::unordered_map<std::string, std::vector<float>>>
+        regt_samples; // in the same order
 
-    VCFRecord(std::string, uint32_t, std::string, std::string, std::string i = ".", std::string g = "");
+    VCFRecord(std::string, uint32_t, std::string, std::string, std::string i = ".",
+        std::string g = "");
 
     VCFRecord();
 
-    VCFRecord(const VCFRecord &);
+    VCFRecord(const VCFRecord&);
 
-    VCFRecord &operator=(const VCFRecord &);
+    VCFRecord& operator=(const VCFRecord&);
 
     ~VCFRecord();
 
@@ -36,7 +38,7 @@ struct VCFRecord {
 
     void clear_sample(uint32_t);
 
-    void add_formats(const std::vector<std::string> &);
+    void add_formats(const std::vector<std::string>&);
 
     void set_format(const uint32_t&, const std::string&, const std::vector<uint16_t>&);
 
@@ -58,23 +60,25 @@ struct VCFRecord {
 
     std::vector<float> get_format_f(const uint32_t&, const std::string&);
 
-    void likelihood(const std::vector<uint32_t> &, const float &, const uint32_t &, const float &min_fraction_allele_covg=0);
+    void likelihood(const std::vector<uint32_t>&, const float&, const uint32_t&,
+        const float& min_fraction_allele_covg = 0);
 
-    void confidence(const uint32_t &min_total_covg=0, const uint32_t &min_diff_covg=0);
+    void confidence(
+        const uint32_t& min_total_covg = 0, const uint32_t& min_diff_covg = 0);
 
     void genotype(const uint16_t);
 
     bool contains_dot_allele() const;
 
-    bool operator==(const VCFRecord &y) const;
+    bool operator==(const VCFRecord& y) const;
 
-    bool operator!=(const VCFRecord &y) const;
+    bool operator!=(const VCFRecord& y) const;
 
-    bool operator<(const VCFRecord &y) const;
+    bool operator<(const VCFRecord& y) const;
 
-    friend std::ostream &operator<<(std::ostream &out, const VCFRecord &m);
+    friend std::ostream& operator<<(std::ostream& out, const VCFRecord& m);
 
-    friend std::istream &operator>>(std::istream &in, VCFRecord &m);
+    friend std::istream& operator>>(std::istream& in, VCFRecord& m);
 };
 
 #endif

--- a/src/check_kmergraph_main.cpp
+++ b/src/check_kmergraph_main.cpp
@@ -1,22 +1,24 @@
-#include <cstring>
 #include <cassert>
-#include <vector>
-#include <iostream>
+#include <cstring>
 #include <fstream>
+#include <iostream>
+#include <vector>
 
 #include <boost/log/trivial.hpp>
 
-#include "utils.h"
 #include "localPRG.h"
+#include "utils.h"
 
-
-int pandora_check_kmergraph(int argc, char *argv[]) // the "pandora check_kmergraph" comand
+int pandora_check_kmergraph(
+    int argc, char* argv[]) // the "pandora check_kmergraph" comand
 {
-    // can either provide a prgfile with 1 prg and a sequence file (or top/bottom) and return the path through the prg for each sequence
-    // OR can provide a prgfile with multiple sequences in it, and a seq file with the same number, with 1-1 correspondance and check
-    // seq n in prg n.
+    // can either provide a prgfile with 1 prg and a sequence file (or top/bottom) and
+    // return the path through the prg for each sequence OR can provide a prgfile with
+    // multiple sequences in it, and a seq file with the same number, with 1-1
+    // correspondance and check seq n in prg n.
     if (argc < 5) {
-        fprintf(stderr, "Usage: pandora check_kmergraph <prg.fa> <seq.fa> <k> <w> <flag>\n");
+        fprintf(stderr,
+            "Usage: pandora check_kmergraph <prg.fa> <seq.fa> <k> <w> <flag>\n");
         return 1;
     }
 
@@ -40,7 +42,8 @@ int pandora_check_kmergraph(int argc, char *argv[]) // the "pandora check_kmergr
         cout << kpath[0]->id;
         for (uint j=1; j != kpath.size(); ++j)
             {
-            if (find(kpath[j]->inNodes.begin(), kpath[j]->inNodes.end(), kpath[j-1])!=kpath[j]->inNodes.end())
+            if (find(kpath[j]->inNodes.begin(), kpath[j]->inNodes.end(),
+        kpath[j-1])!=kpath[j]->inNodes.end())
             {
                     cout << "->" << kpath[j]->id;
             } else {
@@ -62,7 +65,8 @@ int pandora_check_kmergraph(int argc, char *argv[]) // the "pandora check_kmergr
         cout << kpath[0]->id;
         for (uint j=1; j != kpath.size(); ++j)
         {
-	    if (find(kpath[j]->inNodes.begin(), kpath[j]->inNodes.end(), kpath[j-1])!=kpath[j]->inNodes.end())
+            if (find(kpath[j]->inNodes.begin(), kpath[j]->inNodes.end(),
+        kpath[j-1])!=kpath[j]->inNodes.end())
             {
                 cout << "->" << kpath[j]->id;
             } else {
@@ -87,21 +91,24 @@ int pandora_check_kmergraph(int argc, char *argv[]) // the "pandora check_kmergr
             if (line.empty() || line[0] == '>') {
                 if (!name.empty() && !read.empty()) {
                     if (prgs.size() == 1) {
-                        std::cout << "Node path for read " << read_num << " " << name << " along PRG " << prgs[0]->name
-                                  << ": ";
+                        std::cout << "Node path for read " << read_num << " " << name
+                                  << " along PRG " << prgs[0]->name << ": ";
                         npath = prgs[0]->prg.nodes_along_string(read);
                         if (npath.empty()) {
-                            npath = prgs[0]->prg.nodes_along_string(rev_complement(read));
+                            npath
+                                = prgs[0]->prg.nodes_along_string(rev_complement(read));
                         }
                     } else if (read_num < prgs.size()) {
-                        std::cout << "Node path for read " << read_num << " " << name << " along PRG "
-                                  << prgs[read_num]->name << ": ";
+                        std::cout << "Node path for read " << read_num << " " << name
+                                  << " along PRG " << prgs[read_num]->name << ": ";
                         npath = prgs[read_num]->prg.nodes_along_string(read);
                         if (npath.empty()) {
-                            npath = prgs[read_num]->prg.nodes_along_string(rev_complement(read));
+                            npath = prgs[read_num]->prg.nodes_along_string(
+                                rev_complement(read));
                         }
                     } else {
-                        BOOST_LOG_TRIVIAL(error) << "Different numbers of PRGs and reads, exiting";
+                        BOOST_LOG_TRIVIAL(error)
+                            << "Different numbers of PRGs and reads, exiting";
                         break;
                     }
                     if (flag) {
@@ -118,7 +125,8 @@ int pandora_check_kmergraph(int argc, char *argv[]) // the "pandora check_kmergr
                         }
                         std::cout << std::endl;
                     }
-                    /*vector<KmerNodePtr> kpath = prgs[0]->find_kmernodes_on_localnode_path(npath);
+                    /*vector<KmerNodePtr> kpath =
+                    prgs[0]->find_kmernodes_on_localnode_path(npath);
 
                     cout << "kmers on path: " << endl;
                             for (uint j=0; j != kpath.size(); ++j)
@@ -129,13 +137,14 @@ int pandora_check_kmergraph(int argc, char *argv[]) // the "pandora check_kmergr
                         cout << "kmer path: " << kpath[0]->id;
                         for (uint j=1; j != kpath.size(); ++j)
                         {
-                      if (find(kpath[j]->inNodes.begin(), kpath[j]->inNodes.end(), kpath[j-1])!=kpath[j]->inNodes.end())
+                      if (find(kpath[j]->inNodes.begin(), kpath[j]->inNodes.end(),
+                    kpath[j-1])!=kpath[j]->inNodes.end())
                                 {
                                     cout << "->" << kpath[j]->id;
                                 } else {
-                                    cout << endl << "no edge from " << kpath[j-1]->path << " to " << kpath[j]->path << endl;
-                        cout << "outnodes are: " << endl;
-                        for (uint n=0; n!= kpath[j-1]->outNodes.size(); ++n)
+                                    cout << endl << "no edge from " << kpath[j-1]->path
+                    << " to " << kpath[j]->path << endl; cout << "outnodes are: " <<
+                    endl; for (uint n=0; n!= kpath[j-1]->outNodes.size(); ++n)
                         {
                         cout << kpath[j-1]->outNodes[n]->path << endl;
                         }
@@ -161,20 +170,23 @@ int pandora_check_kmergraph(int argc, char *argv[]) // the "pandora check_kmergr
         // and last entry
         if (!name.empty() && !read.empty()) {
             if (prgs.size() == 1) {
-                std::cout << "Node path for read " << read_num << " " << name << " along PRG " << prgs[0]->name << ": ";
+                std::cout << "Node path for read " << read_num << " " << name
+                          << " along PRG " << prgs[0]->name << ": ";
                 npath = prgs[0]->prg.nodes_along_string(read);
                 if (npath.empty()) {
                     npath = prgs[0]->prg.nodes_along_string(rev_complement(read));
                 }
             } else if (read_num < prgs.size()) {
-                std::cout << "Node path for read " << read_num << " " << name << " along PRG " << prgs[read_num]->name
-                          << ": ";
+                std::cout << "Node path for read " << read_num << " " << name
+                          << " along PRG " << prgs[read_num]->name << ": ";
                 npath = prgs[read_num]->prg.nodes_along_string(read);
                 if (npath.empty()) {
-                    npath = prgs[read_num]->prg.nodes_along_string(rev_complement(read));
+                    npath
+                        = prgs[read_num]->prg.nodes_along_string(rev_complement(read));
                 }
             } else {
-                std::cout << "Different numbers of PRGs and reads, exiting" << std::endl;
+                std::cout << "Different numbers of PRGs and reads, exiting"
+                          << std::endl;
                 myfile.close();
                 return 1;
             }
@@ -192,7 +204,8 @@ int pandora_check_kmergraph(int argc, char *argv[]) // the "pandora check_kmergr
                 }
                 std::cout << std::endl;
             }
-            /*vector<KmerNodePtr> kpath = prgs[0]->find_kmernodes_on_localnode_path(npath);
+            /*vector<KmerNodePtr> kpath =
+            prgs[0]->find_kmernodes_on_localnode_path(npath);
 
                 cout << "kmers on path: " << endl;
                 for (uint j=0; j != kpath.size(); ++j)
@@ -203,13 +216,14 @@ int pandora_check_kmergraph(int argc, char *argv[]) // the "pandora check_kmergr
                 cout << "kmer path: " << kpath[0]->id;
                 for (uint j=1; j != kpath.size(); ++j)
                 {
-            if (find(kpath[j]->inNodes.begin(), kpath[j]->inNodes.end(), kpath[j-1])!=kpath[j]->inNodes.end())
+            if (find(kpath[j]->inNodes.begin(), kpath[j]->inNodes.end(),
+            kpath[j-1])!=kpath[j]->inNodes.end())
                     {
                         cout << "->" << kpath[j]->id;
                     } else {
-                cout << endl << "no edge from " << kpath[j-1]->path << " to " << kpath[j]->path << endl;
-                        cout << "outnodes are: " << endl;
-                        for (uint n=0; n!= kpath[j-1]->outNodes.size(); ++n)
+                cout << endl << "no edge from " << kpath[j-1]->path << " to " <<
+            kpath[j]->path << endl; cout << "outnodes are: " << endl; for (uint n=0; n!=
+            kpath[j-1]->outNodes.size(); ++n)
                         {
                             cout << kpath[j-1]->outNodes[n]->path << endl;
                         }
@@ -229,4 +243,3 @@ int pandora_check_kmergraph(int argc, char *argv[]) // the "pandora check_kmergr
     }
     return 0;
 }
-

--- a/src/compare_main.cpp
+++ b/src/compare_main.cpp
@@ -1,71 +1,80 @@
 /*
- * C++ Program to call variation between a set of samples. 
- * To do this, runs pandora map process on each sample/readfile to find the best gene sequence for 
- * each gene inferred present in that sample. Then compares the paths found through each gene and 
- * outputs a vcf and aligned fasta for each one. 
+ * C++ Program to call variation between a set of samples.
+ * To do this, runs pandora map process on each sample/readfile to find the best gene
+ * sequence for each gene inferred present in that sample. Then compares the paths found
+ * through each gene and outputs a vcf and aligned fasta for each one.
  */
 /*
  * QUESTIONS:
- * How do I handle multiple occurrences of a gene in a sample? I would like to output all the versions called against my new reference
+ * How do I handle multiple occurrences of a gene in a sample? I would like to output
+ * all the versions called against my new reference
  */
 
-#include <iostream>
-#include <sstream>
-#include <vector>
-#include <set>
-#include <tuple>
-#include <functional>
+#include <algorithm>
+#include <boost/log/expressions.hpp>
+#include <boost/log/trivial.hpp>
+#include <cassert>
 #include <cctype>
 #include <fstream>
-#include <algorithm>
+#include <functional>
+#include <iostream>
 #include <map>
-#include <cassert>
-#include <boost/log/trivial.hpp>
-#include <boost/log/expressions.hpp>
+#include <set>
+#include <sstream>
+#include <tuple>
+#include <vector>
 
-#include "utils.h"
+#include "estimate_parameters.h"
+#include "index.h"
 #include "localPRG.h"
 #include "localgraph.h"
+#include "noise_filtering.h"
 #include "pangenome/pangraph.h"
 #include "pangenome/pannode.h"
-#include "index.h"
-#include "noise_filtering.h"
-#include "estimate_parameters.h"
-
+#include "utils.h"
 
 using std::set;
 using std::vector;
 
-
-static void show_compare_usage() {
-    std::cerr << "Usage: pandora compare -p PRG_FILE -r READ_INDEX -o OUTDIR <option(s)>\n"
-              << "Options:\n"
-              << "\t-h,--help\t\t\tShow this help message\n"
-              << "\t-p,--prg_file PRG_FILE\t\tSpecify a fasta-style prg file\n"
-              << "\t-r,--read_index READ_INDEX\tSpecify a file with a line per sample\n"
-              << "\t\t\t\t\tsample_id <tab> filepath to reads in fasta/q format\n"
-              << "\t-o,--outdir OUTDIR\tSpecify directory of output\n"
-              << "\t-w W\t\t\t\tWindow size for (w,k)-minimizers, default 14\n"
-              << "\t-k K\t\t\t\tK-mer size for (w,k)-minimizers, default 15\n"
-              << "\t-m,--max_diff INT\t\tMaximum distance between consecutive hits within a cluster, default 250 (bps)\n"
-              << "\t-e,--error_rate FLOAT\t\tEstimated error rate for reads, default 0.11\n"
-              << "\t-t T\t\t\t\tNumber of threads, default 1\n"
-              << "\t--genome_size\tNUM_BP\tEstimated length of genome, used for coverage estimation\n"
-              << "\t--vcf_refs REF_FASTA\t\tA fasta file with an entry for each LocalPRG giving reference sequence for\n"
-              << "\t\t\t\t\tVCF. Must have a perfect match in the graph and the same name as the graph\n"
-              << "\t--illumina\t\t\tData is from illumina rather than nanopore, so is shorter with low error rate\n"
-              << "\t--clean\t\t\tAdd a step to clean and detangle the pangraph\n"
-              << "\t--bin\t\t\tUse binomial model for kmer coverages, default is negative binomial\n"
-              << "\t--max_covg\t\t\tMaximum average coverage from reads to accept\n"
-              << "\t--genotype\t\t\tAdd extra step to carefully genotype sites\n"
-              << "\t--log_level\t\t\tdebug,[info],warning,error\n"
-              << std::endl;
+static void show_compare_usage()
+{
+    std::cerr
+        << "Usage: pandora compare -p PRG_FILE -r READ_INDEX -o OUTDIR <option(s)>\n"
+        << "Options:\n"
+        << "\t-h,--help\t\t\tShow this help message\n"
+        << "\t-p,--prg_file PRG_FILE\t\tSpecify a fasta-style prg file\n"
+        << "\t-r,--read_index READ_INDEX\tSpecify a file with a line per sample\n"
+        << "\t\t\t\t\tsample_id <tab> filepath to reads in fasta/q format\n"
+        << "\t-o,--outdir OUTDIR\tSpecify directory of output\n"
+        << "\t-w W\t\t\t\tWindow size for (w,k)-minimizers, default 14\n"
+        << "\t-k K\t\t\t\tK-mer size for (w,k)-minimizers, default 15\n"
+        << "\t-m,--max_diff INT\t\tMaximum distance between consecutive hits within a "
+           "cluster, default 250 (bps)\n"
+        << "\t-e,--error_rate FLOAT\t\tEstimated error rate for reads, default 0.11\n"
+        << "\t-t T\t\t\t\tNumber of threads, default 1\n"
+        << "\t--genome_size\tNUM_BP\tEstimated length of genome, used for coverage "
+           "estimation\n"
+        << "\t--vcf_refs REF_FASTA\t\tA fasta file with an entry for each LocalPRG "
+           "giving reference sequence for\n"
+        << "\t\t\t\t\tVCF. Must have a perfect match in the graph and the same name as "
+           "the graph\n"
+        << "\t--illumina\t\t\tData is from illumina rather than nanopore, so is "
+           "shorter with low error rate\n"
+        << "\t--clean\t\t\tAdd a step to clean and detangle the pangraph\n"
+        << "\t--bin\t\t\tUse binomial model for kmer coverages, default is negative "
+           "binomial\n"
+        << "\t--max_covg\t\t\tMaximum average coverage from reads to accept\n"
+        << "\t--genotype\t\t\tAdd extra step to carefully genotype sites\n"
+        << "\t--log_level\t\t\tdebug,[info],warning,error\n"
+        << std::endl;
 }
 
 using SampleIdText = std::string;
 using SampleFpath = std::string;
 
-std::vector<std::pair<SampleIdText, SampleFpath>> load_read_index(const std::string &read_index_fpath) {
+std::vector<std::pair<SampleIdText, SampleFpath>> load_read_index(
+    const std::string& read_index_fpath)
+{
     std::map<SampleIdText, SampleFpath> samples;
     std::string name, reads_path, line;
     std::ifstream myfile(read_index_fpath);
@@ -75,7 +84,8 @@ std::vector<std::pair<SampleIdText, SampleFpath>> load_read_index(const std::str
             if (std::getline(linestream, name, '\t')) {
                 linestream >> reads_path;
                 if (samples.find(name) != samples.end()) {
-                    std::cout << "Warning: non-unique sample ids given! Only the last of these will be kept"
+                    std::cout << "Warning: non-unique sample ids given! Only the last "
+                                 "of these will be kept"
                               << std::endl;
                 }
                 samples[name] = reads_path;
@@ -85,11 +95,14 @@ std::vector<std::pair<SampleIdText, SampleFpath>> load_read_index(const std::str
         std::cerr << "Unable to open read index file " << read_index_fpath << std::endl;
         exit(1);
     }
-    std::cout << now() << "Finished loading " << samples.size() << " samples from read index" << std::endl;
-    return std::vector<std::pair<SampleIdText, SampleFpath>>(samples.begin(), samples.end());
+    std::cout << now() << "Finished loading " << samples.size()
+              << " samples from read index" << std::endl;
+    return std::vector<std::pair<SampleIdText, SampleFpath>>(
+        samples.begin(), samples.end());
 }
 
-int pandora_compare(int argc, char *argv[]) {
+int pandora_compare(int argc, char* argv[])
+{
     // if not enough arguments, print usage
     if (argc < 7) {
         show_compare_usage();
@@ -97,12 +110,15 @@ int pandora_compare(int argc, char *argv[]) {
     }
 
     // otherwise, parse the parameters from the command line
-    std::string prgfile, read_index_fpath, outdir = "pandora", vcf_refs_file, log_level="info";
-    uint32_t w = 14, k = 15, min_cluster_size = 10, genome_size = 5000000, max_covg = 300, max_num_kmers_to_average=100,
-            min_allele_covg_gt = 0, min_total_covg_gt = 0, min_diff_covg_gt = 0, min_kmer_covg=0, threads=1; // default parameters
+    std::string prgfile, read_index_fpath, outdir = "pandora", vcf_refs_file,
+                                           log_level = "info";
+    uint32_t w = 14, k = 15, min_cluster_size = 10, genome_size = 5000000,
+             max_covg = 300, max_num_kmers_to_average = 100, min_allele_covg_gt = 0,
+             min_total_covg_gt = 0, min_diff_covg_gt = 0, min_kmer_covg = 0,
+             threads = 1; // default parameters
     uint16_t confidence_threshold = 1;
     int max_diff = 250;
-    float e_rate = 0.11, min_allele_fraction_covg_gt = 0, genotyping_error_rate=0.01;
+    float e_rate = 0.11, min_allele_fraction_covg_gt = 0, genotyping_error_rate = 0.01;
     bool illumina = false, clean = false, bin = false, genotype = false;
     for (int i = 1; i < argc; ++i) {
         std::string arg = argv[i];
@@ -111,56 +127,70 @@ int pandora_compare(int argc, char *argv[]) {
             return 0;
         } else if ((arg == "-p") || (arg == "--prg_file")) {
             if (i + 1 < argc) { // Make sure we aren't at the end of argv!
-                prgfile = argv[++i]; // Increment 'i' so we don't get the argument as the next argv[i].
+                prgfile = argv[++i]; // Increment 'i' so we don't get the argument as
+                                     // the next argv[i].
             } else { // Uh-oh, there was no argument to the destination option.
                 std::cerr << "--prg_file option requires one argument." << std::endl;
                 return 1;
             }
         } else if ((arg == "-r") || (arg == "--read_index")) {
             if (i + 1 < argc) { // Make sure we aren't at the end of argv!
-                read_index_fpath = argv[++i]; // Increment 'i' so we don't get the argument as the next argv[i].
+                read_index_fpath = argv[++i]; // Increment 'i' so we don't get the
+                                              // argument as the next argv[i].
             } else { // Uh-oh, there was no argument to the destination option.
                 std::cerr << "--read_index option requires one argument." << std::endl;
                 return 1;
             }
         } else if ((arg == "-o") || (arg == "--outdir")) {
             if (i + 1 < argc) { // Make sure we aren't at the end of argv!
-                outdir = argv[++i]; // Increment 'i' so we don't get the argument as the next argv[i].
+                outdir = argv[++i]; // Increment 'i' so we don't get the argument as the
+                                    // next argv[i].
             } else { // Uh-oh, there was no argument to the destination option.
                 std::cerr << "--outdir option requires one argument." << std::endl;
                 return 1;
             }
         } else if (arg == "-w") {
             if (i + 1 < argc) { // Make sure we aren't at the end of argv!
-                w = strtoul(argv[++i], nullptr, 10); // Increment 'i' so we don't get the argument as the next argv[i].
+                w = strtoul(
+                    argv[++i], nullptr, 10); // Increment 'i' so we don't get the
+                                             // argument as the next argv[i].
             } else { // Uh-oh, there was no argument to the destination option.
                 std::cerr << "-w option requires one argument." << std::endl;
                 return 1;
             }
         } else if (arg == "-k") {
             if (i + 1 < argc) { // Make sure we aren't at the end of argv!
-                k = strtoul(argv[++i], nullptr, 10); // Increment 'i' so we don't get the argument as the next argv[i].
+                k = strtoul(
+                    argv[++i], nullptr, 10); // Increment 'i' so we don't get the
+                                             // argument as the next argv[i].
             } else { // Uh-oh, there was no argument to the destination option.
                 std::cerr << "-k option requires one argument." << std::endl;
                 return 1;
             }
         } else if ((arg == "-m") || (arg == "--max_diff")) {
             if (i + 1 < argc) { // Make sure we aren't at the end of argv!
-                max_diff = strtol(argv[++i], nullptr, 10); // Increment 'i' so we don't get the argument as the next argv[i].
+                max_diff = strtol(
+                    argv[++i], nullptr, 10); // Increment 'i' so we don't get the
+                                             // argument as the next argv[i].
             } else { // Uh-oh, there was no argument to the destination option.
                 std::cerr << "--max_diff option requires one argument." << std::endl;
                 return 1;
             }
         } else if ((arg == "-c") || (arg == "--min_cluster_size")) {
             if (i + 1 < argc) { // Make sure we aren't at the end of argv!
-                min_cluster_size = strtoul(argv[++i], nullptr, 10); // Increment 'i' so we don't get the argument as the next argv[i].
+                min_cluster_size = strtoul(
+                    argv[++i], nullptr, 10); // Increment 'i' so we don't get the
+                                             // argument as the next argv[i].
             } else { // Uh-oh, there was no argument to the destination option.
-                std::cerr << "--min_cluster_size option requires one argument." << std::endl;
+                std::cerr << "--min_cluster_size option requires one argument."
+                          << std::endl;
                 return 1;
             }
         } else if ((arg == "-e") || (arg == "--error_rate")) {
             if (i + 1 < argc) { // Make sure we aren't at the end of argv!
-                e_rate = strtof(argv[++i], nullptr); // Increment 'i' so we don't get the argument as the next argv[i].
+                e_rate
+                    = strtof(argv[++i], nullptr); // Increment 'i' so we don't get the
+                                                  // argument as the next argv[i].
                 if (e_rate < 0.01) {
                     illumina = true;
                 }
@@ -170,14 +200,17 @@ int pandora_compare(int argc, char *argv[]) {
             }
         } else if ((arg == "--genome_size")) {
             if (i + 1 < argc) { // Make sure we aren't at the end of argv!
-                genome_size = strtoul(argv[++i], nullptr, 10); // Increment 'i' so we don't get the argument as the next argv[i].
+                genome_size = strtoul(
+                    argv[++i], nullptr, 10); // Increment 'i' so we don't get the
+                                             // argument as the next argv[i].
             } else { // Uh-oh, there was no argument to the destination option.
                 std::cerr << "--genome_size option requires one argument." << std::endl;
                 return 1;
             }
         } else if (arg == "--vcf_refs") {
             if (i + 1 < argc) { // Make sure we aren't at the end of argv!
-                vcf_refs_file = argv[++i]; // Increment 'i' so we don't get the argument as the next argv[i].
+                vcf_refs_file = argv[++i]; // Increment 'i' so we don't get the argument
+                                           // as the next argv[i].
             } else { // Uh-oh, there was no argument to the destination option.
                 std::cerr << "--vcf_refs option requires one argument." << std::endl;
                 return 1;
@@ -190,79 +223,106 @@ int pandora_compare(int argc, char *argv[]) {
             bin = true;
         } else if ((arg == "--max_covg")) {
             if (i + 1 < argc) { // Make sure we aren't at the end of argv!
-                max_covg = strtoul(argv[++i], nullptr, 10); // Increment 'i' so we don't get the argument as the next argv[i].
+                max_covg = strtoul(
+                    argv[++i], nullptr, 10); // Increment 'i' so we don't get the
+                                             // argument as the next argv[i].
             } else { // Uh-oh, there was no argument to the destination option.
                 std::cerr << "--max_covg option requires one argument." << std::endl;
                 return 1;
             }
         } else if ((arg == "--max_num_kmers_to_average")) {
             if (i + 1 < argc) { // Make sure we aren't at the end of argv!
-                max_num_kmers_to_average = strtoul(argv[++i], nullptr, 10); // Increment 'i' so we don't get the argument as the next argv[i].
+                max_num_kmers_to_average = strtoul(
+                    argv[++i], nullptr, 10); // Increment 'i' so we don't get the
+                                             // argument as the next argv[i].
             } else { // Uh-oh, there was no argument to the destination option.
-                std::cerr << "--max_num_kmers_to_average option requires one argument." << std::endl;
+                std::cerr << "--max_num_kmers_to_average option requires one argument."
+                          << std::endl;
                 return 1;
             }
         } else if ((arg == "--min_allele_covg_gt")) {
             if (i + 1 < argc) { // Make sure we aren't at the end of argv!
-                min_allele_covg_gt = strtoul(argv[++i], nullptr, 10); // Increment 'i' so we don't get the argument as the next argv[i].
+                min_allele_covg_gt = strtoul(
+                    argv[++i], nullptr, 10); // Increment 'i' so we don't get the
+                                             // argument as the next argv[i].
             } else { // Uh-oh, there was no argument to the destination option.
-                std::cerr << "--min_allele_covg_gt option requires one argument." << std::endl;
+                std::cerr << "--min_allele_covg_gt option requires one argument."
+                          << std::endl;
                 return 1;
             }
         } else if ((arg == "--min_total_covg_gt")) {
             if (i + 1 < argc) { // Make sure we aren't at the end of argv!
-                min_total_covg_gt = strtoul(argv[++i], nullptr, 10); // Increment 'i' so we don't get the argument as the next argv[i].
+                min_total_covg_gt = strtoul(
+                    argv[++i], nullptr, 10); // Increment 'i' so we don't get the
+                                             // argument as the next argv[i].
             } else { // Uh-oh, there was no argument to the destination option.
-                std::cerr << "--min_total_covg_gt option requires one argument." << std::endl;
+                std::cerr << "--min_total_covg_gt option requires one argument."
+                          << std::endl;
                 return 1;
             }
         } else if ((arg == "--min_diff_covg_gt")) {
             if (i + 1 < argc) { // Make sure we aren't at the end of argv!
-                min_diff_covg_gt = strtoul(argv[++i], nullptr, 10); // Increment 'i' so we don't get the argument as the next argv[i].
+                min_diff_covg_gt = strtoul(
+                    argv[++i], nullptr, 10); // Increment 'i' so we don't get the
+                                             // argument as the next argv[i].
             } else { // Uh-oh, there was no argument to the destination option.
-                std::cerr << "--min_diff_covg_gt option requires one argument." << std::endl;
+                std::cerr << "--min_diff_covg_gt option requires one argument."
+                          << std::endl;
                 return 1;
             }
         } else if ((arg == "--min_allele_fraction_covg_gt")) {
             if (i + 1 < argc) { // Make sure we aren't at the end of argv!
-                min_allele_fraction_covg_gt = strtof(argv[++i], nullptr); // Increment 'i' so we don't get the argument as the next argv[i].
+                min_allele_fraction_covg_gt
+                    = strtof(argv[++i], nullptr); // Increment 'i' so we don't get the
+                                                  // argument as the next argv[i].
             } else { // Uh-oh, there was no argument to the destination option.
-                std::cerr << "--min_allele_fraction_covg_gt option requires one argument." << std::endl;
+                std::cerr
+                    << "--min_allele_fraction_covg_gt option requires one argument."
+                    << std::endl;
                 return 1;
             }
         } else if ((arg == "--genotyping_error_rate")) {
             if (i + 1 < argc) { // Make sure we aren't at the end of argv!
-                genotyping_error_rate = strtof(argv[++i], nullptr); // Increment 'i' so we don't get the argument as the next argv[i].
+                genotyping_error_rate
+                    = strtof(argv[++i], nullptr); // Increment 'i' so we don't get the
+                                                  // argument as the next argv[i].
             } else { // Uh-oh, there was no argument to the destination option.
-                std::cerr << "--genotyping_error_rate option requires one argument." << std::endl;
+                std::cerr << "--genotyping_error_rate option requires one argument."
+                          << std::endl;
                 return 1;
             }
         } else if ((arg == "--confidence_threshold")) {
             if (i + 1 < argc) { // Make sure we aren't at the end of argv!
-                confidence_threshold = (uint16_t)strtoul(argv[++i], nullptr, 10); // Increment 'i' so we don't get the argument as the next argv[i].
+                confidence_threshold = (uint16_t)strtoul(
+                    argv[++i], nullptr, 10); // Increment 'i' so we don't get the
+                                             // argument as the next argv[i].
             } else { // Uh-oh, there was no argument to the destination option.
-                std::cerr << "--confidence_threshold option requires one argument." << std::endl;
+                std::cerr << "--confidence_threshold option requires one argument."
+                          << std::endl;
                 return 1;
             }
         } else if ((arg == "--genotype")) {
             genotype = true;
         } else if ((arg == "--log_level")) {
             if (i + 1 < argc) { // Make sure we aren't at the end of argv!
-                log_level = argv[++i]; // Increment 'i' so we don't get the argument as the next argv[i].
+                log_level = argv[++i]; // Increment 'i' so we don't get the argument as
+                                       // the next argv[i].
             } else { // Uh-oh, there was no argument to the destination option.
                 std::cerr << "--log_level option requires one argument." << std::endl;
                 return 1;
             }
         } else if (arg == "-t") {
             if (i + 1 < argc) { // Make sure we aren't at the end of argv!
-                threads = strtoul(argv[++i], nullptr, 10); // Increment 'i' so we don't get the argument as the next argv[i].
+                threads = strtoul(
+                    argv[++i], nullptr, 10); // Increment 'i' so we don't get the
+                                             // argument as the next argv[i].
             } else { // Uh-oh, there was no argument to the destination option.
                 std::cerr << "-t option requires one argument." << std::endl;
                 return 1;
             }
-        }
-        else {
-            std::cerr << argv[i] << " could not be attributed to any parameter" << std::endl;
+        } else {
+            std::cerr << argv[i] << " could not be attributed to any parameter"
+                      << std::endl;
         }
     }
 
@@ -272,10 +332,10 @@ int pandora_compare(int argc, char *argv[]) {
         e_rate = 0.001;
     }
     if (illumina and max_diff > 200) {
-        max_diff = 2*k + 1;
+        max_diff = 2 * k + 1;
     }
 
-    //then run the programme...
+    // then run the programme...
     std::cout << "START: " << now() << std::endl;
     std::cout << "\nUsing parameters: " << std::endl;
     std::cout << "\tprgfile\t\t" << prgfile << std::endl;
@@ -294,7 +354,7 @@ int pandora_compare(int argc, char *argv[]) {
     std::cout << "\tgenotype\t" << genotype << std::endl;
     std::cout << "\tlog_level\t" << log_level << std::endl << std::endl;
 
-    auto g_log_level{boost::log::trivial::info};
+    auto g_log_level { boost::log::trivial::info };
     if (log_level == "debug")
         g_log_level = boost::log::trivial::debug;
     boost::log::core::get()->set_filter(boost::log::trivial::severity >= g_log_level);
@@ -310,18 +370,19 @@ int pandora_compare(int argc, char *argv[]) {
     std::cout << now() << "Loading read index file " << read_index_fpath << std::endl;
     auto samples = load_read_index(read_index_fpath);
     std::vector<std::string> sample_names;
-    for (const auto &sample_pair : samples) sample_names.push_back(sample_pair.first);
+    for (const auto& sample_pair : samples)
+        sample_names.push_back(sample_pair.first);
 
     auto pangraph = std::make_shared<pangenome::Graph>(sample_names);
     std::vector<uint32_t> exp_depth_covgs;
 
     // for each sample, run pandora to get the sample pangraph
     for (uint32_t sample_id = 0; sample_id < samples.size(); ++sample_id) {
-        const auto &sample = samples[sample_id];
+        const auto& sample = samples[sample_id];
         auto pangraph_sample = std::make_shared<pangenome::Graph>();
 
-        const auto &sample_name = sample.first;
-        const auto &sample_fpath = sample.second;
+        const auto& sample_name = sample.first;
+        const auto& sample_fpath = sample.second;
 
         // make output dir for this sample
         auto sample_outdir = outdir;
@@ -330,40 +391,40 @@ int pandora_compare(int argc, char *argv[]) {
 
         // construct the pangraph for this sample
         BOOST_LOG_TRIVIAL(info) << "Constructing pangenome::Graph from read file "
-                                << sample_fpath
-                                << " (this will take a while)";
-        uint32_t covg = pangraph_from_read_file(sample_fpath,
-                                                pangraph_sample,
-                                                index, prgs, w, k,
-                                                max_diff, e_rate,
-                                                min_cluster_size, genome_size, illumina, clean, max_covg, threads);
-        BOOST_LOG_TRIVIAL(info) << "Writing pangenome::Graph to file "
-                                << sample_outdir << "/pandora.pangraph.gfa";
+                                << sample_fpath << " (this will take a while)";
+        uint32_t covg = pangraph_from_read_file(sample_fpath, pangraph_sample, index,
+            prgs, w, k, max_diff, e_rate, min_cluster_size, genome_size, illumina,
+            clean, max_covg, threads);
+        BOOST_LOG_TRIVIAL(info) << "Writing pangenome::Graph to file " << sample_outdir
+                                << "/pandora.pangraph.gfa";
         write_pangraph_gfa(sample_outdir + "/pandora.pangraph.gfa", pangraph_sample);
 
         if (pangraph_sample->nodes.empty()) {
-            BOOST_LOG_TRIVIAL(warning) << "Found no LocalPRGs in the reads for sample " << sample_name;
+            BOOST_LOG_TRIVIAL(warning)
+                << "Found no LocalPRGs in the reads for sample " << sample_name;
         }
 
         BOOST_LOG_TRIVIAL(info) << "Update LocalPRGs with hits";
         pangraph_sample->add_hits_to_kmergraphs(prgs, 0);
 
         BOOST_LOG_TRIVIAL(info) << "Estimate parameters for kmer graph model";
-        auto exp_depth_covg = estimate_parameters(pangraph_sample, sample_outdir, k, e_rate, covg, bin, 0);
+        auto exp_depth_covg = estimate_parameters(
+            pangraph_sample, sample_outdir, k, e_rate, covg, bin, 0);
         exp_depth_covgs.push_back(exp_depth_covg);
 
         if (min_kmer_covg == 0)
-            min_kmer_covg = exp_depth_covg/10;
+            min_kmer_covg = exp_depth_covg / 10;
 
         BOOST_LOG_TRIVIAL(info) << "Find max likelihood PRG paths";
         auto sample_pangraph_size = pangraph_sample->nodes.size();
         Fastaq consensus_fq(true, true);
-        for (auto c = pangraph_sample->nodes.begin(); c != pangraph_sample->nodes.end();) {
-            const LocalPRG &local_prg = *prgs[c->second->prg_id];
+        for (auto c = pangraph_sample->nodes.begin();
+             c != pangraph_sample->nodes.end();) {
+            const LocalPRG& local_prg = *prgs[c->second->prg_id];
             vector<KmerNodePtr> kmp;
             vector<LocalNodePtr> lmp;
-            local_prg.add_consensus_path_to_fastaq(consensus_fq, c->second, kmp, lmp, w, bin, covg,
-                                                   max_num_kmers_to_average, 0);
+            local_prg.add_consensus_path_to_fastaq(consensus_fq, c->second, kmp, lmp, w,
+                bin, covg, max_num_kmers_to_average, 0);
 
             if (kmp.empty()) {
                 c = pangraph_sample->remove_node(c->second);
@@ -371,7 +432,8 @@ int pandora_compare(int argc, char *argv[]) {
             }
 
             pangraph->add_node(prgs[c->second->prg_id]);
-            pangraph->add_hits_between_PRG_and_sample(c->second->prg_id, sample_name, kmp);
+            pangraph->add_hits_between_PRG_and_sample(
+                c->second->prg_id, sample_name, kmp);
 
             ++c;
         }
@@ -381,33 +443,29 @@ int pandora_compare(int argc, char *argv[]) {
         consensus_fq.save(sample_outdir + "/pandora.consensus.fq.gz");
         consensus_fq.clear();
         if (pangraph_sample->nodes.empty() and sample_pangraph_size > 0) {
-            std::cout << "WARNING: All LocalPRGs found were removed for sample " << sample_name
-                      << ". Is your genome_size accurate? Genome size is assumed to be " << genome_size
-                      << " and can be updated with --genome_size" << std::endl;
+            std::cout << "WARNING: All LocalPRGs found were removed for sample "
+                      << sample_name
+                      << ". Is your genome_size accurate? Genome size is assumed to be "
+                      << genome_size << " and can be updated with --genome_size"
+                      << std::endl;
         }
 
-
-        // Note: pangraph_sample is destroyed here and as well as all Read information (pangenome::Graph::reads) about the sample
-        // pangraph does not keep the read information
-        // This is important since this is the heaviest information to keep in compare
-        // pangraph has just coverage information and the consensus path for each sample and PRG
+        // Note: pangraph_sample is destroyed here and as well as all Read information
+        // (pangenome::Graph::reads) about the sample pangraph does not keep the read
+        // information This is important since this is the heaviest information to keep
+        // in compare pangraph has just coverage information and the consensus path for
+        // each sample and PRG
     }
 
     // for each pannode in graph, find a best reference
     // and output a vcf and aligned fasta of sample paths through it
-    BOOST_LOG_TRIVIAL(info) << "Multi-sample pangraph has "
-                            << pangraph->nodes.size() << " nodes";
+    BOOST_LOG_TRIVIAL(info) << "Multi-sample pangraph has " << pangraph->nodes.size()
+                            << " nodes";
 
-
-
-
-
-
-
-    //parallel region!
+    // parallel region!
 
     // load vcf refs
-    VCFRefs vcf_refs; //no need to control this variable - read only
+    VCFRefs vcf_refs; // no need to control this variable - read only
     {
         std::string vcf_ref;
         if (!vcf_refs_file.empty()) {
@@ -416,104 +474,113 @@ int pandora_compare(int argc, char *argv[]) {
         }
     }
 
-    //shared variable - controlled by critical(vcf_ref_fa)
+    // shared variable - controlled by critical(vcf_ref_fa)
     Fastaq vcf_ref_fa(true, false);
 
-    //shared variable - controlled by critical(VCFPathsToBeConcatenated)
-    std::vector<std::string> VCFPathsToBeConcatenated; //TODO: we can allocate the correct size of the vectors already here
+    // shared variable - controlled by critical(VCFPathsToBeConcatenated)
+    std::vector<std::string>
+        VCFPathsToBeConcatenated; // TODO: we can allocate the correct size of the
+                                  // vectors already here
 
-    //shared variable - controlled by critical(VCFGenotypedPathsToBeConcatenated)
-    std::vector<std::string> VCFGenotypedPathsToBeConcatenated; //TODO: we can allocate the correct size of the vectors already here
+    // shared variable - controlled by critical(VCFGenotypedPathsToBeConcatenated)
+    std::vector<std::string>
+        VCFGenotypedPathsToBeConcatenated; // TODO: we can allocate the correct size of
+                                           // the vectors already here
 
-    //create the dir that will contain all vcfs
-    const int nbOfVCFsPerDir=4000;
+    // create the dir that will contain all vcfs
+    const int nbOfVCFsPerDir = 4000;
     auto VCFsDirs = outdir + "/VCFs";
     fs::create_directories(VCFsDirs);
-    //create the dirs for the VCFs
-    for (uint32_t i = 0; i <= pangraph->nodes.size()/nbOfVCFsPerDir; ++i)
+    // create the dirs for the VCFs
+    for (uint32_t i = 0; i <= pangraph->nodes.size() / nbOfVCFsPerDir; ++i)
         fs::create_directories(VCFsDirs + "/" + int_to_string(i + 1));
 
-    //create the dirs for the VCFs genotyped, if flag is passed
+    // create the dirs for the VCFs genotyped, if flag is passed
     auto VCFsGenotypedDirs = outdir + "/VCFs_genotyped";
     if (genotype) {
-        for (uint32_t i = 0; i <= pangraph->nodes.size()/nbOfVCFsPerDir; ++i)
+        for (uint32_t i = 0; i <= pangraph->nodes.size() / nbOfVCFsPerDir; ++i)
             fs::create_directories(VCFsGenotypedDirs + "/" + int_to_string(i + 1));
     }
 
-
-
-
-    //transforms to a vector to parallelize this
-    //TODO: use OMP task instead?
-    std::vector<std::pair<NodeId, std::shared_ptr<pangenome::Node>>> pangraphNodesAsVector;
+    // transforms to a vector to parallelize this
+    // TODO: use OMP task instead?
+    std::vector<std::pair<NodeId, std::shared_ptr<pangenome::Node>>>
+        pangraphNodesAsVector;
     pangraphNodesAsVector.reserve(pangraph->nodes.size());
-    for (auto pan_id_to_node_mapping = pangraph->nodes.begin(); pan_id_to_node_mapping != pangraph->nodes.end(); ++pan_id_to_node_mapping)
+    for (auto pan_id_to_node_mapping = pangraph->nodes.begin();
+         pan_id_to_node_mapping != pangraph->nodes.end(); ++pan_id_to_node_mapping)
         pangraphNodesAsVector.push_back(*pan_id_to_node_mapping);
 
-    #pragma omp parallel for num_threads(threads) schedule(dynamic, 1)
-    for (uint32_t pangraph_node_index=0; pangraph_node_index < pangraphNodesAsVector.size(); ++pangraph_node_index) {
-        const auto &pangraph_node_entry = pangraphNodesAsVector[pangraph_node_index];
+#pragma omp parallel for num_threads(threads) schedule(dynamic, 1)
+    for (uint32_t pangraph_node_index = 0;
+         pangraph_node_index < pangraphNodesAsVector.size(); ++pangraph_node_index) {
+        const auto& pangraph_node_entry = pangraphNodesAsVector[pangraph_node_index];
         BOOST_LOG_TRIVIAL(debug) << "Consider next node";
-        pangenome::Node &pangraph_node = *pangraph_node_entry.second;
+        pangenome::Node& pangraph_node = *pangraph_node_entry.second;
 
-        const auto &prg_id = pangraph_node.prg_id;
+        const auto& prg_id = pangraph_node.prg_id;
         assert(prgs.size() > prg_id);
-        const auto &prg_ptr = prgs[prg_id];
+        const auto& prg_ptr = prgs[prg_id];
 
-        const auto vcf_reference_path = pangraph->infer_node_vcf_reference_path(pangraph_node, prg_ptr, w, vcf_refs,
-                                                                                max_num_kmers_to_average);
+        const auto vcf_reference_path = pangraph->infer_node_vcf_reference_path(
+            pangraph_node, prg_ptr, w, vcf_refs, max_num_kmers_to_average);
 
-        #pragma omp critical(vcf_ref_fa)
+#pragma omp critical(vcf_ref_fa)
         {
-            vcf_ref_fa.add_entry(prg_ptr->name, prg_ptr->string_along_path(vcf_reference_path), "");
+            vcf_ref_fa.add_entry(
+                prg_ptr->name, prg_ptr->string_along_path(vcf_reference_path), "");
         }
 
-        //output the vcf for this sample
+        // output the vcf for this sample
         VCF vcf;
 
-        //add all samples to the vcf
+        // add all samples to the vcf
         vcf.add_samples(sample_names);
-        assert( vcf.samples.size() == samples.size());
+        assert(vcf.samples.size() == samples.size());
 
-        //build the vcf
-        pangraph_node.construct_multisample_vcf(vcf, vcf_reference_path, prg_ptr, w, min_kmer_covg);
+        // build the vcf
+        pangraph_node.construct_multisample_vcf(
+            vcf, vcf_reference_path, prg_ptr, w, min_kmer_covg);
 
-        //save the vcf to disk
-        uint32_t dir = pangraph_node_index / nbOfVCFsPerDir + 1; //get the good dir for this sample vcf
-        auto vcfPath = VCFsDirs + "/" + int_to_string(dir) + "/" + prg_ptr->name + ".vcf";
+        // save the vcf to disk
+        uint32_t dir = pangraph_node_index / nbOfVCFsPerDir
+            + 1; // get the good dir for this sample vcf
+        auto vcfPath
+            = VCFsDirs + "/" + int_to_string(dir) + "/" + prg_ptr->name + ".vcf";
         vcf.save(vcfPath, true, true, true, true, true, true, true);
 
-        //add the vcf path to VCFPathsToBeConcatenated to concatenate after
-        #pragma omp critical(VCFPathsToBeConcatenated)
+// add the vcf path to VCFPathsToBeConcatenated to concatenate after
+#pragma omp critical(VCFPathsToBeConcatenated)
         {
             VCFPathsToBeConcatenated.push_back(vcfPath);
         }
 
-
         if (genotype) {
-            //genotype
-            vcf.genotype(exp_depth_covgs, genotyping_error_rate, confidence_threshold, min_allele_covg_gt,
-                         min_allele_fraction_covg_gt,
-                         min_total_covg_gt, min_diff_covg_gt, false);
+            // genotype
+            vcf.genotype(exp_depth_covgs, genotyping_error_rate, confidence_threshold,
+                min_allele_covg_gt, min_allele_fraction_covg_gt, min_total_covg_gt,
+                min_diff_covg_gt, false);
 
-            //save the genotyped vcf to disk
-            auto vcfGenotypedPath = VCFsGenotypedDirs + "/" + int_to_string(dir) + "/" + prg_ptr->name + "_genotyped.vcf";
+            // save the genotyped vcf to disk
+            auto vcfGenotypedPath = VCFsGenotypedDirs + "/" + int_to_string(dir) + "/"
+                + prg_ptr->name + "_genotyped.vcf";
             vcf.save(vcfGenotypedPath, true, true, true, true, true, true, true);
 
-            //add the genotyped vcf path to VCFGenotypedPathsToBeConcatenated to concatenate after
-            #pragma omp critical(VCFGenotypedPathsToBeConcatenated)
+// add the genotyped vcf path to VCFGenotypedPathsToBeConcatenated to concatenate after
+#pragma omp critical(VCFGenotypedPathsToBeConcatenated)
             {
                 VCFGenotypedPathsToBeConcatenated.push_back(vcfGenotypedPath);
             }
         }
     }
 
-    //generate all the multisample files
+    // generate all the multisample files
     vcf_ref_fa.save(outdir + "/pandora_multisample.vcf_ref.fa");
-    VCF::concatenateVCFs(VCFPathsToBeConcatenated, outdir + "/pandora_multisample_consensus.vcf");
+    VCF::concatenateVCFs(
+        VCFPathsToBeConcatenated, outdir + "/pandora_multisample_consensus.vcf");
     if (genotype)
-        VCF::concatenateVCFs(VCFGenotypedPathsToBeConcatenated, outdir + "/pandora_multisample_genotyped.vcf");
-
+        VCF::concatenateVCFs(VCFGenotypedPathsToBeConcatenated,
+            outdir + "/pandora_multisample_genotyped.vcf");
 
     // output a matrix/vcf which has the presence/absence of each prg in each sample
     BOOST_LOG_TRIVIAL(info) << "Output matrix";
@@ -522,7 +589,8 @@ int pandora_compare(int argc, char *argv[]) {
     if (pangraph->nodes.empty()) {
         std::cout << "No LocalPRGs found to compare samples on. "
                   << "Is your genome_size accurate? Genome size is assumed to be "
-                  << genome_size << " and can be updated with --genome_size" << std::endl;
+                  << genome_size << " and can be updated with --genome_size"
+                  << std::endl;
     }
 
     // clear up

--- a/src/de_bruijn/node.cpp
+++ b/src/de_bruijn/node.cpp
@@ -1,16 +1,22 @@
 #include "de_bruijn/node.h"
 #include "noise_filtering.h"
 
-
 using namespace debruijn;
 
-debruijn::Node::Node(const uint32_t i, const std::deque<uint_least32_t> &n, const uint32_t r) : id(i), hashed_node_ids(n),
-                                                                                      read_ids({r}), out_nodes({}),
-                                                                                      in_nodes({}) {}
+debruijn::Node::Node(
+    const uint32_t i, const std::deque<uint_least32_t>& n, const uint32_t r)
+    : id(i)
+    , hashed_node_ids(n)
+    , read_ids({ r })
+    , out_nodes({})
+    , in_nodes({})
+{
+}
 
 // Nodes are equal if they correspond to the same sequence of oriented pangraph nodes
 // either in the forward or reverse complement direction
-bool debruijn::Node::operator==(const Node &y) const {
+bool debruijn::Node::operator==(const Node& y) const
+{
     if (y.hashed_node_ids.size() != hashed_node_ids.size()) {
         return false;
     }
@@ -33,19 +39,18 @@ bool debruijn::Node::operator==(const Node &y) const {
     return match;
 }
 
-bool debruijn::Node::operator!=(const Node &y) const {
-    return !(*this == y);
-}
+bool debruijn::Node::operator!=(const Node& y) const { return !(*this == y); }
 
 namespace debruijn {
-    std::ostream &operator<<(std::ostream &out, const Node &m) {
-        std::string sep = "";
-        out << "(";
-        for (const auto &n : m.hashed_node_ids) {
-            out << sep << n;
-            sep = ",";
-        }
-        out << ")";
-        return out;
+std::ostream& operator<<(std::ostream& out, const Node& m)
+{
+    std::string sep = "";
+    out << "(";
+    for (const auto& n : m.hashed_node_ids) {
+        out << sep << n;
+        sep = ",";
     }
+    out << ")";
+    return out;
+}
 }

--- a/src/de_bruijn/ns.cpp
+++ b/src/de_bruijn/ns.cpp
@@ -1,31 +1,31 @@
-#ifndef __DBGNS_CPP_INCLUDED__   // if de_bruijn/ns.cpp hasn't been included yet...
+#ifndef __DBGNS_CPP_INCLUDED__ // if de_bruijn/ns.cpp hasn't been included yet...
 #define __DBGNS_CPP_INCLUDED__
 
+#include <boost/functional/hash.hpp>
 #include <iostream>
 #include <memory>
 #include <unordered_map>
-#include <boost/functional/hash.hpp>
-
 
 namespace debruijn {
-    class Node;
+class Node;
 
-    class Graph;
+class Graph;
 
-    typedef std::shared_ptr<debruijn::Node> NodePtr;
-    typedef std::pair<debruijn::NodePtr, bool> OrientedNodePtr;
+typedef std::shared_ptr<debruijn::Node> NodePtr;
+typedef std::pair<debruijn::NodePtr, bool> OrientedNodePtr;
 
-    template<typename SEQUENCE_OF_GENES>
-    struct seq_hash {
-        std::size_t operator()(const SEQUENCE_OF_GENES &seq) const {
-            std::size_t hash = 0;
-            boost::hash_range(hash, seq.begin(), seq.end());
-            return hash;
-        }
-    };
+template <typename SEQUENCE_OF_GENES> struct seq_hash {
+    std::size_t operator()(const SEQUENCE_OF_GENES& seq) const
+    {
+        std::size_t hash = 0;
+        boost::hash_range(hash, seq.begin(), seq.end());
+        return hash;
+    }
+};
 
-    template<typename SEQUENCE_OF_GENES, typename T>
-    using sequence_of_genes_to_data_map = std::unordered_map<SEQUENCE_OF_GENES, T, seq_hash<SEQUENCE_OF_GENES> >;
+template <typename SEQUENCE_OF_GENES, typename T>
+using sequence_of_genes_to_data_map
+    = std::unordered_map<SEQUENCE_OF_GENES, T, seq_hash<SEQUENCE_OF_GENES>>;
 
 }
 

--- a/src/denovo_discovery/denovo_utils.cpp
+++ b/src/denovo_discovery/denovo_utils.cpp
@@ -1,11 +1,10 @@
 #include "denovo_discovery/denovo_utils.h"
 
-
 #define assert_msg(x) !(std::cerr << "Assertion failed: " << x << std::endl)
 
-
-PathComponents find_interval_and_flanks_in_localpath(const Interval &interval,
-                                                     const std::vector<LocalNodePtr> &local_node_max_likelihood_path) {
+PathComponents find_interval_and_flanks_in_localpath(const Interval& interval,
+    const std::vector<LocalNodePtr>& local_node_max_likelihood_path)
+{
     if (interval.empty()) {
         return PathComponents();
     }
@@ -18,40 +17,46 @@ PathComponents find_interval_and_flanks_in_localpath(const Interval &interval,
     std::vector<Interval> intervals_found, flank_left_intervals, flank_right_intervals;
     const auto interval_end { interval.get_end() };
 
-    for (const auto &current_node : local_node_max_likelihood_path) {
+    for (const auto& current_node : local_node_max_likelihood_path) {
         total_bases_traversed += current_node->pos.length;
         start = current_node->pos.start;
         const auto current_node_end { current_node->pos.get_end() };
 
-        const auto havent_reached_interval_start { interval.start >= total_bases_traversed };
+        const auto havent_reached_interval_start { interval.start
+            >= total_bases_traversed };
         if (havent_reached_interval_start) {
             flank_left_intervals.emplace_back(current_node->pos);
             continue;
         }
 
-        const auto found_node_interval_starts_in { (not found_start and interval.start < total_bases_traversed) };
+        const auto found_node_interval_starts_in { (
+            not found_start and interval.start < total_bases_traversed) };
         if (found_node_interval_starts_in) {
             start = current_node_end - (total_bases_traversed - interval.start);
             found_start = true;
 
-            const auto interval_starts_after_start_of_current_node {
-                    interval.start > (total_bases_traversed - current_node->pos.length) };
+            const auto interval_starts_after_start_of_current_node { interval.start
+                > (total_bases_traversed - current_node->pos.length) };
             if (interval_starts_after_start_of_current_node) {
-                flank_left_intervals.emplace_back(Interval(current_node->pos.start, start));
+                flank_left_intervals.emplace_back(
+                    Interval(current_node->pos.start, start));
             }
 
-            const auto interval_doesnt_end_in_this_node { interval_end > total_bases_traversed };
+            const auto interval_doesnt_end_in_this_node { interval_end
+                > total_bases_traversed };
             if (interval_doesnt_end_in_this_node) {
                 intervals_found.emplace_back(Interval(start, current_node_end));
                 continue;
             }
         }
 
-        const auto found_node_interval_ends_in { (not found_end and interval_end <= total_bases_traversed) };
+        const auto found_node_interval_ends_in { (
+            not found_end and interval_end <= total_bases_traversed) };
         if (found_node_interval_ends_in) {
             end = current_node_end - (total_bases_traversed - interval_end);
 
-            const auto interval_ends_before_end_of_current_node { interval_end < total_bases_traversed };
+            const auto interval_ends_before_end_of_current_node { interval_end
+                < total_bases_traversed };
             if (interval_ends_before_end_of_current_node) {
                 flank_right_intervals.emplace_back(Interval(end, current_node_end));
             }
@@ -60,14 +65,17 @@ PathComponents find_interval_and_flanks_in_localpath(const Interval &interval,
             continue;
         }
 
-        const auto node_is_completely_contained_in_interval {
-                interval.start < total_bases_traversed and interval_end > total_bases_traversed };
+        const auto node_is_completely_contained_in_interval { interval.start
+                < total_bases_traversed
+            and interval_end > total_bases_traversed };
         if (node_is_completely_contained_in_interval) {
-            intervals_found.emplace_back(Interval(start, start + current_node->pos.length));
+            intervals_found.emplace_back(
+                Interval(start, start + current_node->pos.length));
             continue;
         }
 
-        const auto past_interval_end { found_end and interval_end < total_bases_traversed };
+        const auto past_interval_end { found_end
+            and interval_end < total_bases_traversed };
         if (past_interval_end) {
             flank_right_intervals.emplace_back(current_node->pos);
         }
@@ -80,26 +88,28 @@ PathComponents find_interval_and_flanks_in_localpath(const Interval &interval,
     prg::Path right_flank_path;
     right_flank_path.initialize(flank_right_intervals);
 
-    PathComponents found_components { left_flank_path, interval_as_path, right_flank_path };
+    PathComponents found_components { left_flank_path, interval_as_path,
+        right_flank_path };
 
     return found_components;
 }
 
-
-std::vector<MinimizerHitPtr>
-find_hits_inside_path(const std::vector<MinimizerHitPtr> &read_hits, const prg::Path &local_path) {
+std::vector<MinimizerHitPtr> find_hits_inside_path(
+    const std::vector<MinimizerHitPtr>& read_hits, const prg::Path& local_path)
+{
     std::vector<MinimizerHitPtr> hits_inside_local_path;
 
     if (local_path.empty()) {
         return hits_inside_local_path;
     }
 
-    for (const auto &current_read_hit : read_hits) {
-        for (const auto &interval : local_path) {
-            const auto &prg_path_of_current_read_hit = current_read_hit->get_prg_path();
-            const auto hit_is_to_left_of_path_start { interval.start > prg_path_of_current_read_hit.get_end() };
-            const auto hit_is_to_right_of_current_interval {
-                    interval.get_end() < prg_path_of_current_read_hit.get_start() };
+    for (const auto& current_read_hit : read_hits) {
+        for (const auto& interval : local_path) {
+            const auto& prg_path_of_current_read_hit = current_read_hit->get_prg_path();
+            const auto hit_is_to_left_of_path_start { interval.start
+                > prg_path_of_current_read_hit.get_end() };
+            const auto hit_is_to_right_of_current_interval { interval.get_end()
+                < prg_path_of_current_read_hit.get_start() };
 
             if (hit_is_to_left_of_path_start) {
                 break;
@@ -115,12 +125,17 @@ find_hits_inside_path(const std::vector<MinimizerHitPtr> &read_hits, const prg::
     return hits_inside_local_path;
 }
 
+ReadCoordinate::ReadCoordinate(
+    uint32_t id, uint32_t start, uint32_t end, bool is_forward)
+    : id(id)
+    , start(start)
+    , end(end)
+    , is_forward(is_forward)
+{
+}
 
-ReadCoordinate::ReadCoordinate(uint32_t id, uint32_t start, uint32_t end, bool is_forward)
-        : id(id), start(start), end(end), is_forward(is_forward) {}
-
-
-bool ReadCoordinate::operator<(const ReadCoordinate &y) const {
+bool ReadCoordinate::operator<(const ReadCoordinate& y) const
+{
     if (this->id < y.id) {
         return true;
     }
@@ -152,43 +167,47 @@ bool ReadCoordinate::operator<(const ReadCoordinate &y) const {
     return false;
 }
 
-
-bool ReadCoordinate::operator==(const ReadCoordinate &y) const {
-    return ((this->id == y.id) and (this->start == y.start) and (this->end == y.end) and
-            (this->is_forward == y.is_forward));
+bool ReadCoordinate::operator==(const ReadCoordinate& y) const
+{
+    return ((this->id == y.id) and (this->start == y.start) and (this->end == y.end)
+        and (this->is_forward == y.is_forward));
 }
 
-
-bool ReadCoordinate::operator!=(const ReadCoordinate &y) const {
+bool ReadCoordinate::operator!=(const ReadCoordinate& y) const
+{
     return (!(*this == y));
 }
 
-
-size_t std::hash<ReadCoordinate>::operator()(const ReadCoordinate &coordinate) const {
-    return hash<int>()(coordinate.start) ^ hash<int>()(coordinate.id) ^ hash<int>()(coordinate.end) ^
-           hash<bool>()(coordinate.is_forward);
+size_t std::hash<ReadCoordinate>::operator()(const ReadCoordinate& coordinate) const
+{
+    return hash<int>()(coordinate.start) ^ hash<int>()(coordinate.id)
+        ^ hash<int>()(coordinate.end) ^ hash<bool>()(coordinate.is_forward);
 }
 
-
-std::ostream &operator<<(std::ostream &out, ReadCoordinate const &y) {
-    out << "{" << y.id << ", " << y.start << ", " << y.end << ", " << y.is_forward << "}";
+std::ostream& operator<<(std::ostream& out, ReadCoordinate const& y)
+{
+    out << "{" << y.id << ", " << y.start << ", " << y.end << ", " << y.is_forward
+        << "}";
     return out;
 }
 
-
 PathComponents::PathComponents() = default;
 
-
-PathComponents::PathComponents(prg::Path flank_left, prg::Path slice, prg::Path flank_right)
-        : flank_left(std::move(flank_left)), slice(std::move(slice)), flank_right(std::move(flank_right)) {}
-
-
-bool PathComponents::operator==(const PathComponents &other) const {
-    return (flank_left == other.flank_left and flank_right == other.flank_right and slice == other.slice);
-
+PathComponents::PathComponents(
+    prg::Path flank_left, prg::Path slice, prg::Path flank_right)
+    : flank_left(std::move(flank_left))
+    , slice(std::move(slice))
+    , flank_right(std::move(flank_right))
+{
 }
 
+bool PathComponents::operator==(const PathComponents& other) const
+{
+    return (flank_left == other.flank_left and flank_right == other.flank_right
+        and slice == other.slice);
+}
 
-bool PathComponents::operator!=(const PathComponents &other) const {
+bool PathComponents::operator!=(const PathComponents& other) const
+{
     return (!(*this == other));
 }

--- a/src/estimate_parameters.cpp
+++ b/src/estimate_parameters.cpp
@@ -1,20 +1,20 @@
-#include <vector>
-#include <iostream>
-#include <fstream>
-#include <cmath>
-#include <cassert>
-#include <numeric>
-#include <algorithm>
-#include "utils.h"
+#include "estimate_parameters.h"
 #include "pangenome/pangraph.h"
 #include "pangenome/pannode.h"
-#include "estimate_parameters.h"
-
+#include "utils.h"
+#include <algorithm>
+#include <cassert>
+#include <cmath>
+#include <fstream>
+#include <iostream>
+#include <numeric>
+#include <vector>
 
 #define assert_msg(x) !(std::cerr << "Assertion failed: " << x << std::endl)
 
-
-double fit_mean_covg(const std::vector<uint32_t> &kmer_covg_dist, const uint8_t zero_thresh) {
+double fit_mean_covg(
+    const std::vector<uint32_t>& kmer_covg_dist, const uint8_t zero_thresh)
+{
 
     double sum = 0;
     double total = 0;
@@ -30,7 +30,9 @@ double fit_mean_covg(const std::vector<uint32_t> &kmer_covg_dist, const uint8_t 
     return sum / total;
 }
 
-double fit_variance_covg(const std::vector<uint32_t> &kmer_covg_dist, double &mean, const uint8_t zero_thresh) {
+double fit_variance_covg(const std::vector<uint32_t>& kmer_covg_dist, double& mean,
+    const uint8_t zero_thresh)
+{
     double acc = 0;
     double total = 0;
     for (uint32_t i = zero_thresh; i < kmer_covg_dist.size(); ++i) {
@@ -45,19 +47,22 @@ double fit_variance_covg(const std::vector<uint32_t> &kmer_covg_dist, double &me
     return acc / total;
 }
 
-void fit_negative_binomial(double &mean, double &variance, float &p, float &r) {
-    assert (mean > 0 and variance > 0);
-    assert( mean < variance );
+void fit_negative_binomial(double& mean, double& variance, float& p, float& r)
+{
+    assert(mean > 0 and variance > 0);
+    assert(mean < variance);
     p = mean / variance;
     r = (mean * p / (1 - p) + variance * p * p / (1 - p)) / 2;
-    BOOST_LOG_TRIVIAL(debug) << "Negative binomial parameters p: " << p << " and r: " << r;
+    BOOST_LOG_TRIVIAL(debug) << "Negative binomial parameters p: " << p
+                             << " and r: " << r;
 }
 
-uint32_t find_mean_covg(std::vector<uint32_t> &kmer_covg_dist) {
-    // tries to return the position in vector at which the maximum of the second peak occurs
-    // expects at least 3 increases of covg to decide we are out of the first peak
-    // Note that if there are localPRGs which occur twice (or more) we expect the kmer covgs
-    // to have an additional smaller peak(s)
+uint32_t find_mean_covg(std::vector<uint32_t>& kmer_covg_dist)
+{
+    // tries to return the position in vector at which the maximum of the second peak
+    // occurs expects at least 3 increases of covg to decide we are out of the first
+    // peak Note that if there are localPRGs which occur twice (or more) we expect the
+    // kmer covgs to have an additional smaller peak(s)
     bool first_peak = true;
     uint32_t max_covg = 0;
     uint32_t noise_buffer = 0;
@@ -84,56 +89,64 @@ uint32_t find_mean_covg(std::vector<uint32_t> &kmer_covg_dist) {
             // have a new max
             max_covg = i;
         }
-
     }
 
     // if still have first_peak true, was a mistake to try with this covg
     if (first_peak) {
-        BOOST_LOG_TRIVIAL(debug) << "Did not find 2 distinct peaks - use default error rate";
+        BOOST_LOG_TRIVIAL(debug)
+            << "Did not find 2 distinct peaks - use default error rate";
         max_covg = 0;
     }
 
     return max_covg;
 }
 
-int find_prob_thresh(std::vector<uint32_t> &kmer_prob_dist) {
-    // finds position at which minimum occurs between two peaks 
+int find_prob_thresh(std::vector<uint32_t>& kmer_prob_dist)
+{
+    // finds position at which minimum occurs between two peaks
     // naive way is to pick window with minimal positive covg
-    // sligtly less naive way is to find this minimal value between two peaks more than 10 apart
-    // Note we are working with log probs so expect all negative, lots near 0 and some larger
-    // negatives. We expect the threshold to be not very far from 0
-    // Also note that we have forced kmer_prob_dist to have size 200 so we can cast
-    // all the long things as ints since we know they are between 0 and 200
+    // sligtly less naive way is to find this minimal value between two peaks more than
+    // 10 apart Note we are working with log probs so expect all negative, lots near 0
+    // and some larger negatives. We expect the threshold to be not very far from 0 Also
+    // note that we have forced kmer_prob_dist to have size 200 so we can cast all the
+    // long things as ints since we know they are between 0 and 200
     if (kmer_prob_dist.empty()) {
         return 0;
     }
 
-    int second_peak = (int) kmer_prob_dist.size() - 1;
+    int second_peak = (int)kmer_prob_dist.size() - 1;
     int first_peak = 0;
     int peak;
-    while ((first_peak == (int) 0 or second_peak == (int) kmer_prob_dist.size() - 1) and first_peak + 1 < second_peak) {
-        peak = (int) distance(kmer_prob_dist.begin(), max_element(kmer_prob_dist.begin() + 1 + first_peak,
-                                                                  kmer_prob_dist.begin() + second_peak));
-        BOOST_LOG_TRIVIAL(debug) << "Found new peak between " << first_peak - 200 << " and " << second_peak - 200 << " at " << peak - 200;
-        if (peak > (int) kmer_prob_dist.size() - 15) {
+    while ((first_peak == (int)0 or second_peak == (int)kmer_prob_dist.size() - 1)
+        and first_peak + 1 < second_peak) {
+        peak = (int)distance(kmer_prob_dist.begin(),
+            max_element(kmer_prob_dist.begin() + 1 + first_peak,
+                kmer_prob_dist.begin() + second_peak));
+        BOOST_LOG_TRIVIAL(debug)
+            << "Found new peak between " << first_peak - 200 << " and "
+            << second_peak - 200 << " at " << peak - 200;
+        if (peak > (int)kmer_prob_dist.size() - 15) {
             second_peak = peak;
         } else {
             first_peak = peak;
         }
     }
 
-    // if first_peak == second_peak, probably wrongly set threshold for where first peak ends
+    // if first_peak == second_peak, probably wrongly set threshold for where first peak
+    // ends
     if (first_peak == second_peak or first_peak + 1 == second_peak) {
         // first try with lower thresold for where first peak is
         first_peak = 0;
-        second_peak = (int) kmer_prob_dist.size() - 1;
-        while ((first_peak == (int) 0 or second_peak == (int) kmer_prob_dist.size() - 1) and
-            first_peak + 1 < second_peak) {
-            peak = (int) distance(kmer_prob_dist.begin(),
-                                  max_element(kmer_prob_dist.begin() + 1 + first_peak,
-                                              kmer_prob_dist.begin() + second_peak));
-            BOOST_LOG_TRIVIAL(debug) << "Found new peak between " << first_peak - 200 << " and " << second_peak - 200 << " at " << peak - 200;
-            if (peak > (int) kmer_prob_dist.size() - 6 and second_peak != peak) {
+        second_peak = (int)kmer_prob_dist.size() - 1;
+        while ((first_peak == (int)0 or second_peak == (int)kmer_prob_dist.size() - 1)
+            and first_peak + 1 < second_peak) {
+            peak = (int)distance(kmer_prob_dist.begin(),
+                max_element(kmer_prob_dist.begin() + 1 + first_peak,
+                    kmer_prob_dist.begin() + second_peak));
+            BOOST_LOG_TRIVIAL(debug)
+                << "Found new peak between " << first_peak - 200 << " and "
+                << second_peak - 200 << " at " << peak - 200;
+            if (peak > (int)kmer_prob_dist.size() - 6 and second_peak != peak) {
                 second_peak = peak;
             } else {
                 first_peak = peak;
@@ -142,13 +155,17 @@ int find_prob_thresh(std::vector<uint32_t> &kmer_prob_dist) {
 
         // secondly, find single peak and pick a min value closer to 0
         if (first_peak == second_peak or first_peak + 1 == second_peak) {
-            peak = (int) distance(kmer_prob_dist.begin(), max_element(kmer_prob_dist.begin(), kmer_prob_dist.end()));
-            for (uint32_t i = (uint32_t) peak; i != kmer_prob_dist.size(); ++i) {
-                if (kmer_prob_dist[i] > 0 and (kmer_prob_dist[i] < kmer_prob_dist[peak] or kmer_prob_dist[peak] == 0)) {
+            peak = (int)distance(kmer_prob_dist.begin(),
+                max_element(kmer_prob_dist.begin(), kmer_prob_dist.end()));
+            for (uint32_t i = (uint32_t)peak; i != kmer_prob_dist.size(); ++i) {
+                if (kmer_prob_dist[i] > 0
+                    and (kmer_prob_dist[i] < kmer_prob_dist[peak]
+                        or kmer_prob_dist[peak] == 0)) {
                     peak = i;
                 }
             }
-            BOOST_LOG_TRIVIAL(debug) << "Found a single peak. Chose a minimal non-zero threshold";
+            BOOST_LOG_TRIVIAL(debug)
+                << "Found a single peak. Chose a minimal non-zero threshold";
             return peak - 200;
         } else {
             BOOST_LOG_TRIVIAL(debug) << "Found a 2 peaks with low -log p values (>-15)";
@@ -157,14 +174,17 @@ int find_prob_thresh(std::vector<uint32_t> &kmer_prob_dist) {
         BOOST_LOG_TRIVIAL(debug) << "Found a 2 peaks";
     }
 
-    peak = (int) distance(kmer_prob_dist.begin(),
-                          min_element(kmer_prob_dist.begin() + first_peak, kmer_prob_dist.begin() + second_peak));
-    BOOST_LOG_TRIVIAL(debug) << "Minimum found between " << first_peak - 200 << " and " << second_peak - 200 << " at " << peak - 200;
+    peak = (int)distance(kmer_prob_dist.begin(),
+        min_element(
+            kmer_prob_dist.begin() + first_peak, kmer_prob_dist.begin() + second_peak));
+    BOOST_LOG_TRIVIAL(debug) << "Minimum found between " << first_peak - 200 << " and "
+                             << second_peak - 200 << " at " << peak - 200;
 
     /*int thresh = kmer_prob_dist.size()-1;
     for (uint i=kmer_prob_dist.size()-1; i!=0; --i)
     {
-        if (kmer_prob_dist[i] > 0 and (kmer_prob_dist[i] < kmer_prob_dist[thresh]) or (kmer_prob_dist[thresh] == 0))
+        if (kmer_prob_dist[i] > 0 and (kmer_prob_dist[i] < kmer_prob_dist[thresh]) or
+    (kmer_prob_dist[thresh] == 0))
         {
             thresh = i;
         }
@@ -174,12 +194,9 @@ int find_prob_thresh(std::vector<uint32_t> &kmer_prob_dist) {
 }
 
 uint32_t estimate_parameters(std::shared_ptr<pangenome::Graph> pangraph,
-                         const std::string &outdir,
-                         const uint32_t k,
-                         float &e_rate,
-                         const uint32_t covg,
-                         bool &bin,
-                         const uint32_t &sample_id) {
+    const std::string& outdir, const uint32_t k, float& e_rate, const uint32_t covg,
+    bool& bin, const uint32_t& sample_id)
+{
     uint32_t exp_depth_covg = covg;
 
     // ignore trivial case
@@ -188,8 +205,9 @@ uint32_t estimate_parameters(std::shared_ptr<pangenome::Graph> pangraph,
     }
 
     std::vector<uint32_t> kmer_covg_dist(1000,
-                                         0); //empty vector of zeroes to represent kmer coverages between 0 and 1000
-    std::vector<uint32_t> kmer_prob_dist(200, 0); //empty vector of zeroes to represent the
+        0); // empty vector of zeroes to represent kmer coverages between 0 and 1000
+    std::vector<uint32_t> kmer_prob_dist(
+        200, 0); // empty vector of zeroes to represent the
     // distribution of log probs between -200 and 0
     uint32_t c, mean_covg;
     unsigned long num_reads = 0;
@@ -198,13 +216,15 @@ uint32_t estimate_parameters(std::shared_ptr<pangenome::Graph> pangraph,
     float negative_binomial_parameter_p = 0, negative_binomial_parameter_r = 0;
 
     // first we estimate error rate
-    BOOST_LOG_TRIVIAL(info) << "Collect kmer coverage distribution" ;
-    for (const auto &node : pangraph->nodes) {
+    BOOST_LOG_TRIVIAL(info) << "Collect kmer coverage distribution";
+    for (const auto& node : pangraph->nodes) {
         num_reads += node.second->covg;
         for (uint32_t i = 1;
-             i != node.second->kmer_prg_with_coverage.kmer_prg->nodes.size() - 1; ++i) //NB first and last kmer in kmergraph are null
+             i != node.second->kmer_prg_with_coverage.kmer_prg->nodes.size() - 1;
+             ++i) // NB first and last kmer in kmergraph are null
         {
-            c = node.second->kmer_prg_with_coverage.get_covg(i, 0, sample_id) + node.second->kmer_prg_with_coverage.get_covg(i, 1, sample_id);
+            c = node.second->kmer_prg_with_coverage.get_covg(i, 0, sample_id)
+                + node.second->kmer_prg_with_coverage.get_covg(i, 1, sample_id);
             if (c < 1000) {
                 kmer_covg_dist[c] += 1;
             }
@@ -215,11 +235,13 @@ uint32_t estimate_parameters(std::shared_ptr<pangenome::Graph> pangraph,
     num_reads = num_reads / pangraph->nodes.size();
 
     // save coverage distribution
-    BOOST_LOG_TRIVIAL(info) << "Writing kmer coverage distribution to " << outdir << "/kmer_covgs.txt";
+    BOOST_LOG_TRIVIAL(info) << "Writing kmer coverage distribution to " << outdir
+                            << "/kmer_covgs.txt";
     fs::create_directories(outdir);
     std::ofstream handle;
     handle.open(outdir + "/kmer_covgs.txt");
-    assert(!handle.fail() or assert_msg("Could not open file " << outdir + "/kmer_covgs.txt"));
+    assert(!handle.fail()
+        or assert_msg("Could not open file " << outdir + "/kmer_covgs.txt"));
     for (uint32_t j = 0; j != kmer_covg_dist.size(); ++j) {
         handle << j << "\t" << kmer_covg_dist[j] << std::endl;
     }
@@ -235,46 +257,56 @@ uint32_t estimate_parameters(std::shared_ptr<pangenome::Graph> pangraph,
         var = fit_variance_covg(kmer_covg_dist, mean, zero_thresh);
         std::cout << "new mean, var: " << mean << " " << var << std::endl;
     }
-    std::cout << bin  << " " << num_reads << " " << covg << std::endl;
-    if (   (bin and num_reads > 30 and covg > 30)
-           or (not bin and abs(var - mean) < 2 and mean > 10 and num_reads > 30 and covg > 2) ){
+    std::cout << bin << " " << num_reads << " " << covg << std::endl;
+    if ((bin and num_reads > 30 and covg > 30)
+        or (not bin and abs(var - mean) < 2 and mean > 10 and num_reads > 30
+            and covg > 2)) {
         bin = true;
         mean_covg = find_mean_covg(kmer_covg_dist);
         if (exp_depth_covg < 1)
             exp_depth_covg = mean;
-        BOOST_LOG_TRIVIAL(info) << "found mean kmer covg " << mean_covg << " and mean global covg " << covg << " with avg num reads covering node " << num_reads;
+        BOOST_LOG_TRIVIAL(info)
+            << "found mean kmer covg " << mean_covg << " and mean global covg " << covg
+            << " with avg num reads covering node " << num_reads;
         if (mean_covg > 0 and mean_covg < covg) {
             auto old_e_rate = e_rate;
-            e_rate = -log((float) mean_covg / covg) / k;
-            BOOST_LOG_TRIVIAL(info) << "Estimated error rate updated from " << old_e_rate << " to " << e_rate;
+            e_rate = -log((float)mean_covg / covg) / k;
+            BOOST_LOG_TRIVIAL(info) << "Estimated error rate updated from "
+                                    << old_e_rate << " to " << e_rate;
         }
     } else if (not bin and num_reads > 30 and covg > 2 and mean < var) {
-        fit_negative_binomial(mean, var, negative_binomial_parameter_p, negative_binomial_parameter_r);
+        fit_negative_binomial(
+            mean, var, negative_binomial_parameter_p, negative_binomial_parameter_r);
         exp_depth_covg = mean;
     } else {
         BOOST_LOG_TRIVIAL(info) << "Insufficient coverage to update error rate";
         exp_depth_covg = fit_mean_covg(kmer_covg_dist, covg / 10);
-        exp_depth_covg = std::max(exp_depth_covg, (uint) 1);
+        exp_depth_covg = std::max(exp_depth_covg, (uint)1);
     }
 
     // find probability threshold
     BOOST_LOG_TRIVIAL(info) << "Collect kmer probability distribution";
-    for (const auto &node : pangraph->nodes) {
+    for (const auto& node : pangraph->nodes) {
         node.second->kmer_prg_with_coverage.set_exp_depth_covg(exp_depth_covg);
         if (bin)
             node.second->kmer_prg_with_coverage.set_binomial_parameter_p(e_rate);
         else
-            node.second->kmer_prg_with_coverage.set_negative_binomial_parameters(negative_binomial_parameter_p, negative_binomial_parameter_r);
+            node.second->kmer_prg_with_coverage.set_negative_binomial_parameters(
+                negative_binomial_parameter_p, negative_binomial_parameter_r);
 
         for (uint32_t i = 1;
-             i < node.second->kmer_prg_with_coverage.kmer_prg->nodes.size() - 1; ++i) //NB first and last kmer in kmergraph are null
+             i < node.second->kmer_prg_with_coverage.kmer_prg->nodes.size() - 1;
+             ++i) // NB first and last kmer in kmergraph are null
         {
             if (bin)
-                binomial_parameter_p = node.second->kmer_prg_with_coverage.bin_prob(i, sample_id);
+                binomial_parameter_p
+                    = node.second->kmer_prg_with_coverage.bin_prob(i, sample_id);
             else
-                binomial_parameter_p = node.second->kmer_prg_with_coverage.nbin_prob(i, sample_id);
+                binomial_parameter_p
+                    = node.second->kmer_prg_with_coverage.nbin_prob(i, sample_id);
             for (int j = 0; j < 200; ++j) {
-                if ((float) j - 200 <= binomial_parameter_p and (float) j + 1 - 200 > binomial_parameter_p) {
+                if ((float)j - 200 <= binomial_parameter_p
+                    and (float) j + 1 - 200 > binomial_parameter_p) {
                     kmer_prob_dist[j] += 1;
                     break;
                 }
@@ -283,10 +315,12 @@ uint32_t estimate_parameters(std::shared_ptr<pangenome::Graph> pangraph,
     }
 
     // save probability distribution
-    BOOST_LOG_TRIVIAL(info) << "Writing kmer probability distribution to " << outdir << "/kmer_probs.txt";
+    BOOST_LOG_TRIVIAL(info) << "Writing kmer probability distribution to " << outdir
+                            << "/kmer_probs.txt";
     handle.open(outdir + "/kmer_probs.txt");
-    assert(!handle.fail() or assert_msg("Could not open file " << outdir + "/kmer_probs.txt"));
-    for (int j = 0; (uint32_t) j != kmer_prob_dist.size(); ++j) {
+    assert(!handle.fail()
+        or assert_msg("Could not open file " << outdir + "/kmer_probs.txt"));
+    for (int j = 0; (uint32_t)j != kmer_prob_dist.size(); ++j) {
         handle << j - 200 << "\t" << kmer_prob_dist[j] << std::endl;
     }
     handle.close();
@@ -299,16 +333,19 @@ uint32_t estimate_parameters(std::shared_ptr<pangenome::Graph> pangraph,
     ++it;
     // it now represents most negative prob bin with non-zero coverage.
     // if there are enough remaining kmers, estimate thresh, otherwise use a default
-    if (std::accumulate(it, kmer_prob_dist.end(), (uint32_t) 0) > 1000) {
+    if (std::accumulate(it, kmer_prob_dist.end(), (uint32_t)0) > 1000) {
         thresh = find_prob_thresh(kmer_prob_dist);
         BOOST_LOG_TRIVIAL(info) << "Estimated threshold for true kmers is " << thresh;
     } else {
-        thresh = (int) std::distance(kmer_prob_dist.begin(), it) - 200;
-        BOOST_LOG_TRIVIAL(info) << "Did not find enough non-zero coverage kmers to estimated threshold for true kmers. Use the naive threshold " << thresh;
+        thresh = (int)std::distance(kmer_prob_dist.begin(), it) - 200;
+        BOOST_LOG_TRIVIAL(info)
+            << "Did not find enough non-zero coverage kmers to estimated threshold for "
+               "true kmers. Use the naive threshold "
+            << thresh;
     }
 
     // set threshold in each kmer graph
-    for (auto &node : pangraph->nodes) {
+    for (auto& node : pangraph->nodes) {
         node.second->kmer_prg_with_coverage.set_thresh(thresh);
     }
     return exp_depth_covg;

--- a/src/fastaq.cpp
+++ b/src/fastaq.cpp
@@ -1,30 +1,35 @@
-#include <fstream>
-#include <iostream>
 #include <cassert>
 #include <cctype>
+#include <fstream>
+#include <iostream>
 #include <unordered_map>
 
-#include <boost/iostreams/filtering_streambuf.hpp>
 #include <boost/iostreams/filter/gzip.hpp>
+#include <boost/iostreams/filtering_streambuf.hpp>
 #include <boost/log/trivial.hpp>
 
 #include "fastaq.h"
 
-
 #define assert_msg(x) !(std::cerr << "Assertion failed: " << x << std::endl)
 
+Fastaq::Fastaq(bool gz, bool fq)
+    : gzipped(gz)
+    , fastq(fq)
+{
+}
 
-Fastaq::Fastaq(bool gz, bool fq) : gzipped(gz), fastq(fq) {}
-
-char Fastaq::covg_to_score(const uint_least16_t &covg, const uint_least16_t &global_covg, const bool &alt) {
-    // this alternate conversion maps coverage ASCII of value up to 93 and then anything over this is just mapped to
-    // the ASCII value for 93
+char Fastaq::covg_to_score(
+    const uint_least16_t& covg, const uint_least16_t& global_covg, const bool& alt)
+{
+    // this alternate conversion maps coverage ASCII of value up to 93 and then anything
+    // over this is just mapped to the ASCII value for 93
     if (alt) {
         return Fastaq::alt_covg_to_score(covg);
     }
     // Rachel's original (and default) coverage to ASCII conversion function
     if (2 * global_covg < covg) {
-        BOOST_LOG_TRIVIAL(debug) << "Found a base with a coverage way too high, so giving it a score of 0";
+        BOOST_LOG_TRIVIAL(debug)
+            << "Found a base with a coverage way too high, so giving it a score of 0";
         return '!';
     }
 
@@ -38,13 +43,13 @@ char Fastaq::covg_to_score(const uint_least16_t &covg, const uint_least16_t &glo
     return ascii_c;
 }
 
-
-char Fastaq::alt_covg_to_score(const uint_least16_t &covg) {
+char Fastaq::alt_covg_to_score(const uint_least16_t& covg)
+{
     // use ASCII chars 33 - 126 as these are the printable ones
-    const uint_least16_t max{126 - 33};
+    const uint_least16_t max { 126 - 33 };
     uint_least16_t ascii_val;
 
-    if (covg > max) {  // coverage is outside the range of printable ASCIIs
+    if (covg > max) { // coverage is outside the range of printable ASCIIs
         ascii_val = 126;
     } else {
         ascii_val = covg + 33;
@@ -52,12 +57,10 @@ char Fastaq::alt_covg_to_score(const uint_least16_t &covg) {
     return static_cast<char>(ascii_val);
 }
 
-
-void Fastaq::add_entry(const std::string &name,
-                       const std::string &sequence,
-                       const std::vector<uint32_t> &covgs,
-                       const uint_least16_t global_covg,
-                       const std::string header) {
+void Fastaq::add_entry(const std::string& name, const std::string& sequence,
+    const std::vector<uint32_t>& covgs, const uint_least16_t global_covg,
+    const std::string header)
+{
 
     assert(name != "");
     assert(covgs.size() == sequence.length());
@@ -68,8 +71,8 @@ void Fastaq::add_entry(const std::string &name,
 
     char score[covgs.size() + 1];
     auto i = 0;
-    const bool alt_covg_conversion{false};
-    for (const auto &covg: covgs) {
+    const bool alt_covg_conversion { false };
+    for (const auto& covg : covgs) {
         score[i] = covg_to_score(covg, mod_global_covg, alt_covg_conversion);
         i++;
     }
@@ -81,9 +84,9 @@ void Fastaq::add_entry(const std::string &name,
     scores[name] = score;
 }
 
-void Fastaq::add_entry(const std::string &name,
-                       const std::string &sequence,
-                       const std::string header) {
+void Fastaq::add_entry(
+    const std::string& name, const std::string& sequence, const std::string header)
+{
 
     assert(name != "");
 
@@ -93,20 +96,25 @@ void Fastaq::add_entry(const std::string &name,
     scores[name] = {};
 }
 
-void Fastaq::clear() {
+void Fastaq::clear()
+{
     names.clear();
     headers.clear();
     sequences.clear();
     scores.clear();
 }
 
-void Fastaq::save(const std::string &filepath) {
-    if (filepath.length() > 2 and filepath.substr(filepath.length() - 2) == "gz" and !gzipped) {
+void Fastaq::save(const std::string& filepath)
+{
+    if (filepath.length() > 2 and filepath.substr(filepath.length() - 2) == "gz"
+        and !gzipped) {
         gzipped = true;
-    } else if (filepath.length() > 2 and filepath.substr(filepath.length() - 2) != "gz" and gzipped) {
+    } else if (filepath.length() > 2 and filepath.substr(filepath.length() - 2) != "gz"
+        and gzipped) {
         gzipped = false;
     }
-    std::ofstream file(filepath, std::ios_base::out | std::ios_base::binary | std::ios_base::trunc);
+    std::ofstream file(
+        filepath, std::ios_base::out | std::ios_base::binary | std::ios_base::trunc);
     boost::iostreams::filtering_streambuf<boost::iostreams::output> out;
     if (gzipped) {
         out.push(boost::iostreams::gzip_compressor());
@@ -117,29 +125,44 @@ void Fastaq::save(const std::string &filepath) {
     outf << *this;
 }
 
-
-bool Fastaq::operator==(const Fastaq &y) const {
-    if (fastq != y.fastq) { return false; }
-    if (names.size() != y.names.size()) { return false; }
-    for (const auto &name: names) {
-        if (find(y.names.begin(), y.names.end(), name) == y.names.end()) { return false; }
-        if (y.sequences.find(name) == y.sequences.end()) { return false; }
-        if (y.sequences.at(name) != sequences.at(name)) { return false; }
-        if (fastq and y.scores.find(name) == y.scores.end()) { return false; }
-        if (y.scores.at(name) != scores.at(name)) { return false; }
+bool Fastaq::operator==(const Fastaq& y) const
+{
+    if (fastq != y.fastq) {
+        return false;
     }
-    for (const auto &name: y.names) {
-        if (find(names.begin(), names.end(), name) == names.end()) { return false; }
+    if (names.size() != y.names.size()) {
+        return false;
+    }
+    for (const auto& name : names) {
+        if (find(y.names.begin(), y.names.end(), name) == y.names.end()) {
+            return false;
+        }
+        if (y.sequences.find(name) == y.sequences.end()) {
+            return false;
+        }
+        if (y.sequences.at(name) != sequences.at(name)) {
+            return false;
+        }
+        if (fastq and y.scores.find(name) == y.scores.end()) {
+            return false;
+        }
+        if (y.scores.at(name) != scores.at(name)) {
+            return false;
+        }
+    }
+    for (const auto& name : y.names) {
+        if (find(names.begin(), names.end(), name) == names.end()) {
+            return false;
+        }
     }
     return true;
 }
 
-bool Fastaq::operator!=(const Fastaq &y) const {
-    return !(*this == y);
-}
+bool Fastaq::operator!=(const Fastaq& y) const { return !(*this == y); }
 
-std::ostream &operator<<(std::ostream &out, Fastaq const &data) {
-    for (const auto &name : data.names) {
+std::ostream& operator<<(std::ostream& out, Fastaq const& data)
+{
+    for (const auto& name : data.names) {
         if (data.fastq) {
             out << "@";
         } else {
@@ -159,7 +182,8 @@ std::ostream &operator<<(std::ostream &out, Fastaq const &data) {
     return out;
 }
 
-std::istream &operator>>(std::istream &in, Fastaq &data) {
+std::istream& operator>>(std::istream& in, Fastaq& data)
+{
     std::string name, seq, score, header;
     /*in >> name;
     in >> seq;

--- a/src/fastaq_handler.cpp
+++ b/src/fastaq_handler.cpp
@@ -1,17 +1,20 @@
-#include <string>
 #include <cstring>
 #include <iostream>
+#include <string>
 //#include <fstream>
-#include <boost/iostreams/filtering_streambuf.hpp>
-#include <boost/iostreams/copy.hpp>
-#include <boost/iostreams/filter/gzip.hpp>
 #include "fastaq_handler.h"
 #include "utils.h"
+#include <boost/iostreams/copy.hpp>
+#include <boost/iostreams/filter/gzip.hpp>
+#include <boost/iostreams/filtering_streambuf.hpp>
 
-
-FastaqHandler::FastaqHandler(const std::string &filepath) : gzipped(false), instream(&inbuf), num_reads_parsed(0) {
+FastaqHandler::FastaqHandler(const std::string& filepath)
+    : gzipped(false)
+    , instream(&inbuf)
+    , num_reads_parsed(0)
+{
     // level for boost logging
-//    logging::core::get()->set_filter(logging::trivial::severity >= g_log_level);
+    //    logging::core::get()->set_filter(logging::trivial::severity >= g_log_level);
 
     BOOST_LOG_TRIVIAL(debug) << "Open fastaq file" << filepath;
     fastaq_file.open(filepath);
@@ -25,25 +28,25 @@ FastaqHandler::FastaqHandler(const std::string &filepath) : gzipped(false), inst
             gzipped = true;
         }
         inbuf.push(fastaq_file);
-    }
-    catch (const boost::iostreams::gzip_error &e) {
-        std::cerr << "Problem transfering file contents to boost stream: " << e.what() << '\n';
+    } catch (const boost::iostreams::gzip_error& e) {
+        std::cerr << "Problem transfering file contents to boost stream: " << e.what()
+                  << '\n';
     }
 }
 
-FastaqHandler::~FastaqHandler() {
-    close();
-}
+FastaqHandler::~FastaqHandler() { close(); }
 
-bool FastaqHandler::eof() {
+bool FastaqHandler::eof()
+{
     int c = instream.peek();
     return (c == EOF);
 }
 
-void FastaqHandler::get_next() {
-    //cout << "next ";
+void FastaqHandler::get_next()
+{
+    // cout << "next ";
     if (!line.empty() and (line[0] == '>' or line[0] == '@')) {
-        //cout << "read name line " << num_reads_parsed << " " << line << endl;
+        // cout << "read name line " << num_reads_parsed << " " << line << endl;
         name = line.substr(1);
         ++num_reads_parsed;
         read.clear();
@@ -51,81 +54,87 @@ void FastaqHandler::get_next() {
 
     while (getline(instream, line).good()) {
         if (!line.empty() and line[0] == '+') {
-            //skip this line and the qual score line
+            // skip this line and the qual score line
             getline(instream, line);
-            //cout << "qual score line ." << line << "." << endl;
+            // cout << "qual score line ." << line << "." << endl;
         } else if (line.empty() || line[0] == '>' || line[0] == '@') {
-            if (!read.empty() or line.empty()) // ok we'll allow reads with no name, removed
+            if (!read.empty()
+                or line.empty()) // ok we'll allow reads with no name, removed
             {
                 return;
             }
-            //cout << num_reads_parsed << " " << line << endl;
+            // cout << num_reads_parsed << " " << line << endl;
             name = line.substr(1);
             ++num_reads_parsed;
             read.clear();
         } else {
-            //cout << "read line ." << line << "." << endl;
+            // cout << "read line ." << line << "." << endl;
             read += line;
         }
     }
 }
 
-void FastaqHandler::skip_next() {
-    //cout << "skip ";
+void FastaqHandler::skip_next()
+{
+    // cout << "skip ";
     if (!line.empty() and (line[0] == '>' or line[0] == '@')) {
         ++num_reads_parsed;
     }
 
     while (getline(instream, line).good()) {
         if (!line.empty() and line[0] == '+') {
-            //skip this line and the qual score line
+            // skip this line and the qual score line
             getline(instream, line);
-            //cout << "qual score line ." << line << "." << endl;
+            // cout << "qual score line ." << line << "." << endl;
         } else if (line.empty() or line[0] == '>' or line[0] == '@') {
             return;
         }
     }
 }
 
-void print(std::ifstream &infile) {
+void print(std::ifstream& infile)
+{
     char file;
     std::vector<char> read;
     uint i = 0;
 
-    //Read infile to vector
+    // Read infile to vector
     while (!infile.eof()) {
         infile >> file;
         read.push_back(file);
     }
 
-    //Print read vector
+    // Print read vector
     for (i = 0; i < read.size(); i++) {
         std::cout << read[i];
     }
 }
 
-void print(std::istream &infile) {
+void print(std::istream& infile)
+{
     char file;
     std::vector<char> read;
     int i = 0;
 
-    //Read infile to vector
+    // Read infile to vector
     while (!infile.eof()) {
         infile >> file;
         read.push_back(file);
     }
 
-    //Print read vector
+    // Print read vector
     for (auto i = 0; i < read.size(); i++) {
         std::cout << read[i];
     }
 }
 
-void FastaqHandler::get_id(const uint32_t &id) {
+void FastaqHandler::get_id(const uint32_t& id)
+{
     const uint32_t one_based_id = id + 1;
     if (one_based_id < num_reads_parsed) {
-        BOOST_LOG_TRIVIAL(warning) << "restart buffer as have id " << num_reads_parsed << " and want id "
-                                   << one_based_id << " (" << id << ") with 0-based indexing.";
+        BOOST_LOG_TRIVIAL(warning)
+            << "restart buffer as have id " << num_reads_parsed << " and want id "
+            << one_based_id << " (" << id << ") with 0-based indexing.";
         num_reads_parsed = 0;
         name.clear();
         read.clear();
@@ -160,9 +169,8 @@ void FastaqHandler::get_id(const uint32_t &id) {
     }
 }
 
-void FastaqHandler::close() {
+void FastaqHandler::close()
+{
     BOOST_LOG_TRIVIAL(debug) << "Close fastaq file";
     fastaq_file.close();
 }
-
-

--- a/src/get_vcf_ref_main.cpp
+++ b/src/get_vcf_ref_main.cpp
@@ -1,17 +1,16 @@
-#include <cstring>
-#include <cassert>
-#include <vector>
-#include <iostream>
-#include <fstream>
+#include "fastaq.h"
+#include "fastaq_handler.h"
 #include "localPRG.h"
-#include "utils.h"
 #include "localgraph.h"
 #include "localnode.h"
-#include "fastaq_handler.h"
-#include "fastaq.h"
+#include "utils.h"
+#include <cassert>
+#include <cstring>
+#include <fstream>
+#include <iostream>
+#include <vector>
 
-
-int pandora_get_vcf_ref(int argc, char *argv[]) // the "pandora walk" comand
+int pandora_get_vcf_ref(int argc, char* argv[]) // the "pandora walk" comand
 {
     if (argc != 3 and argc != 2) {
         fprintf(stderr, "Usage: pandora get_vcf_ref <in_prg.fa> <seq.fa>\n");
@@ -26,7 +25,7 @@ int pandora_get_vcf_ref(int argc, char *argv[]) // the "pandora walk" comand
     Fastaq fa(true, false);
 
     if (argc == 2) {
-        for (const auto &prg_ptr: prgs) {
+        for (const auto& prg_ptr : prgs) {
             std::vector<LocalNodePtr> npath;
             npath = prg_ptr->prg.top_path();
             fa.add_entry(prg_ptr->name, prg_ptr->string_along_path(npath));
@@ -37,13 +36,14 @@ int pandora_get_vcf_ref(int argc, char *argv[]) // the "pandora walk" comand
         FastaqHandler readfile(argv[2]);
         bool found;
 
-        for (const auto &prg_ptr: prgs) {
+        for (const auto& prg_ptr : prgs) {
             found = false;
             readfile.get_id(0);
             while (not readfile.eof()) {
                 npath = prg_ptr->get_valid_vcf_reference(readfile.read);
                 if (not npath.empty()) {
-                    //BOOST_LOG_TRIVIAL(debug) << ">" << prg_ptr->name << std::endl << readfile.read;
+                    // BOOST_LOG_TRIVIAL(debug) << ">" << prg_ptr->name << std::endl <<
+                    // readfile.read;
                     fa.add_entry(prg_ptr->name, prg_ptr->string_along_path(npath));
                     found = true;
                     break;
@@ -65,4 +65,3 @@ int pandora_get_vcf_ref(int argc, char *argv[]) // the "pandora walk" comand
 
     return 0;
 }
-

--- a/src/index.cpp
+++ b/src/index.cpp
@@ -1,14 +1,14 @@
-#include <iostream>
+#include <algorithm>
 #include <fstream>
+#include <iostream>
 #include <unordered_map>
 #include <vector>
-#include <algorithm>
 
 #include <boost/log/trivial.hpp>
 
-#include "minirecord.h"
 #include "index.h"
 #include "localPRG.h"
+#include "minirecord.h"
 
 /**
  * Adds a k-mer to the index. This is *just* called to add minimizers.
@@ -19,62 +19,76 @@
  * @param knode_id : the id of the node representing this kmer in the KmerGraph
  * @param strand : the strand
  */
-void Index::add_record(const uint64_t kmer, const uint32_t prg_id, const prg::Path &path, const uint32_t knode_id,
-                       const bool strand) {
-    //cout << "Add kmer " << kmer << " id, path, strand " << prg_id << ", " << path << ", " << strand << endl;
-    auto it = minhash.find(kmer); //checks if kmer is in minhash
-    if (it == minhash.end()) { //no
-        auto *newv = new std::vector<MiniRecord>; //get a new vector of MiniRecords - TODO: is this a memory leak?
+void Index::add_record(const uint64_t kmer, const uint32_t prg_id,
+    const prg::Path& path, const uint32_t knode_id, const bool strand)
+{
+    // cout << "Add kmer " << kmer << " id, path, strand " << prg_id << ", " << path <<
+    // ", " << strand << endl;
+    auto it = minhash.find(kmer); // checks if kmer is in minhash
+    if (it == minhash.end()) { // no
+        auto* newv = new std::vector<MiniRecord>; // get a new vector of MiniRecords -
+                                                  // TODO: is this a memory leak?
         newv->reserve(20);
         newv->emplace_back(MiniRecord(prg_id, path, knode_id, strand));
-        minhash.insert(std::pair<uint64_t, std::vector<MiniRecord> *>(kmer, newv)); //add this record to minhash
-        //cout << "New minhash size: " << minhash.size() << endl; 
-    } else { //yes
-        MiniRecord mr(prg_id, path, knode_id, strand); //create a new MiniRecord from this minimizer kmer
-        if (find(it->second->begin(), it->second->end(), mr) == it->second->end()) { //checks if this minimizer record is already in the vector of this minimizer
-            it->second->push_back(mr); //no, add it
+        minhash.insert(std::pair<uint64_t, std::vector<MiniRecord>*>(
+            kmer, newv)); // add this record to minhash
+        // cout << "New minhash size: " << minhash.size() << endl;
+    } else { // yes
+        MiniRecord mr(prg_id, path, knode_id,
+            strand); // create a new MiniRecord from this minimizer kmer
+        if (find(it->second->begin(), it->second->end(), mr)
+            == it->second->end()) { // checks if this minimizer record is already in the
+                                    // vector of this minimizer
+            it->second->push_back(mr); // no, add it
         }
-        //cout << "New minhash entry for  kmer " << kmer << endl;
+        // cout << "New minhash entry for  kmer " << kmer << endl;
     }
 }
 
-void Index::clear() {
+void Index::clear()
+{
     for (auto it = minhash.begin(); it != minhash.end();) {
         delete it->second;
         it = minhash.erase(it);
     }
 }
 
-void Index::save(const std::string &prgfile, uint32_t w, uint32_t k) {
-    auto filename = prgfile + ".k" + std::to_string(k) + ".w" + std::to_string(w) + ".idx";
+void Index::save(const std::string& prgfile, uint32_t w, uint32_t k)
+{
+    auto filename
+        = prgfile + ".k" + std::to_string(k) + ".w" + std::to_string(w) + ".idx";
     save(filename);
 }
 
-void Index::save(const std::string &indexfile) {
+void Index::save(const std::string& indexfile)
+{
     BOOST_LOG_TRIVIAL(debug) << "Saving index to " << indexfile;
     std::ofstream handle;
     handle.open(indexfile);
 
     handle << minhash.size() << std::endl;
 
-    for (auto &it : minhash) {
+    for (auto& it : minhash) {
         handle << it.first << "\t" << it.second->size();
         for (uint32_t j = 0; j != it.second->size(); ++j) {
             handle << "\t" << (*(it.second))[j];
         }
         handle << std::endl;
-
     }
     handle.close();
-    BOOST_LOG_TRIVIAL(debug) << "Finished saving " << minhash.size() << " entries to file";
+    BOOST_LOG_TRIVIAL(debug) << "Finished saving " << minhash.size()
+                             << " entries to file";
 }
 
-void Index::load(const std::string &prgfile, uint32_t w, uint32_t k) {
-    auto filename = prgfile + ".k" + std::to_string(k) + ".w" + std::to_string(w) + ".idx";
+void Index::load(const std::string& prgfile, uint32_t w, uint32_t k)
+{
+    auto filename
+        = prgfile + ".k" + std::to_string(k) + ".w" + std::to_string(w) + ".idx";
     load(filename);
 }
 
-void Index::load(const std::string &indexfile) {
+void Index::load(const std::string& indexfile)
+{
     BOOST_LOG_TRIVIAL(debug) << "Loading index";
     BOOST_LOG_TRIVIAL(debug) << "File is " << indexfile;
     uint64_t key;
@@ -96,7 +110,7 @@ void Index::load(const std::string &indexfile) {
                 myfile >> key;
                 myfile.ignore(1, '\t');
                 myfile >> size;
-                auto *vmr = new std::vector<MiniRecord>;
+                auto* vmr = new std::vector<MiniRecord>;
                 if (minhash.find(key) != minhash.end()) {
                     vmr = minhash[key];
                     vmr->reserve(vmr->size() + size);
@@ -114,51 +128,63 @@ void Index::load(const std::string &indexfile) {
             }
         }
     } else {
-        BOOST_LOG_TRIVIAL(warning) << "Unable to open index file " << indexfile << ". Does it exist? Have you run pandora index?";
+        BOOST_LOG_TRIVIAL(warning) << "Unable to open index file " << indexfile
+                                   << ". Does it exist? Have you run pandora index?";
         exit(1);
     }
 
-    if (minhash.size() <= 1){
-        BOOST_LOG_TRIVIAL(debug) << "Was this file empty?! Index now contains a trivial " << minhash.size() << " entries";
+    if (minhash.size() <= 1) {
+        BOOST_LOG_TRIVIAL(debug)
+            << "Was this file empty?! Index now contains a trivial " << minhash.size()
+            << " entries";
     } else {
-        BOOST_LOG_TRIVIAL(debug) << "Finished loading file. Index now contains " << minhash.size() << " entries";
+        BOOST_LOG_TRIVIAL(debug) << "Finished loading file. Index now contains "
+                                 << minhash.size() << " entries";
     }
 }
 
-bool Index::operator==(const Index &other) const {
-    if (this->minhash.size() != other.minhash.size()){ return false; }
+bool Index::operator==(const Index& other) const
+{
+    if (this->minhash.size() != other.minhash.size()) {
+        return false;
+    }
 
-    for (const auto &kmer : this->minhash){
+    for (const auto& kmer : this->minhash) {
         const auto it = other.minhash.find(kmer.first);
-        if (it == other.minhash.end()) {return false;}
+        if (it == other.minhash.end()) {
+            return false;
+        }
         const auto& qvecp = it->second;
-        for (const auto &record : *this->minhash.at(kmer.first)){
-            if (std::find(qvecp->begin(), qvecp->end(), record) == qvecp->end()) {return false;}
+        for (const auto& record : *this->minhash.at(kmer.first)) {
+            if (std::find(qvecp->begin(), qvecp->end(), record) == qvecp->end()) {
+                return false;
+            }
         }
     }
 
-    for (const auto &kmer : other.minhash){
+    for (const auto& kmer : other.minhash) {
         const auto it = this->minhash.find(kmer.first);
-        if (it == this->minhash.end()) {return false;}
+        if (it == this->minhash.end()) {
+            return false;
+        }
         const auto& qvecp = it->second;
-        for (const auto &record : *other.minhash.at(kmer.first)){
-            if (std::find(qvecp->begin(), qvecp->end(), record) == qvecp->end()) {return false;}
+        for (const auto& record : *other.minhash.at(kmer.first)) {
+            if (std::find(qvecp->begin(), qvecp->end(), record) == qvecp->end()) {
+                return false;
+            }
         }
     }
     return true;
 }
 
-bool Index::operator!=(const Index &other) const {
-    return !(*this==other);
-}
+bool Index::operator!=(const Index& other) const { return !(*this == other); }
 
-
-void index_prgs(std::vector<std::shared_ptr<LocalPRG>> &prgs, //all PRGs to be indexed
-                std::shared_ptr<Index> &index, //kmer sketch index to be built here
-                const uint32_t w, //window size
-                const uint32_t k, //kmer size
-                const std::string &outdir,
-                uint32_t threads) {
+void index_prgs(std::vector<std::shared_ptr<LocalPRG>>& prgs, // all PRGs to be indexed
+    std::shared_ptr<Index>& index, // kmer sketch index to be built here
+    const uint32_t w, // window size
+    const uint32_t k, // kmer size
+    const std::string& outdir, uint32_t threads)
+{
     BOOST_LOG_TRIVIAL(debug) << "Index PRGs";
     if (prgs.size() == 0)
         return;
@@ -170,25 +196,23 @@ void index_prgs(std::vector<std::shared_ptr<LocalPRG>> &prgs, //all PRGs to be i
     }
     index->minhash.reserve(r);
 
-    //create the dirs for the index
-    const int nbOfGFAsPerDir=4000;
-    for (uint32_t i = 0; i <= prgs.size()/nbOfGFAsPerDir; ++i)
+    // create the dirs for the index
+    const int nbOfGFAsPerDir = 4000;
+    for (uint32_t i = 0; i <= prgs.size() / nbOfGFAsPerDir; ++i)
         fs::create_directories(outdir + "/" + int_to_string(i + 1));
 
     // now fill index
-    std::atomic_uint32_t nbOfPRGsDone{0};
-    #pragma omp parallel for num_threads(threads) schedule(dynamic, 1)
-    for (uint32_t i = 0; i < prgs.size(); ++i) { //for each prg
-        uint32_t dir = i/nbOfGFAsPerDir + 1;
-        prgs[i]->minimizer_sketch(index, w, k, (((double)(nbOfPRGsDone.load()))/prgs.size())*100);
-        prgs[i]->kmer_prg.save(
-                outdir + "/" + int_to_string(dir) + "/" + prgs[i]->name + ".k" + std::to_string(k) + ".w" +
-                std::to_string(w) + ".gfa");
+    std::atomic_uint32_t nbOfPRGsDone { 0 };
+#pragma omp parallel for num_threads(threads) schedule(dynamic, 1)
+    for (uint32_t i = 0; i < prgs.size(); ++i) { // for each prg
+        uint32_t dir = i / nbOfGFAsPerDir + 1;
+        prgs[i]->minimizer_sketch(
+            index, w, k, (((double)(nbOfPRGsDone.load())) / prgs.size()) * 100);
+        prgs[i]->kmer_prg.save(outdir + "/" + int_to_string(dir) + "/" + prgs[i]->name
+            + ".k" + std::to_string(k) + ".w" + std::to_string(w) + ".gfa");
 
         ++nbOfPRGsDone;
     }
     BOOST_LOG_TRIVIAL(debug) << "Finished adding " << prgs.size() << " LocalPRGs";
     BOOST_LOG_TRIVIAL(debug) << "Number of keys in Index: " << index->minhash.size();
 }
-	    
-

--- a/src/interval.cpp
+++ b/src/interval.cpp
@@ -1,28 +1,29 @@
-#include <limits>
-#include <cassert>
 #include "interval.h"
-
+#include <cassert>
+#include <limits>
 
 #define assert_msg(x) !(std::cerr << "Assertion failed: " << x << std::endl)
 
-
-Interval::Interval(uint32_t s, uint32_t e) : start(s) {
+Interval::Interval(uint32_t s, uint32_t e)
+    : start(s)
+{
     assert(e >= start); // not a real interval ;
-    assert (e - start < std::numeric_limits<uint32_t>::max() or
-            assert_msg("Interval [" << s << "," << e << ") was too long"));
-    length = e - start; // intervals need to be exclusive of end point so that empty strings can be represented
+    assert(e - start < std::numeric_limits<uint32_t>::max()
+        or assert_msg("Interval [" << s << "," << e << ") was too long"));
+    length = e - start; // intervals need to be exclusive of end point so that empty
+                        // strings can be represented
 }
 
-uint32_t Interval::get_end() const {
-    return start + (uint32_t) length;
-}
+uint32_t Interval::get_end() const { return start + (uint32_t)length; }
 
-std::ostream &operator<<(std::ostream &out, Interval const &i) {
+std::ostream& operator<<(std::ostream& out, Interval const& i)
+{
     out << "[" << i.start << ", " << i.get_end() << ")";
     return out;
 }
 
-std::istream &operator>>(std::istream &in, Interval &i) {
+std::istream& operator>>(std::istream& in, Interval& i)
+{
     uint32_t end;
     in.ignore(1, '[');
     in >> i.start;
@@ -30,28 +31,37 @@ std::istream &operator>>(std::istream &in, Interval &i) {
     in >> end;
     in.ignore(1, ')');
     assert(end >= i.start);
-    assert (end - i.start < std::numeric_limits<uint32_t>::max() or
-            assert_msg("Interval [" << i.start << "," << end << ") was too long"));
+    assert(end - i.start < std::numeric_limits<uint32_t>::max()
+        or assert_msg("Interval [" << i.start << "," << end << ") was too long"));
     i.length = end - i.start;
     return in;
 }
 
-bool Interval::operator==(const Interval &y) const {
+bool Interval::operator==(const Interval& y) const
+{
     return (start == y.start and length == y.length);
 }
 
-bool Interval::operator!=(const Interval &y) const {
+bool Interval::operator!=(const Interval& y) const
+{
     return !(start == y.start and length == y.length);
 }
 
-bool Interval::operator<(const Interval &y) const {
-    if (start < y.start) { return true; }
-    if (start > y.start) { return false; }
-    if (length < y.length) { return true; }
-    if (length > y.length) { return false; }
+bool Interval::operator<(const Interval& y) const
+{
+    if (start < y.start) {
+        return true;
+    }
+    if (start > y.start) {
+        return false;
+    }
+    if (length < y.length) {
+        return true;
+    }
+    if (length > y.length) {
+        return false;
+    }
     return false;
 }
 
-bool Interval::empty() const {
-    return length == 0;
-}
+bool Interval::empty() const { return length == 0; }

--- a/src/inthash.cpp
+++ b/src/inthash.cpp
@@ -1,9 +1,8 @@
-#include <iostream>
+#include "inthash.h"
 #include <cassert>
 #include <cmath>
 #include <cstring>
-#include "inthash.h"
-
+#include <iostream>
 
 /* Taken from Heng Li minimap https://github.com/lh3/minimap/blob/master/sketch.c
  *
@@ -33,86 +32,78 @@
  * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  *
- * Note that this uses Thomas Wang's integer hash functions. 
+ * Note that this uses Thomas Wang's integer hash functions.
  * See <https://gist.github.com/lh3/59882d6b96166dfc3d8d> for a snapshot.
- * Also for any 1<k<=64, let mask=(1<<k)-1. hash_64() is a bijection on [0,1<<k), which means
- *  hash_64(x, mask)==hash_64(y, mask) if and only if x==y.
+ * Also for any 1<k<=64, let mask=(1<<k)-1. hash_64() is a bijection on [0,1<<k), which
+ * means hash_64(x, mask)==hash_64(y, mask) if and only if x==y.
  */
 
-unsigned char seq_nt4_table[256] = {
-        0, 1, 2, 3, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4,
-        4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4,
-        4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4,
-        4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4,
-        4, 0, 4, 1, 4, 4, 4, 2, 4, 4, 4, 4, 4, 4, 4, 4,
-        4, 4, 4, 4, 3, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4,
-        4, 0, 4, 1, 4, 4, 4, 2, 4, 4, 4, 4, 4, 4, 4, 4,
-        4, 4, 4, 4, 3, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4,
-        4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4,
-        4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4,
-        4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4,
-        4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4,
-        4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4,
-        4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4,
-        4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4,
-        4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4
-};
+unsigned char seq_nt4_table[256] = { 0, 1, 2, 3, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4,
+    4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4,
+    4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 0, 4, 1, 4, 4, 4, 2, 4,
+    4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 3, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 0, 4, 1, 4,
+    4, 4, 2, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 3, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4,
+    4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4,
+    4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4,
+    4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4,
+    4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4,
+    4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4 };
 
-uint32_t nt4(char c) {
-    return seq_nt4_table[(uint8_t) c];
-}
+uint32_t nt4(char c) { return seq_nt4_table[(uint8_t)c]; }
 
-void test_table() {
+void test_table()
+{
     char c = 'A';
-    int u = seq_nt4_table[(uint8_t) c];
+    int u = seq_nt4_table[(uint8_t)c];
     assert(u == 0);
     c = 'a';
-    u = seq_nt4_table[(uint8_t) c];
+    u = seq_nt4_table[(uint8_t)c];
     assert(u == 0);
 
     c = 'C';
-    u = seq_nt4_table[(uint8_t) c];
+    u = seq_nt4_table[(uint8_t)c];
     assert(u == 1);
     c = 'c';
-    u = seq_nt4_table[(uint8_t) c];
+    u = seq_nt4_table[(uint8_t)c];
     assert(u == 1);
 
     c = 'G';
-    u = seq_nt4_table[(uint8_t) c];
+    u = seq_nt4_table[(uint8_t)c];
     assert(u = 2);
     c = 'g';
-    u = seq_nt4_table[(uint8_t) c];
+    u = seq_nt4_table[(uint8_t)c];
     assert(u == 2);
 
     c = 'T';
-    u = seq_nt4_table[(uint8_t) c];
+    u = seq_nt4_table[(uint8_t)c];
     assert(u == 3);
     c = 't';
-    u = seq_nt4_table[(uint8_t) c];
+    u = seq_nt4_table[(uint8_t)c];
     assert(u == 3);
 
     c = 'N';
-    u = seq_nt4_table[(uint8_t) c];
+    u = seq_nt4_table[(uint8_t)c];
     assert(u == 4);
     c = 'R';
-    u = seq_nt4_table[(uint8_t) c];
+    u = seq_nt4_table[(uint8_t)c];
     assert(u == 4);
     c = 'Y';
-    u = seq_nt4_table[(uint8_t) c];
+    u = seq_nt4_table[(uint8_t)c];
     assert(u == 4);
     c = 'X';
-    u = seq_nt4_table[(uint8_t) c];
+    u = seq_nt4_table[(uint8_t)c];
     assert(u == 4);
     c = 'S';
-    u = seq_nt4_table[(uint8_t) c];
+    u = seq_nt4_table[(uint8_t)c];
     assert(u == 4);
     c = '-';
-    u = seq_nt4_table[(uint8_t) c];
+    u = seq_nt4_table[(uint8_t)c];
     assert(u == 4);
     return;
 }
 
-uint64_t hash64(uint64_t key, const uint64_t &mask) {
+uint64_t hash64(uint64_t key, const uint64_t& mask)
+{
     assert(key <= mask);
     key = (~key + (key << 21)) & mask; // key = (key << 21) - key - 1;
     key = key ^ key >> 24;
@@ -126,40 +117,42 @@ uint64_t hash64(uint64_t key, const uint64_t &mask) {
 
 /* Now use these functions in my own code */
 
-std::pair<uint64_t, uint64_t> KmerHash::kmerhash(const std::string &s, const uint32_t k) {
+std::pair<uint64_t, uint64_t> KmerHash::kmerhash(const std::string& s, const uint32_t k)
+{
     // if we've already worked out the answer, return
-    auto it = lookup.find(s); //checks if this string is already in the hash
+    auto it = lookup.find(s); // checks if this string is already in the hash
     if (it != lookup.end()) {
         return it->second;
     }
 
-    // this takes the hash of both forwards and reverse complement kmers and returns them as a pair 
+    // this takes the hash of both forwards and reverse complement kmers and returns
+    // them as a pair
     assert(s.size() == k);
     int c;
-    uint64_t shift1 = 2 * (k - 1), mask = (1ULL << 2 * k) - 1, kmer[2] = {0, 0};
-    //uint64_t mask1 = pow(4,k) - 1, kh = 0, rckh = 0;
-    char myArray[s.size() + 1];//as 1 char space for null is also required
+    uint64_t shift1 = 2 * (k - 1), mask = (1ULL << 2 * k) - 1, kmer[2] = { 0, 0 };
+    // uint64_t mask1 = pow(4,k) - 1, kh = 0, rckh = 0;
+    char myArray[s.size() + 1]; // as 1 char space for null is also required
     strcpy(myArray, s.c_str());
     for (char i : s) {
-        c = seq_nt4_table[(uint8_t) i];
-        //cout << s[i] << " -> " << c;
+        c = seq_nt4_table[(uint8_t)i];
+        // cout << s[i] << " -> " << c;
         if (c < 4) { // not an ambiguous base
-            kmer[0] = (kmer[0] << 2 | c) & mask;           // forward k-mer
+            kmer[0] = (kmer[0] << 2 | c) & mask; // forward k-mer
             kmer[1] = (kmer[1] >> 2) | (3ULL ^ c) << shift1; // reverse k-mer
-            //kh += c*pow(4,i);
-            //rckh += (3-c)*pow(4,k-i-1);
+            // kh += c*pow(4,i);
+            // rckh += (3-c)*pow(4,k-i-1);
         }
-        //cout << "after adding " << s[i] << "=" << c << " kh is now " << kh << " and kmer[0] is now " << kmer[0] << ", rckh is now " << rckh << " and kmer[1] is now " << kmer[1] << endl;
+        // cout << "after adding " << s[i] << "=" << c << " kh is now " << kh << " and
+        // kmer[0] is now " << kmer[0] << ", rckh is now " << rckh << " and kmer[1] is
+        // now " << kmer[1] << endl;
     }
-    //cout << "s: " << s << " -> " << kh << endl;
+    // cout << "s: " << s << " -> " << kh << endl;
     kmer[0] = hash64(kmer[0], mask);
     kmer[1] = hash64(kmer[1], mask);
-    //cout << "kmer " << s << " has kmer[0] " << kmer[0] << " and kmer[1] " << kmer[1] << endl;
+    // cout << "kmer " << s << " has kmer[0] " << kmer[0] << " and kmer[1] " << kmer[1]
+    // << endl;
 
     auto ret = std::make_pair(kmer[0], kmer[1]);
     lookup[s] = ret;
     return ret;
 }
-
-
-

--- a/src/kmergraph.cpp
+++ b/src/kmergraph.cpp
@@ -1,33 +1,32 @@
-#include <sstream>
-#include <fstream>
 #include <cassert>
-#include <limits>
-#include <cstdio>      /* NULL */
-#include <cstdlib>     /* srand, rand */
 #include <cmath>
+#include <cstdio> /* NULL */
+#include <cstdlib> /* srand, rand */
+#include <fstream>
+#include <limits>
+#include <sstream>
 
 #include <boost/log/trivial.hpp>
 
-#include "utils.h"
-#include "kmernode.h"
 #include "kmergraph.h"
 #include "kmergraphwithcoverage.h"
+#include "kmernode.h"
 #include "localPRG.h"
-
+#include "utils.h"
 
 #define assert_msg(x) !(std::cerr << "Assertion failed: " << x << std::endl)
 
-
 using namespace prg;
 
-
-KmerGraph::KmerGraph() {
+KmerGraph::KmerGraph()
+{
     shortest_path_length = 0;
     k = 0; // nb the kmer size is determined by the first non-null node added
 }
 
 // copy constructor
-KmerGraph::KmerGraph(const KmerGraph &other) {
+KmerGraph::KmerGraph(const KmerGraph& other)
+{
     shortest_path_length = other.shortest_path_length;
     k = other.k;
     KmerNodePtr n;
@@ -37,7 +36,7 @@ KmerGraph::KmerGraph(const KmerGraph &other) {
     nodes.reserve(other.nodes.size());
 
     // create deep copies of the nodes, minus the edges
-    for (const auto &node : other.nodes) {
+    for (const auto& node : other.nodes) {
         n = std::make_shared<KmerNode>(*node);
         assert(nodes.size() == n->id);
         nodes.push_back(n);
@@ -45,7 +44,7 @@ KmerGraph::KmerGraph(const KmerGraph &other) {
     }
 
     // now need to copy the edges
-    for (const auto &node : other.nodes) {
+    for (const auto& node : other.nodes) {
         for (uint32_t j = 0; j < node->out_nodes.size(); ++j) {
             add_edge(nodes.at(node->id), nodes.at(node->out_nodes[j].lock()->id));
         }
@@ -53,7 +52,8 @@ KmerGraph::KmerGraph(const KmerGraph &other) {
 }
 
 // Assignment operator
-KmerGraph &KmerGraph::operator=(const KmerGraph &other) {
+KmerGraph& KmerGraph::operator=(const KmerGraph& other)
+{
     // check for self-assignment
     if (this == &other)
         return *this;
@@ -68,7 +68,7 @@ KmerGraph &KmerGraph::operator=(const KmerGraph &other) {
     KmerNodePtr n;
 
     // create deep copies of the nodes, minus the edges
-    for (const auto &node : other.nodes) {
+    for (const auto& node : other.nodes) {
         n = std::make_shared<KmerNode>(*node);
         assert(nodes.size() == n->id);
         nodes.push_back(n);
@@ -76,7 +76,7 @@ KmerGraph &KmerGraph::operator=(const KmerGraph &other) {
     }
 
     // now need to copy the edges
-    for (const auto &node : other.nodes) {
+    for (const auto& node : other.nodes) {
         for (uint32_t j = 0; j < node->out_nodes.size(); ++j) {
             add_edge(nodes.at(node->id), nodes.at(node->out_nodes[j].lock()->id));
         }
@@ -85,7 +85,8 @@ KmerGraph &KmerGraph::operator=(const KmerGraph &other) {
     return *this;
 }
 
-void KmerGraph::clear() {
+void KmerGraph::clear()
+{
     nodes.clear();
     assert(nodes.empty());
 
@@ -96,24 +97,25 @@ void KmerGraph::clear() {
     k = 0;
 }
 
-KmerNodePtr KmerGraph::add_node(const prg::Path &p) { //add this kmer path to this kmer graph
-    for (const auto &c : nodes) { //check if this kmer path is already added
-        if (c->path == p) { //TODO: overload operator == to receive a prg::Path?
+KmerNodePtr KmerGraph::add_node(const prg::Path& p)
+{ // add this kmer path to this kmer graph
+    for (const auto& c : nodes) { // check if this kmer path is already added
+        if (c->path == p) { // TODO: overload operator == to receive a prg::Path?
             return c;
         }
     }
 
     // if we didn't find an existing node, add this kmer path to the graph
-    KmerNodePtr n(std::make_shared<KmerNode>(nodes.size(), p)); //create the node
-    nodes.push_back(n); //add it to nodes
+    KmerNodePtr n(std::make_shared<KmerNode>(nodes.size(), p)); // create the node
+    nodes.push_back(n); // add it to nodes
     sorted_nodes.insert(n);
-    //nodes[next_id] = make_shared<KmerNode>(next_id, p);
+    // nodes[next_id] = make_shared<KmerNode>(next_id, p);
     assert(k == 0 or p.length() == 0 or p.length() == k);
     if (k == 0 and p.length() > 0) {
         k = p.length();
     }
-    assert(nodes.size() < std::numeric_limits<uint32_t>::max() ||
-           assert_msg("WARNING, reached max kmer graph node size"));
+    assert(nodes.size() < std::numeric_limits<uint32_t>::max()
+        || assert_msg("WARNING, reached max kmer graph node size"));
     if (nodes.size() == reserved_size) {
         reserved_size *= 2;
         nodes.reserve(reserved_size);
@@ -121,7 +123,9 @@ KmerNodePtr KmerGraph::add_node(const prg::Path &p) { //add this kmer path to th
     return n;
 }
 
-KmerNodePtr KmerGraph::add_node_with_kh(const prg::Path &p, const uint64_t &kh, const uint8_t &num) {
+KmerNodePtr KmerGraph::add_node_with_kh(
+    const prg::Path& p, const uint64_t& kh, const uint8_t& num)
+{
     KmerNodePtr n = add_node(p);
     n->khash = kh;
     n->num_AT = num;
@@ -129,50 +133,60 @@ KmerNodePtr KmerGraph::add_node_with_kh(const prg::Path &p, const uint64_t &kh, 
     return n;
 }
 
-condition::condition(const prg::Path &p) : q(p) {};
+condition::condition(const prg::Path& p)
+    : q(p) {};
 
 bool condition::operator()(const KmerNodePtr kn) const { return kn->path == q; }
 
-void KmerGraph::add_edge(KmerNodePtr from, KmerNodePtr to) {
+void KmerGraph::add_edge(KmerNodePtr from, KmerNodePtr to)
+{
     assert(from->id < nodes.size() and nodes[from->id] == from);
     assert(to->id < nodes.size() and nodes[to->id] == to);
     assert(from->path < to->path
-           or assert_msg(
-            "Cannot add edge from " << from->id << " to " << to->id << " because " << from->path << " is not less than "
-                                    << to->path));
+        or assert_msg("Cannot add edge from " << from->id << " to " << to->id
+                                              << " because " << from->path
+                                              << " is not less than " << to->path));
 
     if (from->find_node_ptr_in_out_nodes(to) == from->out_nodes.end()) {
         from->out_nodes.emplace_back(to);
         to->in_nodes.emplace_back(from);
-        //cout << "added edge from " << from->id << " to " << to->id << endl;
+        // cout << "added edge from " << from->id << " to " << to->id << endl;
     }
 }
 
-void KmerGraph::remove_shortcut_edges() {
+void KmerGraph::remove_shortcut_edges()
+{
     BOOST_LOG_TRIVIAL(debug) << "Remove 'bad' edges from kmergraph";
     prg::Path temp_path;
     uint32_t num_removed_edges = 0;
     std::vector<KmerNodePtr> v = {};
     std::deque<std::vector<KmerNodePtr>> d;
 
-    for (const auto &n : nodes) {
-        //cout << n.first << endl;
-        for (const auto &out : n->out_nodes) {
+    for (const auto& n : nodes) {
+        // cout << n.first << endl;
+        for (const auto& out : n->out_nodes) {
             auto out_node_as_shared_ptr = out.lock();
-            for (auto nextOut = out_node_as_shared_ptr->out_nodes.begin(); nextOut != out_node_as_shared_ptr->out_nodes.end();) {
+            for (auto nextOut = out_node_as_shared_ptr->out_nodes.begin();
+                 nextOut != out_node_as_shared_ptr->out_nodes.end();) {
                 auto nextOutAsSharedPtr = nextOut->lock();
                 // if the outnode of an outnode of A is another outnode of A
-                if (n->find_node_ptr_in_out_nodes(nextOutAsSharedPtr) != n->out_nodes.end()) {
+                if (n->find_node_ptr_in_out_nodes(nextOutAsSharedPtr)
+                    != n->out_nodes.end()) {
                     temp_path = get_union(n->path, nextOutAsSharedPtr->path);
 
                     if (out_node_as_shared_ptr->path.is_subpath(temp_path)) {
-                        //remove it from the outnodes
-                        BOOST_LOG_TRIVIAL(debug) << "found the union of " << n->path << " and " << nextOutAsSharedPtr->path;
-                        BOOST_LOG_TRIVIAL(debug) << "result " << temp_path << " contains " << out_node_as_shared_ptr->path;
+                        // remove it from the outnodes
+                        BOOST_LOG_TRIVIAL(debug) << "found the union of " << n->path
+                                                 << " and " << nextOutAsSharedPtr->path;
+                        BOOST_LOG_TRIVIAL(debug)
+                            << "result " << temp_path << " contains "
+                            << out_node_as_shared_ptr->path;
                         nextOutAsSharedPtr->in_nodes.erase(
-                                nextOutAsSharedPtr->find_node_ptr_in_in_nodes(out_node_as_shared_ptr));
+                            nextOutAsSharedPtr->find_node_ptr_in_in_nodes(
+                                out_node_as_shared_ptr));
                         nextOut = out_node_as_shared_ptr->out_nodes.erase(nextOut);
-                        BOOST_LOG_TRIVIAL(debug) << "next out is now " << nextOutAsSharedPtr->path;
+                        BOOST_LOG_TRIVIAL(debug)
+                            << "next out is now " << nextOutAsSharedPtr->path;
                         num_removed_edges += 1;
                         break;
                     } else {
@@ -184,49 +198,60 @@ void KmerGraph::remove_shortcut_edges() {
             }
         }
     }
-    BOOST_LOG_TRIVIAL(debug) << "Found and removed " << num_removed_edges << " edges from the kmergraph";
+    BOOST_LOG_TRIVIAL(debug) << "Found and removed " << num_removed_edges
+                             << " edges from the kmergraph";
 }
 
-void KmerGraph::check() const {
+void KmerGraph::check() const
+{
     // should not have any leaves, only nodes with degree 0 are start and end
     for (auto c = sorted_nodes.begin(); c != sorted_nodes.end(); ++c) {
-        assert(!(*c)->in_nodes.empty() or (*c) == (*sorted_nodes.begin())||
-               assert_msg("node" << **c << " has inNodes size " << (*c)->in_nodes.size()));
-        assert(!(*c)->out_nodes.empty() or (*c) == *(sorted_nodes.rbegin()) || assert_msg(
-                "node" << **c << " has outNodes size " << (*c)->out_nodes.size() << " and isn't equal to back node "
-                       << **(sorted_nodes.rbegin())));
-        for (const auto &d: (*c)->out_nodes) {
+        assert(!(*c)->in_nodes.empty() or (*c) == (*sorted_nodes.begin())
+            || assert_msg(
+                "node" << **c << " has inNodes size " << (*c)->in_nodes.size()));
+        assert(!(*c)->out_nodes.empty() or (*c) == *(sorted_nodes.rbegin())
+            || assert_msg("node"
+                << **c << " has outNodes size " << (*c)->out_nodes.size()
+                << " and isn't equal to back node " << **(sorted_nodes.rbegin())));
+        for (const auto& d : (*c)->out_nodes) {
             auto dAsSharedPtr = d.lock();
-            assert((*c)->path < dAsSharedPtr->path || assert_msg((*c)->path << " is not less than " << dAsSharedPtr->path));
-            assert(find(c, sorted_nodes.end(), dAsSharedPtr) != sorted_nodes.end() ||
-                   assert_msg(dAsSharedPtr->id << " does not occur later in sorted list than " << (*c)->id));
+            assert((*c)->path < dAsSharedPtr->path
+                || assert_msg(
+                    (*c)->path << " is not less than " << dAsSharedPtr->path));
+            assert(find(c, sorted_nodes.end(), dAsSharedPtr) != sorted_nodes.end()
+                || assert_msg(dAsSharedPtr->id
+                    << " does not occur later in sorted list than " << (*c)->id));
         }
     }
 }
 
-void KmerGraph::discover_k() {
+void KmerGraph::discover_k()
+{
     if (nodes.size() > 0) {
         auto it = nodes.begin();
         it++;
-        const auto &knode = **it;
+        const auto& knode = **it;
         k = knode.path.length();
     }
 }
 
-std::ostream &operator<<(std::ostream &out, KmerGraph const &data) {
-    for (const auto &c: data.nodes) {
+std::ostream& operator<<(std::ostream& out, KmerGraph const& data)
+{
+    for (const auto& c : data.nodes) {
         out << *(c) << std::endl;
     }
     return out;
 }
 
-//save the KmerGraph as gfa
-void KmerGraph::save(const std::string &filepath, const std::shared_ptr<LocalPRG> localprg) {
+// save the KmerGraph as gfa
+void KmerGraph::save(
+    const std::string& filepath, const std::shared_ptr<LocalPRG> localprg)
+{
     std::ofstream handle;
     handle.open(filepath);
     if (handle.is_open()) {
         handle << "H\tVN:Z:1.0\tbn:Z:--linear --singlearr" << std::endl;
-        for (const auto &c : nodes) {
+        for (const auto& c : nodes) {
             handle << "S\t" << c->id << "\t";
 
             if (localprg != nullptr) {
@@ -235,11 +260,14 @@ void KmerGraph::save(const std::string &filepath, const std::shared_ptr<LocalPRG
                 handle << c->path;
             }
 
-            //TODO: leave as coverage 0 or change this?
-            handle << "\tFC:i:" << 0 << "\t" << "\tRC:i:" << 0 << std::endl;//"\t" << (unsigned)nodes[i].second->num_AT << endl;
+            // TODO: leave as coverage 0 or change this?
+            handle << "\tFC:i:" << 0 << "\t"
+                   << "\tRC:i:" << 0
+                   << std::endl; //"\t" << (unsigned)nodes[i].second->num_AT << endl;
 
             for (uint32_t j = 0; j < c->out_nodes.size(); ++j) {
-                handle << "L\t" << c->id << "\t+\t" << c->out_nodes[j].lock()->id << "\t+\t0M" << std::endl;
+                handle << "L\t" << c->id << "\t+\t" << c->out_nodes[j].lock()->id
+                       << "\t+\t0M" << std::endl;
             }
         }
         handle.close();
@@ -249,7 +277,8 @@ void KmerGraph::save(const std::string &filepath, const std::shared_ptr<LocalPRG
     }
 }
 
-void KmerGraph::load(const std::string &filepath) {
+void KmerGraph::load(const std::string& filepath)
+{
     clear();
 
     std::string line;
@@ -273,7 +302,8 @@ void KmerGraph::load(const std::string &filepath) {
         myfile.clear();
         myfile.seekg(0, myfile.beg);
         nodes.reserve(num_nodes);
-        std::vector<uint16_t> outnode_counts(num_nodes + 1, 0), innode_counts(num_nodes + 1, 0);
+        std::vector<uint16_t> outnode_counts(num_nodes + 1, 0),
+            innode_counts(num_nodes + 1, 0);
 
         while (getline(myfile, line).good()) {
             if (line[0] == 'S') {
@@ -282,15 +312,18 @@ void KmerGraph::load(const std::string &filepath) {
                 id = stoi(split_line[1]);
                 ss << split_line[2];
                 char c = ss.peek();
-                assert (isdigit(c) or assert_msg("Cannot read in this sort of kmergraph GFA as it does not label nodes "
-                                                 "with their PRG path"));
+                assert(isdigit(c)
+                    or assert_msg("Cannot read in this sort of kmergraph GFA as it "
+                                  "does not label nodes "
+                                  "with their PRG path"));
                 ss >> p;
                 ss.clear();
-                //add_node(p);
+                // add_node(p);
                 KmerNodePtr kmer_node = std::make_shared<KmerNode>(id, p);
                 assert(kmer_node != nullptr);
-                assert(id == nodes.size() or num_nodes - id == nodes.size() or
-                       assert_msg("id " << id << " != " << nodes.size() << " nodes.size() for kmergraph "));
+                assert(id == nodes.size() or num_nodes - id == nodes.size()
+                    or assert_msg("id " << id << " != " << nodes.size()
+                                        << " nodes.size() for kmergraph "));
                 nodes.push_back(kmer_node);
                 sorted_nodes.insert(kmer_node);
                 if (k == 0 and p.length() > 0) {
@@ -304,10 +337,11 @@ void KmerGraph::load(const std::string &filepath) {
             } else if (line[0] == 'L') {
                 split_line = split(line, "\t");
                 assert(split_line.size() >= 5);
-                assert(stoi(split_line[1]) < (int) outnode_counts.size() or
-                       assert_msg(stoi(split_line[1]) << ">=" << outnode_counts.size()));
-                assert(stoi(split_line[3]) < (int) innode_counts.size() or
-                       assert_msg(stoi(split_line[3]) << ">=" << innode_counts.size()));
+                assert(stoi(split_line[1]) < (int)outnode_counts.size()
+                    or assert_msg(
+                        stoi(split_line[1]) << ">=" << outnode_counts.size()));
+                assert(stoi(split_line[3]) < (int)innode_counts.size()
+                    or assert_msg(stoi(split_line[3]) << ">=" << innode_counts.size()));
                 outnode_counts[stoi(split_line[1])] += 1;
                 innode_counts[stoi(split_line[3])] += 1;
             }
@@ -318,11 +352,13 @@ void KmerGraph::load(const std::string &filepath) {
         }
 
         id = 0;
-        for (const auto &n : nodes) {
+        for (const auto& n : nodes) {
             assert(nodes[id]->id == id);
             id++;
-            assert(n->id < outnode_counts.size() or assert_msg(n->id << ">=" << outnode_counts.size()));
-            assert(n->id < innode_counts.size() or assert_msg(n->id << ">=" << innode_counts.size()));
+            assert(n->id < outnode_counts.size()
+                or assert_msg(n->id << ">=" << outnode_counts.size()));
+            assert(n->id < innode_counts.size()
+                or assert_msg(n->id << ">=" << innode_counts.size()));
             n->out_nodes.reserve(outnode_counts[n->id]);
             n->in_nodes.reserve(innode_counts[n->id]);
         }
@@ -343,8 +379,8 @@ void KmerGraph::load(const std::string &filepath) {
                     to = std::stoi(split_line[1]);
                 }
                 add_edge(nodes[from], nodes[to]);
-                //nodes[from]->outNodes.push_back(nodes.at(to));
-                //nodes[to]->inNodes.push_back(nodes.at(from));
+                // nodes[from]->outNodes.push_back(nodes.at(to));
+                // nodes[to]->inNodes.push_back(nodes.at(from));
             }
         }
     } else {
@@ -353,22 +389,24 @@ void KmerGraph::load(const std::string &filepath) {
     }
 }
 
-
-uint32_t KmerGraph::min_path_length() {
-    //TODO: FIX THIS INNEFICIENCY I INTRODUCED
-    std::vector<KmerNodePtr> sorted_nodes(this->sorted_nodes.begin(), this->sorted_nodes.end());
+uint32_t KmerGraph::min_path_length()
+{
+    // TODO: FIX THIS INNEFICIENCY I INTRODUCED
+    std::vector<KmerNodePtr> sorted_nodes(
+        this->sorted_nodes.begin(), this->sorted_nodes.end());
 
     if (shortest_path_length > 0) {
         return shortest_path_length;
     }
 
 #ifndef NDEBUG
-    //TODO: check if tests must be updated or not due to this (I think not - sorted_nodes is always sorted)
-    //if this is added, some tests bug, since it was not executed before...
-    //check();
+    // TODO: check if tests must be updated or not due to this (I think not -
+    // sorted_nodes is always sorted) if this is added, some tests bug, since it was not
+    // executed before... check();
 #endif
 
-    std::vector<uint32_t> len(sorted_nodes.size(), 0); // length of shortest path from node i to end of graph
+    std::vector<uint32_t> len(
+        sorted_nodes.size(), 0); // length of shortest path from node i to end of graph
     for (uint32_t j = sorted_nodes.size() - 1; j != 0; --j) {
         for (uint32_t i = 0; i != sorted_nodes[j - 1]->out_nodes.size(); ++i) {
             if (len[sorted_nodes[j - 1]->out_nodes[i].lock()->id] + 1 > len[j - 1]) {
@@ -380,35 +418,43 @@ uint32_t KmerGraph::min_path_length() {
     return len[0];
 }
 
-bool KmerGraph::operator==(const KmerGraph &other_graph) const {
+bool KmerGraph::operator==(const KmerGraph& other_graph) const
+{
     // false if have different numbers of nodes
-    if (other_graph.nodes.size() != nodes.size()) {//cout << "different numbers of nodes" << endl;
+    if (other_graph.nodes.size()
+        != nodes.size()) { // cout << "different numbers of nodes" << endl;
         return false;
     }
 
     // false if have different nodes
-    for (const auto &kmer_node_ptr: nodes) {
-        const auto &kmer_node = *kmer_node_ptr;
+    for (const auto& kmer_node_ptr : nodes) {
+        const auto& kmer_node = *kmer_node_ptr;
         // if node not equal to a node in other_graph, then false
-        auto found = find_if(other_graph.nodes.begin(), other_graph.nodes.end(), condition(kmer_node.path));
+        auto found = find_if(other_graph.nodes.begin(), other_graph.nodes.end(),
+            condition(kmer_node.path));
         if (found == other_graph.nodes.end()) {
             return false;
         }
 
         // if the node is found but has different edges, then false
-        if (kmer_node.out_nodes.size() != (*found)->out_nodes.size()) { return false; }
-        if (kmer_node.in_nodes.size() != (*found)->in_nodes.size()) { return false; }
+        if (kmer_node.out_nodes.size() != (*found)->out_nodes.size()) {
+            return false;
+        }
+        if (kmer_node.in_nodes.size() != (*found)->in_nodes.size()) {
+            return false;
+        }
         for (uint32_t j = 0; j != kmer_node.out_nodes.size(); ++j) {
-            if ((*found)->find_node_in_out_nodes(*(kmer_node.out_nodes[j].lock())) == (*found)->out_nodes.end()) {
+            if ((*found)->find_node_in_out_nodes(*(kmer_node.out_nodes[j].lock()))
+                == (*found)->out_nodes.end()) {
                 return false;
             }
         }
-
     }
     // otherwise is true
     return true;
 }
 
-bool pCompKmerNode::operator()(KmerNodePtr lhs, KmerNodePtr rhs) {
+bool pCompKmerNode::operator()(KmerNodePtr lhs, KmerNodePtr rhs)
+{
     return (lhs->path) < (rhs->path);
 }

--- a/src/kmernode.cpp
+++ b/src/kmernode.cpp
@@ -1,17 +1,22 @@
-#include <iostream>
 #include <cassert>
+#include <iostream>
 
 #include <boost/log/trivial.hpp>
 
 #include "kmernode.h"
 #include "utils.h"
 
-
-KmerNode::KmerNode(uint32_t i, const prg::Path &p) : id(i), path(p),
-                                                khash(std::numeric_limits<uint64_t>::max()), num_AT(0) {}
+KmerNode::KmerNode(uint32_t i, const prg::Path& p)
+    : id(i)
+    , path(p)
+    , khash(std::numeric_limits<uint64_t>::max())
+    , num_AT(0)
+{
+}
 
 // copy constructor
-KmerNode::KmerNode(const KmerNode &other) {
+KmerNode::KmerNode(const KmerNode& other)
+{
     id = other.id;
     path = other.path;
     khash = other.khash;
@@ -20,7 +25,8 @@ KmerNode::KmerNode(const KmerNode &other) {
 }
 
 // Assignment operator
-KmerNode &KmerNode::operator=(const KmerNode &other) {
+KmerNode& KmerNode::operator=(const KmerNode& other)
+{
     // check for self-assignment
     if (this == &other)
         return *this;
@@ -34,11 +40,10 @@ KmerNode &KmerNode::operator=(const KmerNode &other) {
     return *this;
 }
 
-std::ostream &operator<<(std::ostream &out, const KmerNode &kmer_node) {
+std::ostream& operator<<(std::ostream& out, const KmerNode& kmer_node)
+{
     out << kmer_node.id << " " << kmer_node.path << " ";
     return out;
 }
 
-bool KmerNode::operator==(const KmerNode &y) const {
-    return path == y.path;
-}
+bool KmerNode::operator==(const KmerNode& y) const { return path == y.path; }

--- a/src/localPRG.cpp
+++ b/src/localPRG.cpp
@@ -1,111 +1,132 @@
-#include <fstream>
-#include <set>
+#include <algorithm>
 #include <cassert>
 #include <cmath>
-#include <algorithm>
-#include <numeric>
 #include <cstdlib>
+#include <fstream>
+#include <numeric>
+#include <set>
 #include <utility>
 
 #include <boost/log/trivial.hpp>
 
-#include "minimizer.h"
-#include "localPRG.h"
-#include "inthash.h"
-#include "utils.h"
 #include "fastaq.h"
-
+#include "inthash.h"
+#include "localPRG.h"
+#include "minimizer.h"
+#include "utils.h"
 
 #define assert_msg(x) !(std::cerr << "Assertion failed: " << x << std::endl)
 
 bool LocalPRG::do_path_memoization_in_nodes_along_path_method = false;
 
-LocalPRG::LocalPRG(uint32_t id, const std::string &name, const std::string &seq)
-        : next_id(0), buff(" "), next_site(5), id(id), name(name), seq(seq), num_hits(2, 0) {
-    std::vector<uint32_t> v; //TODO: v is not used - safe to delete - but is passed as a parameter...
+LocalPRG::LocalPRG(uint32_t id, const std::string& name, const std::string& seq)
+    : next_id(0)
+    , buff(" ")
+    , next_site(5)
+    , id(id)
+    , name(name)
+    , seq(seq)
+    , num_hits(2, 0)
+{
+    std::vector<uint32_t>
+        v; // TODO: v is not used - safe to delete - but is passed as a parameter...
     // avoid error if a prg contains only empty space as it's sequence
     if (seq.find_first_not_of("\t\n\v\f\r") != std::string::npos) {
-        std::vector<uint32_t> b = build_graph(Interval(0, seq.size()), v); //TODO: b is not used - safe to delete
+        std::vector<uint32_t> b = build_graph(
+            Interval(0, seq.size()), v); // TODO: b is not used - safe to delete
     } else {
         prg.add_node(0, "", Interval(0, 0));
     }
-    //index the intervals in the prg
+    // index the intervals in the prg
     prg.intervalTree.index();
 }
 
-
-bool LocalPRG::isalpha_string(const std::string &s) const {
+bool LocalPRG::isalpha_string(const std::string& s) const
+{
     // Returns if a string s is entirely alphabetic
     for (char j : s)
         if (isalpha(j) == 0) {
-            //std::cout << "Found non-alpha char: " << s[j] << std::endl;
+            // std::cout << "Found non-alpha char: " << s[j] << std::endl;
             return false;
         }
     return true;
 }
 
-
-std::string LocalPRG::string_along_path(const prg::Path &p) const {
-    //std::cout << p << std::endl;
+std::string LocalPRG::string_along_path(const prg::Path& p) const
+{
+    // std::cout << p << std::endl;
     assert(p.get_start() <= seq.length());
     assert(p.get_end() <= seq.length());
     std::string s;
-    for (const auto &it : p) {
+    for (const auto& it : p) {
         s += seq.substr(it.start, it.length);
-        //std::cout << s << std::endl;
+        // std::cout << s << std::endl;
     }
-    //std::cout << "lengths: " << s.length() << ", " << p.length << std::endl;
-    assert(s.length() == p.length() ||
-           assert_msg("sequence length " << s.length() << " is not equal to path length " << p.length()));
+    // std::cout << "lengths: " << s.length() << ", " << p.length << std::endl;
+    assert(s.length() == p.length()
+        || assert_msg("sequence length "
+            << s.length() << " is not equal to path length " << p.length()));
     return s;
 }
 
-
-std::string LocalPRG::string_along_path(const std::vector<LocalNodePtr> &p) {
+std::string LocalPRG::string_along_path(const std::vector<LocalNodePtr>& p)
+{
     std::string s;
-    for (const auto &n: p) {
+    for (const auto& n : p) {
         s += n->seq;
     }
     return s;
 }
 
-std::vector<LocalNodePtr> LocalPRG::nodes_along_path(prg::Path &p) const {
+std::vector<LocalNodePtr> LocalPRG::nodes_along_path(prg::Path& p) const
+{
     if (do_path_memoization_in_nodes_along_path_method)
-        return p.nodes_along_path(*this); //memoized version
+        return p.nodes_along_path(*this); // memoized version
     else
-        return nodes_along_path_core(p); //non-memoized version
+        return nodes_along_path_core(p); // non-memoized version
 }
 
-
-std::vector<LocalNodePtr> LocalPRG::nodes_along_path_core(const prg::Path &p) const { //return the local nodes that contain the given kmer path
-    std::vector<LocalNodePtr> path_nodes; //the local nodes path
+std::vector<LocalNodePtr> LocalPRG::nodes_along_path_core(const prg::Path& p) const
+{ // return the local nodes that contain the given kmer path
+    std::vector<LocalNodePtr> path_nodes; // the local nodes path
     path_nodes.reserve(100);
 
     for (auto it = p.begin(); it != p.end(); ++it) {
-        const auto &interval = *it;
+        const auto& interval = *it;
         uint32_t interval_end = it->get_end();
 
         // find the appropriate node of the prg
         // 1. check for degenerate cases
-        if (interval.length == 0) { //0-length intervals
-            if (it == --(p.end())) { //if this is the last interval of the path - it can match any interval
-                auto itstartIndexOfAllIntervals = prg.startIndexOfAllIntervals.find(interval.start); //tries to find the interval in prg.startIndexOfAllIntervals
-                if (itstartIndexOfAllIntervals != prg.startIndexOfAllIntervals.end() && //if we found it and
-                    itstartIndexOfAllIntervals->second != prg.nodes.begin()->second) //the node we are trying to add is not the first node of the prg
-                    path_nodes.push_back(itstartIndexOfAllIntervals->second); //add it
+        if (interval.length == 0) { // 0-length intervals
+            if (it == --(p.end())) { // if this is the last interval of the path - it
+                                     // can match any interval
+                auto itstartIndexOfAllIntervals = prg.startIndexOfAllIntervals.find(
+                    interval.start); // tries to find the interval in
+                                     // prg.startIndexOfAllIntervals
+                if (itstartIndexOfAllIntervals != prg.startIndexOfAllIntervals.end()
+                    && // if we found it and
+                    itstartIndexOfAllIntervals->second
+                        != prg.nodes.begin()
+                               ->second) // the node we are trying to add
+                                         // is not the first node of the prg
+                    path_nodes.push_back(itstartIndexOfAllIntervals->second); // add it
+            } else {
+                // if it is not the last interval, it should match a 0-length interval
+                auto itstartIndexOfZeroLengthIntervals
+                    = prg.startIndexOfZeroLengthIntervals.find(
+                        interval.start); // tries to find the interval in
+                                         // prg.startIndexOfZeroLengthIntervals
+                if (itstartIndexOfZeroLengthIntervals
+                    != prg.startIndexOfZeroLengthIntervals.end())
+                    // found it, add!
+                    path_nodes.push_back(itstartIndexOfZeroLengthIntervals
+                                             ->second); // if it is not the last, add it
             }
-            else {
-                //if it is not the last interval, it should match a 0-length interval
-                auto itstartIndexOfZeroLengthIntervals = prg.startIndexOfZeroLengthIntervals.find(interval.start); //tries to find the interval in prg.startIndexOfZeroLengthIntervals
-                if (itstartIndexOfZeroLengthIntervals != prg.startIndexOfZeroLengthIntervals.end())
-                    //found it, add!
-                    path_nodes.push_back(itstartIndexOfZeroLengthIntervals->second); //if it is not the last, add it
-            }
-        }
-        else {
-            //2. Normal overlaps, use interval tree
+        } else {
+            // 2. Normal overlaps, use interval tree
             std::vector<size_t> overlaps;
-            prg.intervalTree.overlap(interval.start, interval_end, overlaps); // retrieve overlaps
+            prg.intervalTree.overlap(
+                interval.start, interval_end, overlaps); // retrieve overlaps
             for (size_t i = 0; i < overlaps.size(); ++i)
                 path_nodes.push_back(prg.intervalTree.data(overlaps[i]));
         }
@@ -113,24 +134,61 @@ std::vector<LocalNodePtr> LocalPRG::nodes_along_path_core(const prg::Path &p) co
     return path_nodes;
 }
 
-
-/* Split the interval first into the invariant region coming before it, all its alleles and then the rest of the PRG.
+/* Split the interval first into the invariant region coming before it, all its alleles
+ and then the rest of the PRG.
  * Example:
- ATGTCTGAG 5 GTTATT 6 ATTATC 6 GTTATC 5 AGGAACGATATCTTTCATTTT 7  9 A 10 G 10 T 9 CTTCAAAAAAGAAT 8 GCTTCTACAGAGAAC 7 GTGCCCAC 11 A 12 G 11 GGGTTCTATCGGTTATGCAAACAAAAACCA 13 A 14 G 13 TGAACCCTTTATTCTTTTT 15 A 16 G 15 CCCAATTT 17 ACTG 18 GCTG 18 GCTA 17 GTAGTTGCTGAA 19 A 20 G 19 GCAATAA 21 C 22 T 21 GATGCCATTC 23 A 24 C 24 T 23 ACCATGCTTTGATT 25 A 26 T 25 CTCTGTTATTAGCACTGAATTAT 27 A 28 T 27 TGAGTCAATTGAAGATGGAGATATTGGG 29 GTAATT 30 ATAATC 29 AACAATGGCAATATGAT 31 ACGCGTT 32 ACGCGTA 32 CCGCGTT 31 ATTCTGTC 33 CCGCAG 34 ACGCAA 33 AGCCAATCATAATACTGTCTTAGT 35 A 36 T 35 ACGGAACG 37 C 38 T 37 TGCAATAACTTGTGTCT 39 G 40 C 39 TTTTGTTCGCAGCCACC 41  43 A 44 T 43 AAGAAATC 42 AAAGAAAAT 41 AAATGATGACTGGCTACTTACCCAATCAGC 45 C 46 T 45 CTTGCTAT 47 A 48 C 47 GCTTCATTTGG 49  51 TTTAA 52 TTTGG 51 ATGGAGTT 50 GTTGAATGGAGTA 50 CTTGAACGGAGTT 49 GTTGGGGTCAGCGGTGG 53 A 54 T 53 GAACCTTTGCT 55 GTATGGAGATGATTT 57 CCTTC 58 GCTTA 57  56 ATATGGGGATGACTTCCTTC 55 ACTTCATTGATTTTATCATCGAGAATTCACCAGATACTGCTTT 59 A 60 G 59 CATGTTTTAACAAACGG 61 A 62 G 61 CGCAAATTT 63  65 G 66 T 65 CTGATATCAACTTTAC 67 ACAG 68 TCAG 67  64 GCTGATATCACCTTTACTCAG 64 GCTGATACCAACTTTACTCAT 63 GAAATGGCAAAGCGAAG 69 C 70 T 69 AAAAAGAT 71 A 72 C 71 AAAATCACCTTTGGTAT 73 A 74 C 73 CCGCTCTACTCATCAAGACCACTTGTGCATGATCAT 75 C 76 T 75 TGGTAGG 77 GAG 78 AAG 78 GAA 77 TGATGGCGCATTTAATGAAACGGTTAA 79 A 80 G 79 GGGTTAAT 81 C 82 T 81 AATGCAGG 83 AAACTCA 84 GAACTCA 84 AAACTTG 83 GGGATTAATATCGAACTTAGAGTTATTCC 85  87 G 88 T 87 ACACTGGC 86 GACATTGGT 85 TAACTATAC 89 A 90 G 90 C 89 GAATTGGATG 91  93 GCATC 94 ATATT 93 GTAGAGTTCGT 92 ATATTGTAGAATTCGC 91 TGGCCGTGT 95 G 96 T 95 TTCTCCAACATCAATCAGATTTCCCTTATGGGG 97 TTGGAAT 98 TTGGAGC 98 CTGGAAT 97 CTATCGGTTGGGC 99 GCGAAAA 100 ACGAAAG 100 ACGAAAA 99 AACTGGTC 101 AACA 102 CACC 101 ATCTTCATTGA 103  105 A 106 G 105 CACAGCAG 107 C 108 T 107  104 TCACAGTAGT 103 TATAGTGAGAAA 109 ATAATCTC 111 TGCC 112 CGCC 111  110 GTAATCTCCACC 110 ATAACCTCCGCT 109 ATAGACGCTGC 113 GC 114 AC 114 AT 113 ACAGGTCAGG 115 C 116 T 115 ATACCTCT 117 A 118 G 117 ACAATTTTTAATTATCCTTTGTGT 119 C 120 T 119 ATCTTCC 121  123 C 124 T 123 GAAAGAGC 125 TT 126 CT 125  122 TGAAAGGGCTA 121 GGGAGCTTGCTG 127 C 128 T 127 TCAGTCGATCTCTGATTGGAAAAATTACTATCC 129 A 130 T 129 AAAGAATGTGATGAATG 131 C 132 T 131 ACTCAGAAG 133 C 134 T 133 CTTCCTGT 135 ACTGGT 136 GCTGGT 136 GCTGGC 135 TATTTCAGTTC 137 CTCAACA 138 TTCAACG 138 CTCAAAA 137 GGCCGTTTTCATCAA 139 C 140 T 139 CACCGAGACCAATTTTA
- Param i will be start=0, length=2424
- Divided into (0,9) = ATGTCTGAG; (12,6) = GTTATT, (21,6) = ATTATC, (30,6) = GTTATC, (39, 2385) = the rest of the string -> AGGAACGATATCTTTC...
+ ATGTCTGAG 5 GTTATT 6 ATTATC 6 GTTATC 5 AGGAACGATATCTTTCATTTT 7  9 A 10 G 10 T 9
+ CTTCAAAAAAGAAT 8 GCTTCTACAGAGAAC 7 GTGCCCAC 11 A 12 G 11 GGGTTCTATCGGTTATGCAAACAAAAACCA
+ 13 A 14 G 13 TGAACCCTTTATTCTTTTT 15 A 16 G 15 CCCAATTT 17 ACTG 18 GCTG 18 GCTA 17
+ GTAGTTGCTGAA 19 A 20 G 19 GCAATAA 21 C 22 T 21 GATGCCATTC 23 A 24 C 24 T 23
+ ACCATGCTTTGATT 25 A 26 T 25 CTCTGTTATTAGCACTGAATTAT 27 A 28 T 27
+ TGAGTCAATTGAAGATGGAGATATTGGG 29 GTAATT 30 ATAATC 29 AACAATGGCAATATGAT 31 ACGCGTT 32
+ ACGCGTA 32 CCGCGTT 31 ATTCTGTC 33 CCGCAG 34 ACGCAA 33 AGCCAATCATAATACTGTCTTAGT 35 A 36
+ T 35 ACGGAACG 37 C 38 T 37 TGCAATAACTTGTGTCT 39 G 40 C 39 TTTTGTTCGCAGCCACC 41  43 A 44
+ T 43 AAGAAATC 42 AAAGAAAAT 41 AAATGATGACTGGCTACTTACCCAATCAGC 45 C 46 T 45 CTTGCTAT 47 A
+ 48 C 47 GCTTCATTTGG 49  51 TTTAA 52 TTTGG 51 ATGGAGTT 50 GTTGAATGGAGTA 50 CTTGAACGGAGTT
+ 49 GTTGGGGTCAGCGGTGG 53 A 54 T 53 GAACCTTTGCT 55 GTATGGAGATGATTT 57 CCTTC 58 GCTTA 57
+ 56 ATATGGGGATGACTTCCTTC 55 ACTTCATTGATTTTATCATCGAGAATTCACCAGATACTGCTTT 59 A 60 G 59
+ CATGTTTTAACAAACGG 61 A 62 G 61 CGCAAATTT 63  65 G 66 T 65 CTGATATCAACTTTAC 67 ACAG 68
+ TCAG 67  64 GCTGATATCACCTTTACTCAG 64 GCTGATACCAACTTTACTCAT 63 GAAATGGCAAAGCGAAG 69 C 70
+ T 69 AAAAAGAT 71 A 72 C 71 AAAATCACCTTTGGTAT 73 A 74 C 73
+ CCGCTCTACTCATCAAGACCACTTGTGCATGATCAT 75 C 76 T 75 TGGTAGG 77 GAG 78 AAG 78 GAA 77
+ TGATGGCGCATTTAATGAAACGGTTAA 79 A 80 G 79 GGGTTAAT 81 C 82 T 81 AATGCAGG 83 AAACTCA 84
+ GAACTCA 84 AAACTTG 83 GGGATTAATATCGAACTTAGAGTTATTCC 85  87 G 88 T 87 ACACTGGC 86
+ GACATTGGT 85 TAACTATAC 89 A 90 G 90 C 89 GAATTGGATG 91  93 GCATC 94 ATATT 93
+ GTAGAGTTCGT 92 ATATTGTAGAATTCGC 91 TGGCCGTGT 95 G 96 T 95
+ TTCTCCAACATCAATCAGATTTCCCTTATGGGG 97 TTGGAAT 98 TTGGAGC 98 CTGGAAT 97 CTATCGGTTGGGC 99
+ GCGAAAA 100 ACGAAAG 100 ACGAAAA 99 AACTGGTC 101 AACA 102 CACC 101 ATCTTCATTGA 103  105
+ A 106 G 105 CACAGCAG 107 C 108 T 107  104 TCACAGTAGT 103 TATAGTGAGAAA 109 ATAATCTC 111
+ TGCC 112 CGCC 111  110 GTAATCTCCACC 110 ATAACCTCCGCT 109 ATAGACGCTGC 113 GC 114 AC 114
+ AT 113 ACAGGTCAGG 115 C 116 T 115 ATACCTCT 117 A 118 G 117 ACAATTTTTAATTATCCTTTGTGT 119
+ C 120 T 119 ATCTTCC 121  123 C 124 T 123 GAAAGAGC 125 TT 126 CT 125  122 TGAAAGGGCTA
+ 121 GGGAGCTTGCTG 127 C 128 T 127 TCAGTCGATCTCTGATTGGAAAAATTACTATCC 129 A 130 T 129
+ AAAGAATGTGATGAATG 131 C 132 T 131 ACTCAGAAG 133 C 134 T 133 CTTCCTGT 135 ACTGGT 136
+ GCTGGT 136 GCTGGC 135 TATTTCAGTTC 137 CTCAACA 138 TTCAACG 138 CTCAAAA 137
+ GGCCGTTTTCATCAA 139 C 140 T 139 CACCGAGACCAATTTTA Param i will be start=0, length=2424
+ Divided into (0,9) = ATGTCTGAG; (12,6) = GTTATT, (21,6) = ATTATC, (30,6) = GTTATC, (39,
+ 2385) = the rest of the string -> AGGAACGATATCTTTC...
  */
-std::vector<Interval> LocalPRG::split_by_site(const Interval &i) const {
+std::vector<Interval> LocalPRG::split_by_site(const Interval& i) const
+{
     // Splits interval by next_site based on substring of seq in the interval
-    //std::cout << "splitting by site " << next_site << " in interval " << i << std::endl;
+    // std::cout << "splitting by site " << next_site << " in interval " << i <<
+    // std::endl;
 
     // Split first by var site
-    std::vector<Interval> v; //contains the intervals split by the variant site
+    std::vector<Interval> v; // contains the intervals split by the variant site
     v.reserve(4);
     std::string::size_type k = i.start;
     std::string d = buff + std::to_string(next_site) + buff;
     std::string::size_type j = seq.find(d, k);
-    while (j != std::string::npos and j + d.size() <= i.get_end()) { //splits the interval into the start of alleles and their end (e.g: " 5 <start>TGTTCCTGA 6 ... ACGTCT<end> 5 ") - intervals are (0, 0), (<start>, length) - length is such that it is the end (the interval is really inside the site)
+    while (j != std::string::npos
+        and j + d.size()
+            <= i.get_end()) { // splits the interval into the start of alleles and their
+                              // end (e.g: " 5 <start>TGTTCCTGA 6 ... ACGTCT<end> 5 ") -
+                              // intervals are (0, 0), (<start>, length) - length is
+                              // such that it is the end (the interval is really inside
+                              // the site)
         v.emplace_back(Interval(k, j));
         k = j + d.size();
         j = seq.find(d, k);
@@ -143,45 +201,55 @@ std::vector<Interval> LocalPRG::split_by_site(const Interval &i) const {
         if (seq.find(buff, j + d.size()) == j + d.size()) {
             v.emplace_back(Interval(j + d.size(), j + d.size()));
         }
-    } else { //add the last interval to v
+    } else { // add the last interval to v
         v.emplace_back(Interval(k, i.get_end()));
     }
 
     assert(v[0].start >= i.start);
     for (uint32_t l = 1; l != v.size(); ++l) {
-        assert(v[l - 1].get_end() <= v[l].start || assert_msg(
-                v[l - 1].get_end() << ">" << v[l].start << " giving overlapping intervals  " << v[l - 1] << " and "
-                                   << v[l]));
+        assert(v[l - 1].get_end() <= v[l].start
+            || assert_msg(v[l - 1].get_end()
+                << ">" << v[l].start << " giving overlapping intervals  " << v[l - 1]
+                << " and " << v[l]));
     }
     assert(v.back().get_end() <= i.get_end());
 
-    // then split by var site + 1, I.E. SPLITTING BY THE INTERVALS OF THE ALLELES - THIS IS WHAT IS RETURNED
-    std::vector<Interval> w; //will have the intervals of the alleles - such intervals are really inside the alleles, like the site intervals
+    // then split by var site + 1, I.E. SPLITTING BY THE INTERVALS OF THE ALLELES - THIS
+    // IS WHAT IS RETURNED
+    std::vector<Interval> w; // will have the intervals of the alleles - such intervals
+                             // are really inside the alleles, like the site intervals
     w.reserve(20);
     d = buff + std::to_string(next_site + 1) + buff;
     for (uint32_t l = 0; l != v.size(); ++l) {
-        k = v[l].start; //start of allele interval
-        j = seq.find(d, k); //end of allele interval
-        while (j != std::string::npos and j + d.size() <= v[l].get_end()) { //check if the allele interval [k,j) is inside the variant site interval
-            w.emplace_back(Interval(k, j)); //add the allele interval
-            k = j + d.size(); //go to the next start of allele interval
-            j = seq.find(d, k); //go to the next end of allele interval
+        k = v[l].start; // start of allele interval
+        j = seq.find(d, k); // end of allele interval
+        while (j != std::string::npos
+            and j + d.size() <= v[l].get_end()) { // check if the allele interval [k,j)
+                                                  // is inside the variant site interval
+            w.emplace_back(Interval(k, j)); // add the allele interval
+            k = j + d.size(); // go to the next start of allele interval
+            j = seq.find(d, k); // go to the next end of allele interval
         }
-        if (j != std::string::npos and j < v[l].get_end() and j + d.size() > v[l].get_end()) {
+        if (j != std::string::npos and j < v[l].get_end()
+            and j + d.size() > v[l].get_end()) {
             w.emplace_back(Interval(k, j));
         } else if (j != std::string::npos and j + d.size() == v[l].get_end()) {
             w.emplace_back(Interval(k, j));
             if (seq.find(buff, j + d.size()) == j + d.size()) {
                 v.emplace_back(Interval(j + d.size(), j + d.size()));
             }
-        } else { //add the last remaining interval
+        } else { // add the last remaining interval
             w.emplace_back(Interval(k, v[l].get_end()));
         }
     }
     if (v.size() == w.size() && v.size() == 3) {
-        BOOST_LOG_TRIVIAL(warning) << "There was something dodgy with var site " << next_site << ": found no separated "
-                                                                                                 "alternates. I'm going to assume for now that this is as a result of straggly ends of sequences "
-                                                                                                 "which don't align nicely, but you should check this. To handle, add an empty interval alternate.";
+        BOOST_LOG_TRIVIAL(warning)
+            << "There was something dodgy with var site " << next_site
+            << ": found no separated "
+               "alternates. I'm going to assume for now that this is as a result of "
+               "straggly ends of sequences "
+               "which don't align nicely, but you should check this. To handle, add an "
+               "empty interval alternate.";
         std::vector<Interval> x;
         for (uint32_t l = 0; l != w.size() - 1; ++l) {
             x.push_back(w[l]);
@@ -193,28 +261,40 @@ std::vector<Interval> LocalPRG::split_by_site(const Interval &i) const {
 
     assert(w[0].start >= i.start);
     for (uint32_t l = 1; l != w.size(); ++l) {
-        assert(w[l - 1].get_end() <= w[l].start || assert_msg(
-                w[l - 1].get_end() << ">" << w[l].start << " giving overlapping intervals  " << w[l - 1] << " and "
-                                   << w[l] << " when splitting seq :" << seq.substr(i.start, i.length)));
+        assert(w[l - 1].get_end() <= w[l].start
+            || assert_msg(w[l - 1].get_end()
+                << ">" << w[l].start << " giving overlapping intervals  " << w[l - 1]
+                << " and " << w[l]
+                << " when splitting seq :" << seq.substr(i.start, i.length)));
     }
     assert(w.back().get_end() <= i.get_end());
     return w;
 }
 
-
-std::vector<uint32_t> //builds the graph based on the given interval - RETURNS THE SINK NODE AFTER BUILDING THE GRAPH
-LocalPRG::build_graph(const Interval &i, const std::vector<uint32_t> &from_ids, uint32_t current_level) { //i: the interval from where to build the graph; from_ids: the sources from
+std::vector<uint32_t> // builds the graph based on the given interval - RETURNS THE SINK
+                      // NODE AFTER BUILDING THE GRAPH
+LocalPRG::build_graph(
+    const Interval& i, const std::vector<uint32_t>& from_ids, uint32_t current_level)
+{ // i: the interval from where to build the graph; from_ids: the sources from
     // we will return the ids on the ends of any stretches of graph added
-    std::vector<uint32_t> end_ids; //these are all the sink vertices (leaves) created by this interval, then we can join them into a single node afterwards
+    std::vector<uint32_t>
+        end_ids; // these are all the sink vertices (leaves) created by this interval,
+                 // then we can join them into a single node afterwards
     end_ids.reserve(20);
 
-    // save the start id, so can add 0, and the last id to the index at level 0 at the end
+    // save the start id, so can add 0, and the last id to the index at level 0 at the
+    // end
     uint32_t start_id = next_id;
 
     // add nodes
-    std::string s = seq.substr(i.start, i.length); //gets the whole PRG string associated with this interval
-    if (isalpha_string(s)) // should return true for empty string too - If s does not contain variation, then it wont have spaces, and this will return false. If it contains variations, then it will have space and will return true. Basically the question is: does s contains variation?
-    {   //s does not contain variations
+    std::string s = seq.substr(
+        i.start, i.length); // gets the whole PRG string associated with this interval
+    if (isalpha_string(
+            s)) // should return true for empty string too - If s does not contain
+                // variation, then it wont have spaces, and this will return false. If
+                // it contains variations, then it will have space and will return true.
+                // Basically the question is: does s contains variation?
+    { // s does not contain variations
         prg.add_node(next_id, s, i);
         // add edges from previous part of graph to start of this interval
         for (uint32_t j = 0; j != from_ids.size(); j++) {
@@ -222,43 +302,63 @@ LocalPRG::build_graph(const Interval &i, const std::vector<uint32_t> &from_ids, 
         }
         end_ids.push_back(next_id);
         next_id++;
-    } else { //s contains variation
+    } else { // s contains variation
         // split by next var site
-        std::vector<Interval> v = split_by_site(i); // should have length at least 4 //Split the interval first into the invariant region coming before it, all its alleles and then the rest of the PRG.
-        if (v.size() < (uint32_t) 4) {
-            BOOST_LOG_TRIVIAL(warning) << "In conversion from linear localPRG string to graph, splitting the string by "
-                                          "the next var site resulted in the wrong number of intervals. Please check that site numbers "
-                                          "are flanked by a space on either side. Or perhaps ordering of numbers in GFA is irregular?! "
-                                          "Size of partition based on site " << next_site << " is " << v.size()
-                                          << "\nLocalPRG name: " << name;
+        std::vector<Interval> v
+            = split_by_site(i); // should have length at least 4 //Split the interval
+                                // first into the invariant region coming before it, all
+                                // its alleles and then the rest of the PRG.
+        if (v.size() < (uint32_t)4) {
+            BOOST_LOG_TRIVIAL(warning)
+                << "In conversion from linear localPRG string to graph, splitting the "
+                   "string by "
+                   "the next var site resulted in the wrong number of intervals. "
+                   "Please check that site numbers "
+                   "are flanked by a space on either side. Or perhaps ordering of "
+                   "numbers in GFA is irregular?! "
+                   "Size of partition based on site "
+                << next_site << " is " << v.size() << "\nLocalPRG name: " << name;
             std::exit(-1);
         }
-        next_site += 2; //update next site
-        // add first interval (should be the invariable seq, and thus composed only by alpha chars)
-        s = seq.substr(v[0].start, v[0].length); //gets the sequence of the invariable part
-        if (!(isalpha_string(s))) { //verify that the invariable part is indeed invariable
-            BOOST_LOG_TRIVIAL(warning) << "In conversion from linear localPRG string to graph, splitting the string by "
-                                          "the next var site resulted in the first interval being non alphabetic. Please check that site "
-                                          "numbers are flanked by a space on either side. Or perhaps ordering of numbers in GFA is "
-                                          "irregular?! After splitting by site " << next_site
-                                       << " do not have alphabetic sequence before "
-                                          "var site: " << v[0];
+        next_site += 2; // update next site
+        // add first interval (should be the invariable seq, and thus composed only by
+        // alpha chars)
+        s = seq.substr(
+            v[0].start, v[0].length); // gets the sequence of the invariable part
+        if (!(isalpha_string(
+                s))) { // verify that the invariable part is indeed invariable
+            BOOST_LOG_TRIVIAL(warning)
+                << "In conversion from linear localPRG string to graph, splitting the "
+                   "string by "
+                   "the next var site resulted in the first interval being non "
+                   "alphabetic. Please check that site "
+                   "numbers are flanked by a space on either side. Or perhaps ordering "
+                   "of numbers in GFA is "
+                   "irregular?! After splitting by site "
+                << next_site
+                << " do not have alphabetic sequence before "
+                   "var site: "
+                << v[0];
             std::exit(-1);
         }
-        prg.add_node(next_id, s, v[0]); //adds the invariable part as a node in the graph
+        prg.add_node(
+            next_id, s, v[0]); // adds the invariable part as a node in the graph
         // add edges from previous PRG to the start of this PRG
         for (uint32_t j = 0; j != from_ids.size(); j++) {
             prg.add_edge(from_ids[j], next_id);
         }
 
-        std::vector<uint32_t> mid_ids; //will denote the id of the source node
+        std::vector<uint32_t> mid_ids; // will denote the id of the source node
         mid_ids.reserve(20);
         mid_ids.push_back(next_id);
         next_id++;
-        // add (recurring as necessary) middle intervals //RECUSIVELY BUILDS THE GRAPH FOR EACH ALLELE AND ADD THEM HERE.
+        // add (recurring as necessary) middle intervals //RECUSIVELY BUILDS THE GRAPH
+        // FOR EACH ALLELE AND ADD THEM HERE.
         for (uint32_t j = 1; j != v.size() - 1; j++) {
             std::vector<uint32_t> w = build_graph(v[j], mid_ids, current_level + 1);
-            end_ids.insert(end_ids.end(), w.begin(), w.end()); //add the leaves from this internal graph to the set of all leaves
+            end_ids.insert(
+                end_ids.end(), w.begin(), w.end()); // add the leaves from this internal
+                                                    // graph to the set of all leaves
         }
         // join all leaves into the last node of v, which will be the rest of the PRG
         end_ids = build_graph(v.back(), end_ids, current_level);
@@ -269,10 +369,13 @@ LocalPRG::build_graph(const Interval &i, const std::vector<uint32_t> &from_ids, 
     return end_ids;
 }
 
-//TODO: this finds all paths in the LocalPRG described by p shifted one node to the right
-//TODO: this is the main bottleneck and can be optimized
-std::vector<PathPtr> LocalPRG::shift(prg::Path p) const {
-    // returns all paths of the same length which have been shifted by one position along prg graph
+// TODO: this finds all paths in the LocalPRG described by p shifted one node to the
+// right
+// TODO: this is the main bottleneck and can be optimized
+std::vector<PathPtr> LocalPRG::shift(prg::Path p) const
+{
+    // returns all paths of the same length which have been shifted by one position
+    // along prg graph
     prg::Path q;
     q = p.subpath(1, p.length() - 1);
     std::vector<LocalNodePtr> n;
@@ -280,27 +383,33 @@ std::vector<PathPtr> LocalPRG::shift(prg::Path p) const {
     std::deque<PathPtr> short_paths = { std::make_shared<prg::Path>(q) };
     std::vector<PathPtr> k_paths;
     bool non_terminus;
-    //uint exp_num_return_seqs = 0;
+    // uint exp_num_return_seqs = 0;
 
     // first find extensions of the path
     while (!short_paths.empty()) {
         p = *(short_paths.front());
-        n = nodes_along_path(p); //TODO: this can be optimized by deriving the nodes_along_path from the previous path
+        n = nodes_along_path(p); // TODO: this can be optimized by deriving the
+                                 // nodes_along_path from the previous path
         short_paths.pop_front();
 
         // if we can extend within the same localnode, do
-        if (p.get_end() < n.back()->pos.get_end()) { //extend by one base in the same local node
-            //p.path.back().length += 1; //changes to the interval are done explictly now
-            Interval interval = p.getAndRemoveLastInterval(); //get the last interval and remove it
-            interval.length+=1; //modify it
-            p.push_back(interval); //add it back
+        if (p.get_end()
+            < n.back()->pos.get_end()) { // extend by one base in the same local node
+            // p.path.back().length += 1; //changes to the interval are done explictly
+            // now
+            Interval interval
+                = p.getAndRemoveLastInterval(); // get the last interval and remove it
+            interval.length += 1; // modify it
+            p.push_back(interval); // add it back
             k_paths.push_back(std::make_shared<prg::Path>(p));
         } else if (p.get_end() != (--(prg.nodes.end()))->second->pos.get_end()) {
-            for (uint32_t i = 0; i != n.back()->outNodes.size(); ++i) { //go to the out-neighbours to extend
-                //exp_num_return_seqs += 1;
+            for (uint32_t i = 0; i != n.back()->outNodes.size();
+                 ++i) { // go to the out-neighbours to extend
+                // exp_num_return_seqs += 1;
                 short_paths.push_back(std::make_shared<prg::Path>(p));
                 short_paths.back()->add_end_interval(
-                        Interval(n.back()->outNodes[i]->pos.start, n.back()->outNodes[i]->pos.start));
+                    Interval(n.back()->outNodes[i]->pos.start,
+                        n.back()->outNodes[i]->pos.start));
             }
         }
     }
@@ -308,20 +417,23 @@ std::vector<PathPtr> LocalPRG::shift(prg::Path p) const {
     // now check if by adding null nodes we reach the end of the prg
     for (uint32_t i = 0; i != k_paths.size(); ++i) {
         short_paths = { k_paths[i] };
-        non_terminus = false; // assume there all extensions are terminal i.e. reach end or prg
+        non_terminus
+            = false; // assume there all extensions are terminal i.e. reach end or prg
 
         while (!short_paths.empty()) {
             p = *(short_paths.front());
             n = nodes_along_path(p);
             short_paths.pop_front();
 
-            if (n.back()->pos.get_end() == (--(prg.nodes.end()))->second->pos.get_end()) {
+            if (n.back()->pos.get_end()
+                == (--(prg.nodes.end()))->second->pos.get_end()) {
                 return_paths.push_back(std::make_shared<prg::Path>(p));
             } else if (n.back()->pos.get_end() == p.get_end()) {
                 for (uint32_t j = 0; j != n.back()->outNodes.size(); ++j) {
                     if (n.back()->outNodes[j]->pos.length == 0) {
                         short_paths.push_back(std::make_shared<prg::Path>((p)));
-                        short_paths.back()->add_end_interval(n.back()->outNodes[j]->pos);
+                        short_paths.back()->add_end_interval(
+                            n.back()->outNodes[j]->pos);
                     } else {
                         non_terminus = true;
                     }
@@ -338,12 +450,20 @@ std::vector<PathPtr> LocalPRG::shift(prg::Path p) const {
     return return_paths;
 }
 
-void LocalPRG::minimizer_sketch(const std::shared_ptr<Index> &index, const uint32_t w, const uint32_t k, double percentageDone) {
-    if (percentageDone >= 0) BOOST_LOG_TRIVIAL(info) << "Sketch PRG " << name << " which has " << prg.nodes.size() << " nodes (" << percentageDone << "% done)";
-    else BOOST_LOG_TRIVIAL(info) << "Sketch PRG " << name << " which has " << prg.nodes.size() << " nodes";
+void LocalPRG::minimizer_sketch(const std::shared_ptr<Index>& index, const uint32_t w,
+    const uint32_t k, double percentageDone)
+{
+    if (percentageDone >= 0)
+        BOOST_LOG_TRIVIAL(info)
+            << "Sketch PRG " << name << " which has " << prg.nodes.size() << " nodes ("
+            << percentageDone << "% done)";
+    else
+        BOOST_LOG_TRIVIAL(info)
+            << "Sketch PRG " << name << " which has " << prg.nodes.size() << " nodes";
 
     // clean up after any previous runs
-    // although note we can't clear the index because it is also added to by other LocalPRGs
+    // although note we can't clear the index because it is also added to by other
+    // LocalPRGs
     kmer_prg.clear();
 
     // declare variables
@@ -357,7 +477,7 @@ void LocalPRG::minimizer_sketch(const std::shared_ptr<Index> &index, const uint3
     std::string kmer;
     uint64_t smallest;
     std::pair<uint64_t, uint64_t> kh;
-    KmerHash hash; //TODO: replace by GATB's MPHF?
+    KmerHash hash; // TODO: replace by GATB's MPHF?
     uint32_t num_kmers_added = 0;
     KmerNodePtr kn, new_kn;
     std::vector<LocalNodePtr> n;
@@ -365,7 +485,7 @@ void LocalPRG::minimizer_sketch(const std::shared_ptr<Index> &index, const uint3
 
     // create a null start node in the kmer graph
     d = { Interval(0, 0) };
-    kmer_path.initialize(d); //initializes this path with the null start
+    kmer_path.initialize(d); // initializes this path with the null start
     kmer_prg.add_node(kmer_path);
     num_kmers_added += 1;
 
@@ -375,156 +495,198 @@ void LocalPRG::minimizer_sketch(const std::shared_ptr<Index> &index, const uint3
     }
 
     // find first w,k minimizers
-    walk_paths = prg.walk(prg.nodes.begin()->second->id, 0, w + k - 1); //get all walks to be checked - all walks from prg.nodes.begin()->second->id composed of exactly w+k-1 bases - NOTE: WALKS AND PATHS HERE ARE THE SAME, SINCE THIS IS A DAG!!!
-    if (walk_paths.empty()){
+    walk_paths = prg.walk(prg.nodes.begin()->second->id, 0,
+        w + k - 1); // get all walks to be checked - all walks from
+                    // prg.nodes.begin()->second->id composed of exactly w+k-1 bases -
+                    // NOTE: WALKS AND PATHS HERE ARE THE SAME, SINCE THIS IS A DAG!!!
+    if (walk_paths.empty()) {
         return; // also trivially not true
     }
 
-    for (uint32_t i = 0; i != walk_paths.size(); ++i) { //goes through all walks
+    for (uint32_t i = 0; i != walk_paths.size(); ++i) { // goes through all walks
         // find minimizer for this walk
-        smallest = std::numeric_limits<uint64_t>::max(); //will store the minimizer
+        smallest = std::numeric_limits<uint64_t>::max(); // will store the minimizer
 
-        //TODO: this can be optimized by invoking string_along_path() for the whole walk (only once) and computing the minimizer on that string
-        //TODO: this optimization won't be huge though...
-        for (uint32_t j = 0; j != w; j++) { //goes through all kmer of this window, and find the minimizer (which will be the minimizer of this walk)
-            kmer_path = walk_paths[i]->subpath(j, k); //gets the subpath related to this k-mer //TODO: move constructor/assignment op in Path?
+        // TODO: this can be optimized by invoking string_along_path() for the whole
+        // walk (only once) and computing the minimizer on that string
+        // TODO: this optimization won't be huge though...
+        for (uint32_t j = 0; j != w;
+             j++) { // goes through all kmer of this window, and find the minimizer
+                    // (which will be the minimizer of this walk)
+            kmer_path = walk_paths[i]->subpath(
+                j, k); // gets the subpath related to this k-mer //TODO: move
+                       // constructor/assignment op in Path?
             if (!kmer_path.empty()) {
-                kmer = string_along_path(kmer_path); //get the string along the path
-                kh = hash.kmerhash(kmer, k); //TODO: replace by GATB's minimizer?
+                kmer = string_along_path(kmer_path); // get the string along the path
+                kh = hash.kmerhash(kmer, k); // TODO: replace by GATB's minimizer?
                 smallest = std::min(smallest, std::min(kh.first, kh.second));
             }
         }
-        for (uint32_t j = 0; j != w; j++) { //now re-iterates the k-mers
-            kmer_path = walk_paths[i]->subpath(j, k); //gets the subpath related to this kmer
-            auto old_kn = kmer_prg.nodes[0]; //old minimizer kmer node starts with the virtual start node
+        for (uint32_t j = 0; j != w; j++) { // now re-iterates the k-mers
+            kmer_path
+                = walk_paths[i]->subpath(j, k); // gets the subpath related to this kmer
+            auto old_kn = kmer_prg.nodes[0]; // old minimizer kmer node starts with the
+                                             // virtual start node
             if (!kmer_path.empty()) {
-                kmer = string_along_path(kmer_path); //get the kmer
-                kh = hash.kmerhash(kmer, k); //and the hashes
-                n = nodes_along_path(kmer_path); //and the nodes of the localPRG along this kmer_path
+                kmer = string_along_path(kmer_path); // get the kmer
+                kh = hash.kmerhash(kmer, k); // and the hashes
+                n = nodes_along_path(
+                    kmer_path); // and the nodes of the localPRG along this kmer_path
 
-                if (prg.walk(n.back()->id, n.back()->pos.get_end(), w + k - 1).empty()) { //if the walk from the last node and last base of the path along this kmer is empty
-                    while (kmer_path.get_end() >= n.back()->pos.get_end() and n.back()->outNodes.size() == 1 and
-                           n.back()->outNodes[0]->pos.length == 0) {
+                if (prg.walk(n.back()->id, n.back()->pos.get_end(), w + k - 1)
+                        .empty()) { // if the walk from the last node and last base of
+                                    // the path along this kmer is empty
+                    while (kmer_path.get_end() >= n.back()->pos.get_end()
+                        and n.back()->outNodes.size() == 1
+                        and n.back()->outNodes[0]->pos.length == 0) {
                         kmer_path.add_end_interval(n.back()->outNodes[0]->pos);
                         n.push_back(n.back()->outNodes[0]);
                     }
                 }
 
-                if (kh.first == smallest or kh.second == smallest) { //if this kmer is the minimizer
-                    KmerNodePtr dummyKmerHoldingKmerPath = std::make_shared<KmerNode>(KmerNode(0, kmer_path));
-                    const auto found = kmer_prg.sorted_nodes.find(dummyKmerHoldingKmerPath); //checks if the kmer path is already in this kmer graph
-                    if (found == kmer_prg.sorted_nodes.end()) { //it is not
+                if (kh.first == smallest
+                    or kh.second == smallest) { // if this kmer is the minimizer
+                    KmerNodePtr dummyKmerHoldingKmerPath
+                        = std::make_shared<KmerNode>(KmerNode(0, kmer_path));
+                    const auto found = kmer_prg.sorted_nodes.find(
+                        dummyKmerHoldingKmerPath); // checks if the kmer path is already
+                                                   // in this kmer graph
+                    if (found == kmer_prg.sorted_nodes.end()) { // it is not
                         // add to the KmerGraph (kmer_prg) first
-                        num_AT = std::count(kmer.begin(), kmer.end(), 'A') + std::count(kmer.begin(), kmer.end(), 'T');
-                        kn = kmer_prg.add_node_with_kh(kmer_path, std::min(kh.first, kh.second), num_AT);
+                        num_AT = std::count(kmer.begin(), kmer.end(), 'A')
+                            + std::count(kmer.begin(), kmer.end(), 'T');
+                        kn = kmer_prg.add_node_with_kh(
+                            kmer_path, std::min(kh.first, kh.second), num_AT);
 
-                        //TODO: name these criticals
-                        #pragma omp critical
-                        { //and now to the index
-                            index->add_record(std::min(kh.first, kh.second), id, kmer_path, kn->id,
-                                              (kh.first <= kh.second));
+// TODO: name these criticals
+#pragma omp critical
+                        { // and now to the index
+                            index->add_record(std::min(kh.first, kh.second), id,
+                                kmer_path, kn->id, (kh.first <= kh.second));
                         }
                         num_kmers_added += 1;
-                        kmer_prg.add_edge(old_kn, kn);//add an edge from the old minimizer kmer to the current
-                        old_kn = kn; //update old minimizer kmer node
-                        current_leaves.push_back(kn); //add to the leaves - it is a leaf now
+                        kmer_prg.add_edge(old_kn, kn); // add an edge from the old
+                                                       // minimizer kmer to the current
+                        old_kn = kn; // update old minimizer kmer node
+                        current_leaves.push_back(
+                            kn); // add to the leaves - it is a leaf now
                     }
                 }
             }
         }
     }
 
-    // while we have intermediate leaves of the kmergraph, for each in turn, explore the neighbourhood
-    // in the prg to find the next minikmers as you walk the prg
-    // This is what find the rest of the minimizers!!!
-    while (!current_leaves.empty()) { //current leaves should contain all minimizers from each previous walk
+    // while we have intermediate leaves of the kmergraph, for each in turn, explore the
+    // neighbourhood in the prg to find the next minikmers as you walk the prg This is
+    // what find the rest of the minimizers!!!
+    while (!current_leaves.empty()) { // current leaves should contain all minimizers
+                                      // from each previous walk
         kn = current_leaves.front();
         current_leaves.pop_front();
         assert(kn->khash < std::numeric_limits<uint64_t>::max());
 
-        // find all paths which are this kmer-minimizer shifted by one place along the graph
+        // find all paths which are this kmer-minimizer shifted by one place along the
+        // graph
         shift_paths = shift(kn->path);
         if (shift_paths.empty()) {
-            //assert(kn->path.get_start() == 0); not true for a too short test, would be true if all paths long enough to have at least 2 minikmers on...
+            // assert(kn->path.get_start() == 0); not true for a too short test, would
+            // be true if all paths long enough to have at least 2 minikmers on...
             end_leaves.push_back(kn);
         }
-        for (uint32_t i = 0; i != shift_paths.size(); ++i) { //add all shift_paths to shifts
+        for (uint32_t i = 0; i != shift_paths.size();
+             ++i) { // add all shift_paths to shifts
             v = { shift_paths[i] };
             shifts.push_back(v);
         }
         shift_paths.clear();
 
-        while (!shifts.empty()) { //goes through all shifted paths
-            v = shifts.front(); //get the first shifted path
+        while (!shifts.empty()) { // goes through all shifted paths
+            v = shifts.front(); // get the first shifted path
             shifts.pop_front();
             assert(v.back()->length() == k);
             kmer = string_along_path(*(v.back()));
             kh = hash.kmerhash(kmer, k);
             if (std::min(kh.first, kh.second) <= kn->khash) {
                 // found next minimizer
-                KmerNodePtr dummyKmerHoldingKmerPath = std::make_shared<KmerNode>(KmerNode(0, *(v.back())));
+                KmerNodePtr dummyKmerHoldingKmerPath
+                    = std::make_shared<KmerNode>(KmerNode(0, *(v.back())));
                 const auto found = kmer_prg.sorted_nodes.find(dummyKmerHoldingKmerPath);
                 if (found == kmer_prg.sorted_nodes.end()) {
-                    num_AT = std::count(kmer.begin(), kmer.end(), 'A') + std::count(kmer.begin(), kmer.end(), 'T');
-                    new_kn = kmer_prg.add_node_with_kh(*(v.back()), std::min(kh.first, kh.second), num_AT);
+                    num_AT = std::count(kmer.begin(), kmer.end(), 'A')
+                        + std::count(kmer.begin(), kmer.end(), 'T');
+                    new_kn = kmer_prg.add_node_with_kh(
+                        *(v.back()), std::min(kh.first, kh.second), num_AT);
 
-                    //TODO: name these criticals
-                    #pragma omp critical
+// TODO: name these criticals
+#pragma omp critical
                     {
-                        index->add_record(std::min(kh.first, kh.second), id, *(v.back()), new_kn->id,
-                                          (kh.first <= kh.second));
+                        index->add_record(std::min(kh.first, kh.second), id,
+                            *(v.back()), new_kn->id, (kh.first <= kh.second));
                     }
                     kmer_prg.add_edge(kn, new_kn);
-                    if (v.back()->get_end() == (--(prg.nodes.end()))->second->pos.get_end()) {
+                    if (v.back()->get_end()
+                        == (--(prg.nodes.end()))->second->pos.get_end()) {
                         end_leaves.push_back(new_kn);
-                    } else if (find(current_leaves.begin(), current_leaves.end(), new_kn) == current_leaves.end()) {
+                    } else if (find(
+                                   current_leaves.begin(), current_leaves.end(), new_kn)
+                        == current_leaves.end()) {
                         current_leaves.push_back(new_kn);
                     }
                     num_kmers_added += 1;
                 } else {
                     kmer_prg.add_edge(kn, *found);
-                    if (v.back()->get_end() == (--(prg.nodes.end()))->second->pos.get_end()) {
+                    if (v.back()->get_end()
+                        == (--(prg.nodes.end()))->second->pos.get_end()) {
                         end_leaves.push_back(*found);
-                    } else if (find(current_leaves.begin(), current_leaves.end(), *found) == current_leaves.end()) {
+                    } else if (find(
+                                   current_leaves.begin(), current_leaves.end(), *found)
+                        == current_leaves.end()) {
                         current_leaves.push_back(*found);
                     }
                 }
             } else if (v.size() == w) {
-                // the old minimizer has dropped out the window, minimizer the w new kmers
+                // the old minimizer has dropped out the window, minimizer the w new
+                // kmers
                 smallest = std::numeric_limits<uint64_t>::max();
                 auto old_kn = kn;
                 for (uint32_t j = 0; j != w; j++) {
                     kmer = string_along_path(*(v[j]));
                     kh = hash.kmerhash(kmer, k);
                     smallest = std::min(smallest, std::min(kh.first, kh.second));
-                    //std::cout << min(kh.first, kh.second) << " ";
+                    // std::cout << min(kh.first, kh.second) << " ";
                 }
                 for (uint32_t j = 0; j != w; j++) {
                     kmer = string_along_path(*(v[j]));
                     kh = hash.kmerhash(kmer, k);
                     if (kh.first == smallest or kh.second == smallest) {
-                        KmerNodePtr dummyKmerHoldingKmerPath = std::make_shared<KmerNode>(KmerNode(0, *(v[j])));
-                        const auto found = kmer_prg.sorted_nodes.find(dummyKmerHoldingKmerPath);
+                        KmerNodePtr dummyKmerHoldingKmerPath
+                            = std::make_shared<KmerNode>(KmerNode(0, *(v[j])));
+                        const auto found
+                            = kmer_prg.sorted_nodes.find(dummyKmerHoldingKmerPath);
                         if (found == kmer_prg.sorted_nodes.end()) {
-                            num_AT = std::count(kmer.begin(), kmer.end(), 'A') +
-                                     std::count(kmer.begin(), kmer.end(), 'T');
-                            new_kn = kmer_prg.add_node_with_kh(*(v[j]), std::min(kh.first, kh.second), num_AT);
+                            num_AT = std::count(kmer.begin(), kmer.end(), 'A')
+                                + std::count(kmer.begin(), kmer.end(), 'T');
+                            new_kn = kmer_prg.add_node_with_kh(
+                                *(v[j]), std::min(kh.first, kh.second), num_AT);
 
-                            //TODO: name these criticals
-                            #pragma omp critical
+// TODO: name these criticals
+#pragma omp critical
                             {
-                                index->add_record(std::min(kh.first, kh.second), id, *(v[j]), new_kn->id,
-                                                  (kh.first <= kh.second));
+                                index->add_record(std::min(kh.first, kh.second), id,
+                                    *(v[j]), new_kn->id, (kh.first <= kh.second));
                             }
 
-                            // if there is more than one mini in the window, edge should go to the first, and from the first to the second
+                            // if there is more than one mini in the window, edge should
+                            // go to the first, and from the first to the second
                             kmer_prg.add_edge(old_kn, new_kn);
                             old_kn = new_kn;
 
-                            if (v.back()->get_end() == (--(prg.nodes.end()))->second->pos.get_end()) {
+                            if (v.back()->get_end()
+                                == (--(prg.nodes.end()))->second->pos.get_end()) {
                                 end_leaves.push_back(new_kn);
-                            } else if (find(current_leaves.begin(), current_leaves.end(), new_kn) ==
-                                       current_leaves.end()) {
+                            } else if (find(current_leaves.begin(),
+                                           current_leaves.end(), new_kn)
+                                == current_leaves.end()) {
                                 current_leaves.push_back(new_kn);
                             }
                             num_kmers_added += 1;
@@ -532,20 +694,27 @@ void LocalPRG::minimizer_sketch(const std::shared_ptr<Index> &index, const uint3
                             kmer_prg.add_edge(old_kn, *found);
                             old_kn = *found;
 
-                            if (v.back()->get_end() == (--(prg.nodes.end()))->second->pos.get_end()) {
+                            if (v.back()->get_end()
+                                == (--(prg.nodes.end()))->second->pos.get_end()) {
                                 end_leaves.push_back(*found);
-                            } else if (find(current_leaves.begin(), current_leaves.end(), *found) ==
-                                       current_leaves.end()) {
+                            } else if (find(current_leaves.begin(),
+                                           current_leaves.end(), *found)
+                                == current_leaves.end()) {
                                 current_leaves.push_back(*found);
                             }
                         }
                     }
                 }
-            } else if (v.back()->get_end() == (--(prg.nodes.end()))->second->pos.get_end()) { //marginal case - we are in the end of the PRG -> current minimizer is a leaf
+            } else if (v.back()->get_end()
+                == (--(prg.nodes.end()))
+                       ->second->pos
+                       .get_end()) { // marginal case - we are in the end of the PRG ->
+                                     // current minimizer is a leaf
                 end_leaves.push_back(kn);
             } else {
-                shift_paths = shift(*(v.back())); //shift this path
-                for (uint32_t i = 0; i != shift_paths.size(); ++i) { //add it to the shifts
+                shift_paths = shift(*(v.back())); // shift this path
+                for (uint32_t i = 0; i != shift_paths.size();
+                     ++i) { // add it to the shifts
                     shifts.push_back(v);
                     shifts.back().push_back(shift_paths[i]);
                 }
@@ -556,7 +725,8 @@ void LocalPRG::minimizer_sketch(const std::shared_ptr<Index> &index, const uint3
 
     // create a null end node, and for each end leaf add an edge to this terminus
     assert(!end_leaves.empty());
-    d = { Interval((--(prg.nodes.end()))->second->pos.get_end(), (--(prg.nodes.end()))->second->pos.get_end()) };
+    d = { Interval((--(prg.nodes.end()))->second->pos.get_end(),
+        (--(prg.nodes.end()))->second->pos.get_end()) };
     kmer_path.initialize(d);
     kn = kmer_prg.add_node(kmer_path);
     num_kmers_added += 1;
@@ -565,44 +735,47 @@ void LocalPRG::minimizer_sketch(const std::shared_ptr<Index> &index, const uint3
     }
 
     // print, check and return
-    assert(num_kmers_added == 0 or kmer_prg.nodes.size() == num_kmers_added ||
-           assert_msg("nodes.size(): " << kmer_prg.nodes.size() << " and num minikmers: " << num_kmers_added));
+    assert(num_kmers_added == 0 or kmer_prg.nodes.size() == num_kmers_added
+        || assert_msg("nodes.size(): " << kmer_prg.nodes.size()
+                                       << " and num minikmers: " << num_kmers_added));
     kmer_prg.remove_shortcut_edges();
     kmer_prg.check();
 }
 
-
-bool intervals_overlap(const Interval &first, const Interval &second) {
-    return ((first == second) or
-            (second.length == 0 and (first.start == second.start or first.get_end() == second.get_end())) or
-            (first.start < second.get_end() and first.get_end() > second.start));
+bool intervals_overlap(const Interval& first, const Interval& second)
+{
+    return ((first == second)
+        or (second.length == 0
+            and (first.start == second.start or first.get_end() == second.get_end()))
+        or (first.start < second.get_end() and first.get_end() > second.start));
 }
 
-
-std::vector<KmerNodePtr>
-LocalPRG::kmernode_path_from_localnode_path(const std::vector<LocalNodePtr> &localnode_path) const {
+std::vector<KmerNodePtr> LocalPRG::kmernode_path_from_localnode_path(
+    const std::vector<LocalNodePtr>& localnode_path) const
+{
     std::vector<KmerNodePtr> kmernode_path;
 
     if (localnode_path.empty())
         return kmernode_path;
 
     std::deque<Interval> d;
-    for (const auto &n: localnode_path) {
+    for (const auto& n : localnode_path) {
         d.push_back(n->pos);
     }
 
     prg::Path local_path;
     local_path.initialize(d);
 
-    for (const auto &n: kmer_prg.sorted_nodes) {
-        for (const auto &interval : local_path) {
+    for (const auto& n : kmer_prg.sorted_nodes) {
+        for (const auto& interval : local_path) {
             if (interval.start > n->path.get_end())
                 break;
             else if (interval.get_end() < n->path.get_start())
                 continue;
-            else if ((intervals_overlap(interval, n->path[0]) or
-                      intervals_overlap(interval, n->path.back())) and not local_path.is_branching(n->path)) {
-                //and not n.second->path.is_branching(local_path))
+            else if ((intervals_overlap(interval, n->path[0])
+                         or intervals_overlap(interval, n->path.back()))
+                and not local_path.is_branching(n->path)) {
+                // and not n.second->path.is_branching(local_path))
                 kmernode_path.push_back(n);
                 break;
             }
@@ -613,28 +786,32 @@ LocalPRG::kmernode_path_from_localnode_path(const std::vector<LocalNodePtr> &loc
     return kmernode_path;
 }
 
-
-std::vector<LocalNodePtr>
-LocalPRG::localnode_path_from_kmernode_path(const std::vector<KmerNodePtr> &kmernode_path, const uint32_t w) const {
+std::vector<LocalNodePtr> LocalPRG::localnode_path_from_kmernode_path(
+    const std::vector<KmerNodePtr>& kmernode_path, const uint32_t w) const
+{
     BOOST_LOG_TRIVIAL(debug) << "Convert kmernode path to localnode path";
     std::vector<LocalNodePtr> localnode_path, kmernode, walk_path;
     if (kmernode_path.empty())
         return localnode_path;
     std::vector<PathPtr> walk_paths;
     for (uint32_t i = 0; i != kmernode_path.size(); ++i) {
-        if (i != 0 and kmernode_path[i]->path.length() == 0) // only have null paths at beginning and end
+        if (i != 0
+            and kmernode_path[i]->path.length()
+                == 0) // only have null paths at beginning and end
         {
             break;
         }
         kmernode = nodes_along_path(kmernode_path[i]->path);
 
-        // if the start of the new localnode path is after the end of the previous, join up WLOG with top path
-        while (!localnode_path.empty() and !localnode_path.back()->outNodes.empty() and
-               kmernode[0]->id > localnode_path.back()->outNodes[0]->id) {
+        // if the start of the new localnode path is after the end of the previous, join
+        // up WLOG with top path
+        while (!localnode_path.empty() and !localnode_path.back()->outNodes.empty()
+            and kmernode[0]->id > localnode_path.back()->outNodes[0]->id) {
             localnode_path.push_back(localnode_path.back()->outNodes[0]);
         }
         // if new the localnodes in kmernode overlap old ones, truncate localnode_path
-        while (!localnode_path.empty() and kmernode[0]->id <= localnode_path.back()->id) {
+        while (
+            !localnode_path.empty() and kmernode[0]->id <= localnode_path.back()->id) {
             localnode_path.pop_back();
         }
         localnode_path.insert(localnode_path.end(), kmernode.begin(), kmernode.end());
@@ -666,22 +843,24 @@ LocalPRG::localnode_path_from_kmernode_path(const std::vector<KmerNodePtr> &kmer
                 }
             }
             if (overlap) {
-                localnode_path.insert(localnode_path.begin(), walk_path.begin(), walk_path.begin() + m);
+                localnode_path.insert(
+                    localnode_path.begin(), walk_path.begin(), walk_path.begin() + m);
                 break;
             }
         }
         if (localnode_path[0]->id != 0) {
-            //std::cout << "localnode path still does not start with 0" << std::endl;
+            // std::cout << "localnode path still does not start with 0" << std::endl;
             // add the first path to start
             LocalNodePtr next = nullptr;
             while (localnode_path[0]->id != 0 and next != localnode_path[0]) {
-                //std::cout << "look for a previous node to " << *localnode_path[0] << std::endl;
+                // std::cout << "look for a previous node to " << *localnode_path[0] <<
+                // std::endl;
                 next = prg.get_previous_node(localnode_path[0]);
                 if (next != nullptr) {
-                    //std::cout << "add " << *next << std::endl;
+                    // std::cout << "add " << *next << std::endl;
                     localnode_path.insert(localnode_path.begin(), next);
                 }
-                //std::cout << "new start node is " << *localnode_path[0] << std::endl;
+                // std::cout << "new start node is " << *localnode_path[0] << std::endl;
             }
         }
     }
@@ -713,88 +892,100 @@ LocalPRG::localnode_path_from_kmernode_path(const std::vector<KmerNodePtr> &kmer
                 }
             }
             if (overlap) {
-                localnode_path.insert(localnode_path.end(), walk_path.begin() + m, walk_path.end());
+                localnode_path.insert(
+                    localnode_path.end(), walk_path.begin() + m, walk_path.end());
                 break;
             }
         }
         if (localnode_path.back()->id != prg.nodes.size() - 1) {
-            //std::cout << "localnode path still does not end with " << prg.nodes.size()-1 << std::endl;
+            // std::cout << "localnode path still does not end with " <<
+            // prg.nodes.size()-1 << std::endl;
             // add the first path to end
-            while (localnode_path.back()->id != prg.nodes.size() - 1 and !localnode_path.back()->outNodes.empty()) {
-                //std::cout << "extend " << *localnode_path.back();
+            while (localnode_path.back()->id != prg.nodes.size() - 1
+                and !localnode_path.back()->outNodes.empty()) {
+                // std::cout << "extend " << *localnode_path.back();
                 localnode_path.push_back(localnode_path.back()->outNodes[0]);
-                //std::cout << " with " << *localnode_path.back() << std::endl;
+                // std::cout << " with " << *localnode_path.back() << std::endl;
             }
         }
     }
     return localnode_path;
 }
 
-
-std::vector<uint32_t>
-get_covgs_along_localnode_path(const PanNodePtr pan_node, const std::vector<LocalNodePtr> &localnode_path,
-                               const std::vector<KmerNodePtr> &kmernode_path, const uint32_t &sample_id) {
-    // defines estimated per base coverage for the bases of localnode_path based on the coverages from the
-    // kmernode_path kmers
-    // NB the kmernode_path may be a vector of pointers to nodes in the localPRG copy of the kmergraph,
-    // and it is the copy of the kmergraph in the pangraph pan_node which stores coverages, which is why we
+std::vector<uint32_t> get_covgs_along_localnode_path(const PanNodePtr pan_node,
+    const std::vector<LocalNodePtr>& localnode_path,
+    const std::vector<KmerNodePtr>& kmernode_path, const uint32_t& sample_id)
+{
+    // defines estimated per base coverage for the bases of localnode_path based on the
+    // coverages from the kmernode_path kmers NB the kmernode_path may be a vector of
+    // pointers to nodes in the localPRG copy of the kmergraph, and it is the copy of
+    // the kmergraph in the pangraph pan_node which stores coverages, which is why we
     // need both
 
-    //define 0 coverage for each base in localnode path
+    // define 0 coverage for each base in localnode path
     std::vector<std::vector<uint32_t>> coverages_for_each_base_in_localnode_path;
 
-    for (const auto &node: localnode_path) {
+    for (const auto& node : localnode_path) {
         std::vector<uint32_t> zero_covg_on_all_node_bases(node->pos.length, 0);
-        coverages_for_each_base_in_localnode_path.push_back(zero_covg_on_all_node_bases);
+        coverages_for_each_base_in_localnode_path.push_back(
+            zero_covg_on_all_node_bases);
     }
 
     // collect covgs
     uint32_t j = 0, k = 0, start = 0, end = 0;
-    for (const auto &kmernode_ptr: kmernode_path) {
+    for (const auto& kmernode_ptr : kmernode_path) {
         if (kmernode_ptr->path.length() == 0)
             continue;
 
-        while (j < localnode_path.size() and localnode_path[j]->pos.get_end() < kmernode_ptr->path.get_start()) {
+        while (j < localnode_path.size()
+            and localnode_path[j]->pos.get_end() < kmernode_ptr->path.get_start()) {
             j++;
         }
 
         k = j;
-        for (const auto &interval : kmernode_ptr->path) {
-                assert(localnode_path[k]->pos.start <= interval.start and
-                   localnode_path[k]->pos.get_end() >= interval.get_end());
+        for (const auto& interval : kmernode_ptr->path) {
+            assert(localnode_path[k]->pos.start <= interval.start
+                and localnode_path[k]->pos.get_end() >= interval.get_end());
 
             start = interval.start - localnode_path[k]->pos.start;
             end = std::min(start + interval.length, localnode_path[k]->pos.get_end());
 
             for (uint32_t l = start; l < end; ++l) {
-                assert(kmernode_ptr->id < pan_node->kmer_prg_with_coverage.kmer_prg->nodes.size() and
-                       pan_node->kmer_prg_with_coverage.kmer_prg->nodes[kmernode_ptr->id] != nullptr);
+                assert(kmernode_ptr->id
+                        < pan_node->kmer_prg_with_coverage.kmer_prg->nodes.size()
+                    and pan_node->kmer_prg_with_coverage.kmer_prg
+                            ->nodes[kmernode_ptr->id]
+                        != nullptr);
 
-                coverages_for_each_base_in_localnode_path[k][l] = std::max(
-                        coverages_for_each_base_in_localnode_path[k][l],
-                        pan_node->kmer_prg_with_coverage.get_covg(kmernode_ptr->id, 0, sample_id) +
-                        pan_node->kmer_prg_with_coverage.get_covg(kmernode_ptr->id, 1, sample_id));
+                coverages_for_each_base_in_localnode_path[k][l]
+                    = std::max(coverages_for_each_base_in_localnode_path[k][l],
+                        pan_node->kmer_prg_with_coverage.get_covg(
+                            kmernode_ptr->id, 0, sample_id)
+                            + pan_node->kmer_prg_with_coverage.get_covg(
+                                kmernode_ptr->id, 1, sample_id));
             }
             k++;
         }
     }
 
     std::vector<uint32_t> flattened_coverages_vector;
-    for (const auto &v : coverages_for_each_base_in_localnode_path) {
-        flattened_coverages_vector.insert(flattened_coverages_vector.end(), v.begin(), v.end());
+    for (const auto& v : coverages_for_each_base_in_localnode_path) {
+        flattened_coverages_vector.insert(
+            flattened_coverages_vector.end(), v.begin(), v.end());
     }
 
     return flattened_coverages_vector;
 }
 
-
-void LocalPRG::write_covgs_to_file(const boost::filesystem::path &filepath, const std::vector<uint32_t> &covgs) const {
+void LocalPRG::write_covgs_to_file(
+    const boost::filesystem::path& filepath, const std::vector<uint32_t>& covgs) const
+{
     std::ofstream handle;
     handle.open(filepath.string());
-    assert (!handle.fail() or assert_msg("Could not open file " << filepath.string()));
+    assert(!handle.fail() or assert_msg("Could not open file " << filepath.string()));
 
     handle << ">" << name << std::endl;
-    for (const auto &i : covgs) {
+    for (const auto& i : covgs) {
         handle << i << " ";
     }
     handle << std::endl;
@@ -802,12 +993,12 @@ void LocalPRG::write_covgs_to_file(const boost::filesystem::path &filepath, cons
     handle.close();
 }
 
-
-void LocalPRG::write_path_to_fasta(const boost::filesystem::path &filepath, const std::vector<LocalNodePtr> &lmp,
-                                   const float &ppath) const {
+void LocalPRG::write_path_to_fasta(const boost::filesystem::path& filepath,
+    const std::vector<LocalNodePtr>& lmp, const float& ppath) const
+{
     std::ofstream handle;
     handle.open(filepath.string());
-    assert (!handle.fail() or assert_msg("Could not open file " << filepath.string()));
+    assert(!handle.fail() or assert_msg("Could not open file " << filepath.string()));
 
     handle << ">" << name << "\tlog P(data|sequence)=" << ppath << std::endl;
     for (uint32_t j = 0; j != lmp.size(); ++j) {
@@ -818,12 +1009,12 @@ void LocalPRG::write_path_to_fasta(const boost::filesystem::path &filepath, cons
     handle.close();
 }
 
-
-void LocalPRG::append_path_to_fasta(const boost::filesystem::path &filepath, const std::vector<LocalNodePtr> &lmp,
-                                    const float &ppath) const {
+void LocalPRG::append_path_to_fasta(const boost::filesystem::path& filepath,
+    const std::vector<LocalNodePtr>& lmp, const float& ppath) const
+{
     std::ofstream handle;
     handle.open(filepath.string(), std::ios::app);
-    assert (!handle.fail() or assert_msg("Could not open file " << filepath.string()));
+    assert(!handle.fail() or assert_msg("Could not open file " << filepath.string()));
 
     handle << ">" << name << "\tlog P(data|sequence)=" << ppath << std::endl;
     for (uint32_t j = 0; j != lmp.size(); ++j) {
@@ -834,18 +1025,17 @@ void LocalPRG::append_path_to_fasta(const boost::filesystem::path &filepath, con
     handle.close();
 }
 
-
-void
-LocalPRG::write_aligned_path_to_fasta(const boost::filesystem::path &filepath, const std::vector<LocalNodePtr> &lmp,
-                                      const float &ppath) const {
+void LocalPRG::write_aligned_path_to_fasta(const boost::filesystem::path& filepath,
+    const std::vector<LocalNodePtr>& lmp, const float& ppath) const
+{
     std::ofstream handle;
     handle.open(filepath.string());
-    assert (!handle.fail() or assert_msg("Could not open file " << filepath.string()));
+    assert(!handle.fail() or assert_msg("Could not open file " << filepath.string()));
 
     handle << ">" << name << "\tlog P(data|sequence)=" << ppath << std::endl;
 
     uint32_t i = 0;
-    for (const auto &c : prg.nodes) {
+    for (const auto& c : prg.nodes) {
         if (c.second == lmp[i]) {
             handle << lmp[i]->seq;
             i++;
@@ -859,10 +1049,10 @@ LocalPRG::write_aligned_path_to_fasta(const boost::filesystem::path &filepath, c
     handle.close();
 }
 
-
-void LocalPRG::build_vcf(VCF &vcf, const std::vector<LocalNodePtr> &ref) const {
+void LocalPRG::build_vcf(VCF& vcf, const std::vector<LocalNodePtr>& ref) const
+{
     BOOST_LOG_TRIVIAL(debug) << "Build VCF for prg " << name;
-    assert(!prg.nodes.empty()); //otherwise empty nodes -> segfault
+    assert(!prg.nodes.empty()); // otherwise empty nodes -> segfault
 
     std::vector<LocalNodePtr> varpath;
     varpath.reserve(100);
@@ -916,7 +1106,8 @@ void LocalPRG::build_vcf(VCF &vcf, const std::vector<LocalNodePtr> &ref) const {
 
             // initialise alt paths
             for (uint32_t n = 0; n < ref[level_start.back()]->outNodes.size(); ++n) {
-                if (ref[level_start.back()]->outNodes[n] != ref[level_start.back() + 1]) {
+                if (ref[level_start.back()]->outNodes[n]
+                    != ref[level_start.back() + 1]) {
                     varpath = { ref[level_start.back()]->outNodes[n] };
                     paths.push_back(varpath);
                 }
@@ -940,16 +1131,18 @@ void LocalPRG::build_vcf(VCF &vcf, const std::vector<LocalNodePtr> &ref) const {
                     paths.clear();
                     alts.clear();
                     bottompath.push_back(ref[level_start.back()]->outNodes.back());
-                    while (!bottompath.back()->outNodes.empty() and
-                           bottompath.back()->outNodes[0]->id != ref[ref_i]->outNodes[0]->id) {
+                    while (!bottompath.back()->outNodes.empty()
+                        and bottompath.back()->outNodes[0]->id
+                            != ref[ref_i]->outNodes[0]->id) {
                         bottompath.push_back(bottompath.back()->outNodes.back());
                     }
                     alts.push_back(bottompath);
 
                     bottompath.clear();
                     bottompath.push_back(ref[level_start.back()]->outNodes[0]);
-                    while (!bottompath.back()->outNodes.empty() and
-                           bottompath.back()->outNodes[0]->id != ref[ref_i]->outNodes[0]->id) {
+                    while (!bottompath.back()->outNodes.empty()
+                        and bottompath.back()->outNodes[0]->id
+                            != ref[ref_i]->outNodes[0]->id) {
                         bottompath.push_back(bottompath.back()->outNodes[0]);
                     }
                     alts.push_back(bottompath);
@@ -962,8 +1155,8 @@ void LocalPRG::build_vcf(VCF &vcf, const std::vector<LocalNodePtr> &ref) const {
 
             // add sites to vcf
             assert(pos + ref_seq.length() <= ref_length);
-            for (auto &alt : alts) {
-                for (auto &j : alt) {
+            for (auto& alt : alts) {
+                for (auto& j : alt) {
                     alt_seq += j->seq;
                 }
                 if (ref_seq != alt_seq) {
@@ -983,14 +1176,13 @@ void LocalPRG::build_vcf(VCF &vcf, const std::vector<LocalNodePtr> &ref) const {
     }
 }
 
-
-void LocalPRG::add_sample_gt_to_vcf(VCF &vcf, const std::vector<LocalNodePtr> &rpath,
-                                    const std::vector<LocalNodePtr> &sample_path,
-                                    const std::string &sample_name) const {
+void LocalPRG::add_sample_gt_to_vcf(VCF& vcf, const std::vector<LocalNodePtr>& rpath,
+    const std::vector<LocalNodePtr>& sample_path, const std::string& sample_name) const
+{
     BOOST_LOG_TRIVIAL(debug) << "Update VCF with sample path";
     /*for (uint i=0; i!=sample_path.size(); ++i)
     {
-	std::cout << *sample_path[i] << " ";
+        std::cout << *sample_path[i] << " ";
     }
     std::cout << std::endl;
     std::cout << now() << "Using ref path" << std::endl;
@@ -999,7 +1191,7 @@ void LocalPRG::add_sample_gt_to_vcf(VCF &vcf, const std::vector<LocalNodePtr> &r
         std::cout << *rpath[i] << " ";
     }
     std::cout << std::endl;*/
-    assert(!prg.nodes.empty()); //otherwise empty nodes -> segfault
+    assert(!prg.nodes.empty()); // otherwise empty nodes -> segfault
 
     // if prg has only one node, simple case
     if (prg.nodes.size() == 1) {
@@ -1033,23 +1225,24 @@ void LocalPRG::add_sample_gt_to_vcf(VCF &vcf, const std::vector<LocalNodePtr> &r
         } else if (found_new_site) {
             // refpath back == samplepath back
             // add ref allele from previous site to this one
-            //std::cout << "update with ref alleles from " << pos << " to " << pos_to << std::endl;
+            // std::cout << "update with ref alleles from " << pos << " to " << pos_to
+            // << std::endl;
             vcf.add_sample_ref_alleles(sample_name, name, pos, pos_to);
             pos = pos_to;
 
             // add new site to vcf
-            //std::cout << "find ref seq" << std::endl;
+            // std::cout << "find ref seq" << std::endl;
             for (uint32_t j = 1; j < refpath.size() - 1; ++j) {
                 ref += refpath[j]->seq;
-                //std::cout << ref << std::endl;
+                // std::cout << ref << std::endl;
             }
-            //std::cout << "find alt seq" << std::endl;
+            // std::cout << "find alt seq" << std::endl;
             for (uint32_t j = 1; j < samplepath.size() - 1; ++j) {
                 alt += samplepath[j]->seq;
-                //std::cout << alt << std::endl;
+                // std::cout << alt << std::endl;
             }
 
-            //std::cout << "add sample gt" << std::endl;
+            // std::cout << "add sample gt" << std::endl;
             vcf.add_sample_gt(sample_name, name, pos, ref, alt);
             found_new_site = false;
 
@@ -1073,7 +1266,7 @@ void LocalPRG::add_sample_gt_to_vcf(VCF &vcf, const std::vector<LocalNodePtr> &r
             }
             pos_to = pos;
         } else {
-            //std::cout << pos_to << std::endl;
+            // std::cout << pos_to << std::endl;
             refpath.erase(refpath.begin(), refpath.end() - 1);
             if (refpath.back()->id != prg.nodes.size() - 1) {
                 ref = "";
@@ -1090,17 +1283,19 @@ void LocalPRG::add_sample_gt_to_vcf(VCF &vcf, const std::vector<LocalNodePtr> &r
             }
         }
     }
-    //std::cout << "add last ref alleles" << std::endl;
+    // std::cout << "add last ref alleles" << std::endl;
     vcf.add_sample_ref_alleles(sample_name, name, pos, pos_to);
-    //std::cout << "done" << std::endl;
+    // std::cout << "done" << std::endl;
 }
 
-
-// Find the path through the PRG which deviates at pos from the ref path with alt sequence
-std::vector<LocalNodePtr>
-LocalPRG::find_alt_path(const std::vector<LocalNodePtr> &ref_path, const uint32_t pos, const std::string &ref,
-                        const std::string &alt) const {
-    //std::cout << now() << "Find alt path for PRG " << name << " variant " << pos << " " << ref << " " << alt << std::endl;
+// Find the path through the PRG which deviates at pos from the ref path with alt
+// sequence
+std::vector<LocalNodePtr> LocalPRG::find_alt_path(
+    const std::vector<LocalNodePtr>& ref_path, const uint32_t pos,
+    const std::string& ref, const std::string& alt) const
+{
+    // std::cout << now() << "Find alt path for PRG " << name << " variant " << pos << "
+    // " << ref << " " << alt << std::endl;
     std::vector<LocalNodePtr> alt_path, considered_path;
     std::deque<std::vector<LocalNodePtr>> paths_in_progress;
     uint32_t ref_added = 0, pos_along_ref_path = 0;
@@ -1112,7 +1307,7 @@ LocalPRG::find_alt_path(const std::vector<LocalNodePtr> &ref_path, const uint32_
     if (ref == ".")
         working_ref = "";
 
-    for (const auto &n: ref_path) {
+    for (const auto& n : ref_path) {
         if (ref_added < pos) {
             ref_added += n->pos.length;
             alt_path.push_back(n);
@@ -1121,23 +1316,25 @@ LocalPRG::find_alt_path(const std::vector<LocalNodePtr> &ref_path, const uint32_
             break;
         }
     }
-    //std::cout << "pos " << pos << " pos_along_ref_path " << pos_along_ref_path << " ref_path.size() " << ref_path.size() << std::endl;
+    // std::cout << "pos " << pos << " pos_along_ref_path " << pos_along_ref_path << "
+    // ref_path.size() " << ref_path.size() << std::endl;
 
     // find the localnodeptr we want to make our way back to
-    while (pos_along_ref_path < ref_path.size() - 1 and
-           (ref_added < pos + working_ref.length() or ref_path[pos_along_ref_path]->pos.length == 0)) {
+    while (pos_along_ref_path < ref_path.size() - 1
+        and (ref_added < pos + working_ref.length()
+            or ref_path[pos_along_ref_path]->pos.length == 0)) {
         ref_added += ref_path[pos_along_ref_path]->pos.length;
         pos_along_ref_path++;
     }
     assert(pos_along_ref_path < ref_path.size());
     auto ref_node_to_find = ref_path[pos_along_ref_path];
-    //std::cout << "trying to find " << *ref_node_to_find;
+    // std::cout << "trying to find " << *ref_node_to_find;
 
     // find an alt path with the required sequence
     if (alt_path.empty() and not ref_path.empty() and ref_path[0]->pos.length == 0)
         alt_path.push_back(ref_path[0]);
     assert(!alt_path.empty());
-    for (const auto &m: alt_path.back()->outNodes) {
+    for (const auto& m : alt_path.back()->outNodes) {
         paths_in_progress.push_back({ m });
     }
 
@@ -1152,14 +1349,17 @@ LocalPRG::find_alt_path(const std::vector<LocalNodePtr> &ref_path, const uint32_
         std::cout << std::endl;*/
 
         auto considered_seq = string_along_path(considered_path);
-        //std::cout << "considered_seq " << considered_seq << std::endl;
+        // std::cout << "considered_seq " << considered_seq << std::endl;
 
         if (considered_seq == working_alt) {
             // check if merge with ref path
-            if (find(considered_path.back()->outNodes.begin(), considered_path.back()->outNodes.end(),
-                     ref_node_to_find) != considered_path.back()->outNodes.end()) {
-                alt_path.insert(alt_path.end(), considered_path.begin(), considered_path.end());
-                alt_path.insert(alt_path.end(), ref_path.begin() + pos_along_ref_path, ref_path.end());
+            if (find(considered_path.back()->outNodes.begin(),
+                    considered_path.back()->outNodes.end(), ref_node_to_find)
+                != considered_path.back()->outNodes.end()) {
+                alt_path.insert(
+                    alt_path.end(), considered_path.begin(), considered_path.end());
+                alt_path.insert(alt_path.end(), ref_path.begin() + pos_along_ref_path,
+                    ref_path.end());
                 /*std::cout << "found alt path ";
                 for (const auto &t : considered_path){
                     std::cout << t->pos << " ";
@@ -1167,40 +1367,40 @@ LocalPRG::find_alt_path(const std::vector<LocalNodePtr> &ref_path, const uint32_
                 std::cout << std::endl;*/
                 return alt_path;
             } else {
-                for (const auto &m: considered_path.back()->outNodes) {
+                for (const auto& m : considered_path.back()->outNodes) {
                     paths_in_progress.push_back(considered_path);
                     paths_in_progress.back().push_back(m);
                 }
             }
-        } else if (considered_seq.length() <= working_alt.length() and
-                   considered_seq == working_alt.substr(0, considered_seq.length())) {
-            for (const auto &m: considered_path.back()->outNodes) {
+        } else if (considered_seq.length() <= working_alt.length()
+            and considered_seq == working_alt.substr(0, considered_seq.length())) {
+            for (const auto& m : considered_path.back()->outNodes) {
                 paths_in_progress.push_back(considered_path);
                 paths_in_progress.back().push_back(m);
             }
         }
     }
-    assert (true or assert_msg("Should have found an alt path!!"));
+    assert(true or assert_msg("Should have found an alt path!!"));
     return alt_path; // this never happens
 }
 
-uint32_t
-LocalPRG::get_number_of_bases_in_local_path_before_a_given_position(const std::vector<LocalNodePtr> &local_path,
-                                                                    uint32_t position) const {
+uint32_t LocalPRG::get_number_of_bases_in_local_path_before_a_given_position(
+    const std::vector<LocalNodePtr>& local_path, uint32_t position) const
+{
     uint32_t number_of_bases_in_local_path_before_the_position = 0;
-    for (const auto &local_node : local_path) {
+    for (const auto& local_node : local_path) {
         bool local_node_is_empty = local_node->pos.length == 0;
         if (local_node_is_empty) {
             continue;
         }
 
         bool local_node_starts_before_position = local_node->pos.start < position;
-        bool local_node_ends_before_position =
-                local_node->pos.get_end() <= position;
+        bool local_node_ends_before_position = local_node->pos.get_end() <= position;
         if (local_node_ends_before_position) {
             number_of_bases_in_local_path_before_the_position += local_node->pos.length;
         } else if (local_node_starts_before_position) {
-            number_of_bases_in_local_path_before_the_position += position - local_node->pos.start;
+            number_of_bases_in_local_path_before_the_position
+                += position - local_node->pos.start;
             break;
         }
     }
@@ -1208,55 +1408,70 @@ LocalPRG::get_number_of_bases_in_local_path_before_a_given_position(const std::v
     return number_of_bases_in_local_path_before_the_position;
 }
 
-uint32_t
-LocalPRG::get_number_of_bases_that_are_exclusively_in_the_previous_kmer_node(const KmerNodePtr &previous_kmer_node,
-                                                                             const KmerNodePtr &current_kmer_node) const {
+uint32_t LocalPRG::get_number_of_bases_that_are_exclusively_in_the_previous_kmer_node(
+    const KmerNodePtr& previous_kmer_node, const KmerNodePtr& current_kmer_node) const
+{
     uint32_t number_of_bases_that_are_exclusively_in_the_previous_kmer_node = 0;
     auto previous_kmer_node_path_interval_iterator = previous_kmer_node->path.begin();
 
-    bool previous_kmer_node_path_interval_ends_before_current_kmer_node =
-            previous_kmer_node_path_interval_iterator->get_end() <=
-            current_kmer_node->path.get_start();
+    bool previous_kmer_node_path_interval_ends_before_current_kmer_node
+        = previous_kmer_node_path_interval_iterator->get_end()
+        <= current_kmer_node->path.get_start();
     while (previous_kmer_node_path_interval_ends_before_current_kmer_node) {
-        number_of_bases_that_are_exclusively_in_the_previous_kmer_node += previous_kmer_node_path_interval_iterator->length;
+        number_of_bases_that_are_exclusively_in_the_previous_kmer_node
+            += previous_kmer_node_path_interval_iterator->length;
         previous_kmer_node_path_interval_iterator++;
-        previous_kmer_node_path_interval_ends_before_current_kmer_node =
-                previous_kmer_node_path_interval_iterator->get_end() <=
-                current_kmer_node->path.get_start();
+        previous_kmer_node_path_interval_ends_before_current_kmer_node
+            = previous_kmer_node_path_interval_iterator->get_end()
+            <= current_kmer_node->path.get_start();
     }
 
-    if (current_kmer_node->path.get_start() > previous_kmer_node_path_interval_iterator->start) {
-        number_of_bases_that_are_exclusively_in_the_previous_kmer_node +=
-                current_kmer_node->path.get_start() - previous_kmer_node_path_interval_iterator->start;
+    if (current_kmer_node->path.get_start()
+        > previous_kmer_node_path_interval_iterator->start) {
+        number_of_bases_that_are_exclusively_in_the_previous_kmer_node
+            += current_kmer_node->path.get_start()
+            - previous_kmer_node_path_interval_iterator->start;
     }
 
     return number_of_bases_that_are_exclusively_in_the_previous_kmer_node;
 }
 
-
 std::pair<std::vector<uint32_t>, std::vector<uint32_t>>
-LocalPRG::get_forward_and_reverse_kmer_coverages_in_range(const KmerGraphWithCoverage &kmer_graph_with_coverage,
-                                                          const std::vector<KmerNodePtr> &kmer_path,
-                                                          const std::vector<LocalNodePtr> &local_path, const uint32_t &range_pos_start,
-                                                          const uint32_t &range_pos_end, const uint32_t &sample_id) const {
-    assert(kmer_path.size() >
-           1); // this is an assert because it is the programmers responsibility to ensure that the kmer_path given to this function has at least size 1
-    // TODO: this assert could be removed if we represent std::vector<KmerNodePtr> as a concept (class) in such a way that this class could only be constructed if given a large enough kmer_path (or whatever condition to build a correct kmer_path)
-    // TODO: the existence of this class would transfer the responsibility of having a correct kmer_path to its constructor, instead of here
-    // TODO: kmer_path is used in lots of places and there are some hard-coded logic about it, it is worth upgrading it to a class, this will be done later
+LocalPRG::get_forward_and_reverse_kmer_coverages_in_range(
+    const KmerGraphWithCoverage& kmer_graph_with_coverage,
+    const std::vector<KmerNodePtr>& kmer_path,
+    const std::vector<LocalNodePtr>& local_path, const uint32_t& range_pos_start,
+    const uint32_t& range_pos_end, const uint32_t& sample_id) const
+{
+    assert(kmer_path.size()
+        > 1); // this is an assert because it is the programmers responsibility to
+              // ensure that the kmer_path given to this function has at least size 1
+    // TODO: this assert could be removed if we represent std::vector<KmerNodePtr> as a
+    // concept (class) in such a way that this class could only be constructed if given
+    // a large enough kmer_path (or whatever condition to build a correct kmer_path)
+    // TODO: the existence of this class would transfer the responsibility of having a
+    // correct kmer_path to its constructor, instead of here
+    // TODO: kmer_path is used in lots of places and there are some hard-coded logic
+    // about it, it is worth upgrading it to a class, this will be done later
 
-    uint32_t starting_position_of_first_non_trivial_kmer_in_kmer_path = kmer_path[1]->path.get_start(); // TODO: e.g. this could be replaced by kmer_path.get_first_non_trivial_kmer().get_start(); (for now, we have to implicitly know hat kmer_path[1] is the first non-trivial kmer)
-    uint32_t number_of_bases_in_local_path_before_first_non_trivial_kmer_in_kmer_path = get_number_of_bases_in_local_path_before_a_given_position(
+    uint32_t starting_position_of_first_non_trivial_kmer_in_kmer_path
+        = kmer_path[1]
+              ->path.get_start(); // TODO: e.g. this could be replaced by
+                                  // kmer_path.get_first_non_trivial_kmer().get_start();
+                                  // (for now, we have to implicitly know hat
+                                  // kmer_path[1] is the first non-trivial kmer)
+    uint32_t number_of_bases_in_local_path_before_first_non_trivial_kmer_in_kmer_path
+        = get_number_of_bases_in_local_path_before_a_given_position(
             local_path, starting_position_of_first_non_trivial_kmer_in_kmer_path);
-
 
     std::vector<uint32_t> forward_coverages;
     std::vector<uint32_t> reverse_coverages;
-    uint32_t number_of_bases_in_local_path_which_were_already_considered = number_of_bases_in_local_path_before_first_non_trivial_kmer_in_kmer_path;
+    uint32_t number_of_bases_in_local_path_which_were_already_considered
+        = number_of_bases_in_local_path_before_first_non_trivial_kmer_in_kmer_path;
     uint32_t kmer_size = kmer_path[1]->path.length();
     KmerNodePtr previous_kmer_node = nullptr;
 
-    for (const auto &current_kmer_node: kmer_path) {
+    for (const auto& current_kmer_node : kmer_path) {
         bool current_kmer_node_is_empty = current_kmer_node->path.length() == 0;
         if (current_kmer_node_is_empty) {
             continue;
@@ -1264,22 +1479,31 @@ LocalPRG::get_forward_and_reverse_kmer_coverages_in_range(const KmerGraphWithCov
 
         bool there_is_previous_kmer_node = previous_kmer_node != nullptr;
         if (there_is_previous_kmer_node) {
-            uint32_t number_of_bases_that_are_exclusively_in_the_previous_kmer_node = get_number_of_bases_that_are_exclusively_in_the_previous_kmer_node(
+            uint32_t number_of_bases_that_are_exclusively_in_the_previous_kmer_node
+                = get_number_of_bases_that_are_exclusively_in_the_previous_kmer_node(
                     previous_kmer_node, current_kmer_node);
-            number_of_bases_in_local_path_which_were_already_considered += number_of_bases_that_are_exclusively_in_the_previous_kmer_node;
+            number_of_bases_in_local_path_which_were_already_considered
+                += number_of_bases_that_are_exclusively_in_the_previous_kmer_node;
         }
 
-        bool is_inside_the_given_range =
-                range_pos_start <= number_of_bases_in_local_path_which_were_already_considered + kmer_size and
-                number_of_bases_in_local_path_which_were_already_considered < range_pos_end;
+        bool is_inside_the_given_range = range_pos_start
+                <= number_of_bases_in_local_path_which_were_already_considered
+                    + kmer_size
+            and number_of_bases_in_local_path_which_were_already_considered
+                < range_pos_end;
         if (is_inside_the_given_range) {
-            assert(current_kmer_node->id < kmer_graph_with_coverage.kmer_prg->nodes.size() and
-                   kmer_graph_with_coverage.kmer_prg->nodes[current_kmer_node->id] != nullptr);
-            forward_coverages.push_back(kmer_graph_with_coverage.get_covg(current_kmer_node->id, 0, sample_id));
-            reverse_coverages.push_back(kmer_graph_with_coverage.get_covg(current_kmer_node->id, 1, sample_id));
+            assert(
+                current_kmer_node->id < kmer_graph_with_coverage.kmer_prg->nodes.size()
+                and kmer_graph_with_coverage.kmer_prg->nodes[current_kmer_node->id]
+                    != nullptr);
+            forward_coverages.push_back(
+                kmer_graph_with_coverage.get_covg(current_kmer_node->id, 0, sample_id));
+            reverse_coverages.push_back(
+                kmer_graph_with_coverage.get_covg(current_kmer_node->id, 1, sample_id));
         } else {
-            bool has_gone_past_the_given_range =
-                    number_of_bases_in_local_path_which_were_already_considered > range_pos_end;
+            bool has_gone_past_the_given_range
+                = number_of_bases_in_local_path_which_were_already_considered
+                > range_pos_end;
             if (has_gone_past_the_given_range)
                 break;
         }
@@ -1290,13 +1514,13 @@ LocalPRG::get_forward_and_reverse_kmer_coverages_in_range(const KmerGraphWithCov
     return std::make_pair(forward_coverages, reverse_coverages);
 }
 
-
-uint32_t sum(const std::vector<uint32_t> &v) {
+uint32_t sum(const std::vector<uint32_t>& v)
+{
     return std::accumulate(v.begin(), v.end(), 0);
 }
 
-
-uint32_t mean(const std::vector<uint32_t> &v) {
+uint32_t mean(const std::vector<uint32_t>& v)
+{
     /*std::string s;
     for (const auto &i : v)
         s += int_to_string(i) + " ";
@@ -1306,8 +1530,8 @@ uint32_t mean(const std::vector<uint32_t> &v) {
     return std::accumulate(v.begin(), v.end(), 0) / v.size();
 }
 
-
-uint32_t median(std::vector<uint32_t> v) {
+uint32_t median(std::vector<uint32_t> v)
+{
     /*std::string s;
     for (const auto &i : v)
         s += int_to_string(i) + " ";
@@ -1325,8 +1549,8 @@ uint32_t median(std::vector<uint32_t> v) {
     }
 }
 
-
-uint32_t mode(std::vector<uint32_t> v) {
+uint32_t mode(std::vector<uint32_t> v)
+{
     std::sort(v.begin(), v.end());
     /*std::string s;
     for (const auto &i : v)
@@ -1336,7 +1560,7 @@ uint32_t mode(std::vector<uint32_t> v) {
     uint32_t max_count = 1;
     uint32_t most_common = 0;
     uint32_t last = 0;
-    for (const auto &n : v) {
+    for (const auto& n : v) {
         if (n == last)
             counter++;
         else {
@@ -1351,20 +1575,21 @@ uint32_t mode(std::vector<uint32_t> v) {
     return most_common;
 }
 
-
-float gaps(std::vector<uint32_t> v, const uint32_t &min_covg) {
+float gaps(std::vector<uint32_t> v, const uint32_t& min_covg)
+{
     if (v.empty())
         return 0;
     uint32_t gap = 0;
-    for (const auto &n : v) {
+    for (const auto& n : v) {
         if (n < min_covg)
             gap++;
     }
     return float(gap) / v.size();
 }
 
-
-float gaps(std::vector<uint32_t> v1, std::vector<uint32_t> v2, const uint32_t &min_kmer_covg) {
+float gaps(
+    std::vector<uint32_t> v1, std::vector<uint32_t> v2, const uint32_t& min_kmer_covg)
+{
     if (v1.empty() or v2.size() != v1.size())
         return 0;
     uint32_t gap = 0;
@@ -1375,24 +1600,25 @@ float gaps(std::vector<uint32_t> v1, std::vector<uint32_t> v2, const uint32_t &m
     return float(gap) / v1.size();
 }
 
-
-void LocalPRG::add_sample_covgs_to_vcf(VCF &vcf, const KmerGraphWithCoverage &kg, const std::vector<LocalNodePtr> &ref_path,
-                                       const uint32_t &min_kmer_covg, const std::string &sample_name,
-                                       const uint32_t &sample_id) const {
+void LocalPRG::add_sample_covgs_to_vcf(VCF& vcf, const KmerGraphWithCoverage& kg,
+    const std::vector<LocalNodePtr>& ref_path, const uint32_t& min_kmer_covg,
+    const std::string& sample_name, const uint32_t& sample_id) const
+{
     BOOST_LOG_TRIVIAL(debug) << "Update VCF with sample covgs";
 
-    assert(!prg.nodes.empty()); //otherwise empty nodes -> segfault
+    assert(!prg.nodes.empty()); // otherwise empty nodes -> segfault
     vcf.sort_records();
 
     std::vector<LocalNodePtr> alt_path;
 
-    std::vector<KmerNodePtr> ref_kmer_path = kmernode_path_from_localnode_path(ref_path);
+    std::vector<KmerNodePtr> ref_kmer_path
+        = kmernode_path_from_localnode_path(ref_path);
 
     std::vector<KmerNodePtr> alt_kmer_path;
 
-    for (auto &recordPointer : vcf.records) {
-        auto &record = *recordPointer;
-        //std::cout << record << std::endl;
+    for (auto& recordPointer : vcf.records) {
+        auto& record = *recordPointer;
+        // std::cout << record << std::endl;
         // find corresponding ref kmers
         auto end_pos = record.pos + record.ref.length();
         if (record.ref == ".")
@@ -1400,17 +1626,18 @@ void LocalPRG::add_sample_covgs_to_vcf(VCF &vcf, const KmerGraphWithCoverage &kg
 
         std::vector<uint32_t> ref_fwd_covgs;
         std::vector<uint32_t> ref_rev_covgs;
-        std::tie(ref_fwd_covgs, ref_rev_covgs) = get_forward_and_reverse_kmer_coverages_in_range(kg, ref_kmer_path,
-                                                                                                 ref_path, record.pos,
-                                                                                                 end_pos, sample_id);
+        std::tie(ref_fwd_covgs, ref_rev_covgs)
+            = get_forward_and_reverse_kmer_coverages_in_range(
+                kg, ref_kmer_path, ref_path, record.pos, end_pos, sample_id);
 
         // find corresponding alt kmers
-        // if sample has alt path, we have the kmer path for this, but otherwise we will need to work it out
+        // if sample has alt path, we have the kmer path for this, but otherwise we will
+        // need to work it out
         auto sample_it = find(vcf.samples.begin(), vcf.samples.end(), sample_name);
         assert(sample_it != vcf.samples.end());
         auto sample_index = distance(vcf.samples.begin(), sample_it);
-        assert((uint) sample_index != vcf.samples.size());
-        assert(record.samples.size() > (uint) sample_index);
+        assert((uint)sample_index != vcf.samples.size());
+        assert(record.samples.size() > (uint)sample_index);
 
         record.set_format(sample_index, "MEAN_FWD_COVG", mean(ref_fwd_covgs));
         record.set_format(sample_index, "MEAN_REV_COVG", mean(ref_rev_covgs));
@@ -1418,9 +1645,10 @@ void LocalPRG::add_sample_covgs_to_vcf(VCF &vcf, const KmerGraphWithCoverage &kg
         record.set_format(sample_index, "MED_REV_COVG", median(ref_rev_covgs));
         record.set_format(sample_index, "SUM_FWD_COVG", sum(ref_fwd_covgs));
         record.set_format(sample_index, "SUM_REV_COVG", sum(ref_rev_covgs));
-        record.set_format(sample_index, "GAPS", gaps(ref_fwd_covgs, ref_rev_covgs, min_kmer_covg));
+        record.set_format(
+            sample_index, "GAPS", gaps(ref_fwd_covgs, ref_rev_covgs, min_kmer_covg));
 
-        for (const auto &alt_allele : record.alt) {
+        for (const auto& alt_allele : record.alt) {
             alt_path = find_alt_path(ref_path, record.pos, record.ref, alt_allele);
             alt_kmer_path = kmernode_path_from_localnode_path(alt_path);
 
@@ -1431,10 +1659,9 @@ void LocalPRG::add_sample_covgs_to_vcf(VCF &vcf, const KmerGraphWithCoverage &kg
 
             std::vector<uint32_t> alt_fwd_covgs;
             std::vector<uint32_t> alt_rev_covgs;
-            std::tie(alt_fwd_covgs, alt_rev_covgs) = get_forward_and_reverse_kmer_coverages_in_range(kg, alt_kmer_path,
-                                                                                                     alt_path,
-                                                                                                     record.pos,
-                                                                                                     end_pos, sample_id);
+            std::tie(alt_fwd_covgs, alt_rev_covgs)
+                = get_forward_and_reverse_kmer_coverages_in_range(
+                    kg, alt_kmer_path, alt_path, record.pos, end_pos, sample_id);
 
             record.append_format(sample_index, "MEAN_FWD_COVG", mean(alt_fwd_covgs));
             record.append_format(sample_index, "MEAN_REV_COVG", mean(alt_rev_covgs));
@@ -1442,53 +1669,59 @@ void LocalPRG::add_sample_covgs_to_vcf(VCF &vcf, const KmerGraphWithCoverage &kg
             record.append_format(sample_index, "MED_REV_COVG", median(alt_rev_covgs));
             record.append_format(sample_index, "SUM_FWD_COVG", sum(alt_fwd_covgs));
             record.append_format(sample_index, "SUM_REV_COVG", sum(alt_rev_covgs));
-            record.append_format(sample_index, "GAPS", gaps(alt_fwd_covgs, alt_rev_covgs, min_kmer_covg));
+            record.append_format(sample_index, "GAPS",
+                gaps(alt_fwd_covgs, alt_rev_covgs, min_kmer_covg));
         }
     }
 
-    vcf.add_formats({ "MEAN_FWD_COVG", "MEAN_REV_COVG", "MED_FWD_COVG", "MED_REV_COVG", "SUM_FWD_COVG", "SUM_REV_COVG",
-                      "GAPS" });
-
+    vcf.add_formats({ "MEAN_FWD_COVG", "MEAN_REV_COVG", "MED_FWD_COVG", "MED_REV_COVG",
+        "SUM_FWD_COVG", "SUM_REV_COVG", "GAPS" });
 }
 
-
-void LocalPRG::add_consensus_path_to_fastaq(Fastaq &output_fq, PanNodePtr pnode, std::vector<KmerNodePtr> &kmp,
-                                            std::vector<LocalNodePtr> &lmp, const uint32_t w, const bool bin,
-                                            const uint32_t global_covg, const uint32_t &max_num_kmers_to_average,
-                                            const uint32_t &sample_id) const {
+void LocalPRG::add_consensus_path_to_fastaq(Fastaq& output_fq, PanNodePtr pnode,
+    std::vector<KmerNodePtr>& kmp, std::vector<LocalNodePtr>& lmp, const uint32_t w,
+    const bool bin, const uint32_t global_covg,
+    const uint32_t& max_num_kmers_to_average, const uint32_t& sample_id) const
+{
     if (pnode->reads.empty()) {
         BOOST_LOG_TRIVIAL(warning) << "Node " << pnode->get_name() << " has no reads";
         return;
     }
-    kmp.reserve(800); //TODO: check this
+    kmp.reserve(800); // TODO: check this
 
     BOOST_LOG_TRIVIAL(debug) << "Find maxpath for " << pnode->get_name();
     std::string prob_model = "nbin";
     if (bin)
         prob_model = "bin";
-    float ppath = pnode->kmer_prg_with_coverage.find_max_path(kmp, prob_model, max_num_kmers_to_average, sample_id);
-
+    float ppath = pnode->kmer_prg_with_coverage.find_max_path(
+        kmp, prob_model, max_num_kmers_to_average, sample_id);
 
     lmp.reserve(100);
     lmp = localnode_path_from_kmernode_path(kmp, w);
 
-    std::vector<uint32_t> covgs = get_covgs_along_localnode_path(pnode, lmp, kmp, sample_id);
+    std::vector<uint32_t> covgs
+        = get_covgs_along_localnode_path(pnode, lmp, kmp, sample_id);
     auto mode_covg = mode(covgs);
     auto mean_covg = mean(covgs);
-    BOOST_LOG_TRIVIAL(debug) << "Found global coverage " << global_covg << " and path mode " << mode_covg << " and mean "
-                            << mean_covg;
+    BOOST_LOG_TRIVIAL(debug) << "Found global coverage " << global_covg
+                             << " and path mode " << mode_covg << " and mean "
+                             << mean_covg;
     if (global_covg > 20 and 20 * mean(covgs) < global_covg) {
-        BOOST_LOG_TRIVIAL(debug) << "Skip LocalPRG " << name << " mean along max likelihood path too low";
+        BOOST_LOG_TRIVIAL(debug)
+            << "Skip LocalPRG " << name << " mean along max likelihood path too low";
         kmp.clear();
         return;
     }
     if (global_covg > 20 and mean(covgs) > 10 * global_covg) {
-        BOOST_LOG_TRIVIAL(debug) << "Skip LocalPRG " << name << " as mean along max likelihood path too high";
+        BOOST_LOG_TRIVIAL(debug) << "Skip LocalPRG " << name
+                                 << " as mean along max likelihood path too high";
         kmp.clear();
         return;
     }
     if (global_covg > 20 and mode(covgs) < 3 and mean(covgs) < 3) {
-        BOOST_LOG_TRIVIAL(debug) << "Skip LocalPRG " << name << " as mode and mean along max likelihood path too low";
+        BOOST_LOG_TRIVIAL(debug)
+            << "Skip LocalPRG " << name
+            << " as mode and mean along max likelihood path too low";
         kmp.clear();
         return;
     }
@@ -1497,23 +1730,26 @@ void LocalPRG::add_consensus_path_to_fastaq(Fastaq &output_fq, PanNodePtr pnode,
     std::string header = " log P(data|sequence)=" + std::to_string(ppath);
     std::string seq = string_along_path(lmp);
 
-    #pragma omp critical(consensus_fq)
+#pragma omp critical(consensus_fq)
     {
         output_fq.add_entry(fq_name, seq, covgs, global_covg, header);
     }
 }
 
-
-std::vector<LocalNodePtr> LocalPRG::get_valid_vcf_reference(const std::string &vcf_reference_sequence) const {
+std::vector<LocalNodePtr> LocalPRG::get_valid_vcf_reference(
+    const std::string& vcf_reference_sequence) const
+{
     std::vector<LocalNodePtr> reference_path = {};
     if (vcf_reference_sequence.length() < 30) {
-        BOOST_LOG_TRIVIAL(warning) << "Input vcf_ref path was too short to be the ref for PRG " << name;
+        BOOST_LOG_TRIVIAL(warning)
+            << "Input vcf_ref path was too short to be the ref for PRG " << name;
         return reference_path;
     }
 
     reference_path = this->prg.nodes_along_string(vcf_reference_sequence);
     if (reference_path.empty()) {
-        reference_path = this->prg.nodes_along_string(rev_complement(vcf_reference_sequence));
+        reference_path
+            = this->prg.nodes_along_string(rev_complement(vcf_reference_sequence));
     }
 
     if (reference_path.empty())
@@ -1523,20 +1759,23 @@ std::vector<LocalNodePtr> LocalPRG::get_valid_vcf_reference(const std::string &v
 
     LocalNode last_prg_node = *(*(prg.nodes.rbegin())).second;
     auto final_prg_coordinate = last_prg_node.pos.get_end();
-    bool not_ending_at_prg_end = reference_path.back()->pos.get_end() != final_prg_coordinate;
+    bool not_ending_at_prg_end
+        = reference_path.back()->pos.get_end() != final_prg_coordinate;
 
     if (not_starting_at_prg_start or not_ending_at_prg_end) {
-        BOOST_LOG_TRIVIAL(warning) << "Input vcf_ref path did not start/end at the beginning/end of PRG " << name;
+        BOOST_LOG_TRIVIAL(warning)
+            << "Input vcf_ref path did not start/end at the beginning/end of PRG "
+            << name;
         reference_path.clear();
     }
     return reference_path;
 }
 
-
-void LocalPRG::add_variants_to_vcf(VCF &master_vcf, PanNodePtr pnode, const std::string &vcf_ref,
-                                   const std::vector<KmerNodePtr> &kmp, const std::vector<LocalNodePtr> &lmp,
-                                   const uint32_t &min_kmer_covg, const uint32_t &sample_id,
-                                   const std::string &sample_name) {
+void LocalPRG::add_variants_to_vcf(VCF& master_vcf, PanNodePtr pnode,
+    const std::string& vcf_ref, const std::vector<KmerNodePtr>& kmp,
+    const std::vector<LocalNodePtr>& lmp, const uint32_t& min_kmer_covg,
+    const uint32_t& sample_id, const std::string& sample_name)
+{
     auto reference_path = get_valid_vcf_reference(vcf_ref);
     if (reference_path.empty()) {
         BOOST_LOG_TRIVIAL(warning) << "Could not find reference sequence for " << name
@@ -1547,18 +1786,18 @@ void LocalPRG::add_variants_to_vcf(VCF &master_vcf, PanNodePtr pnode, const std:
     VCF vcf;
     build_vcf(vcf, reference_path);
     add_sample_gt_to_vcf(vcf, reference_path, lmp, sample_name);
-    add_sample_covgs_to_vcf(vcf, pnode->kmer_prg_with_coverage, reference_path, min_kmer_covg, sample_name, sample_id);
+    add_sample_covgs_to_vcf(vcf, pnode->kmer_prg_with_coverage, reference_path,
+        min_kmer_covg, sample_name, sample_id);
     vcf.merge_multi_allelic();
     vcf.correct_dot_alleles(string_along_path(reference_path), name);
-    #pragma omp critical(master_vcf)
+#pragma omp critical(master_vcf)
     {
         master_vcf.append_vcf(vcf);
     }
-
 }
 
-
-std::string LocalPRG::random_path() {
+std::string LocalPRG::random_path()
+{
     std::vector<LocalNodePtr> npath;
     npath.push_back(prg.nodes.at(0));
     while (not npath.back()->outNodes.empty()) {
@@ -1568,8 +1807,9 @@ std::string LocalPRG::random_path() {
     return string_along_path(npath);
 }
 
-
-bool operator!=(const std::vector<KmerNodePtr> &lhs, const std::vector<KmerNodePtr> &rhs) {
+bool operator!=(
+    const std::vector<KmerNodePtr>& lhs, const std::vector<KmerNodePtr>& rhs)
+{
     if (lhs.size() != rhs.size()) {
         return true;
     }
@@ -1581,9 +1821,8 @@ bool operator!=(const std::vector<KmerNodePtr> &lhs, const std::vector<KmerNodeP
     return false;
 }
 
-
-std::ostream &operator<<(std::ostream &out, LocalPRG const &data) {
+std::ostream& operator<<(std::ostream& out, LocalPRG const& data)
+{
     out << data.name;
     return out;
 }
-

--- a/src/localgraph.cpp
+++ b/src/localgraph.cpp
@@ -1,40 +1,43 @@
-#include <fstream>
-#include <cassert>
 #include <algorithm>
+#include <cassert>
+#include <fstream>
 
 #include <boost/log/trivial.hpp>
 
 #include "localgraph.h"
 #include "utils.h"
 
-
 #define assert_msg(x) !(std::cerr << "Assertion failed: " << x << std::endl)
 
-
-LocalGraph::LocalGraph() {
+LocalGraph::LocalGraph()
+{
     // reserve space in index
-    //index.reserve(10);
+    // index.reserve(10);
 }
 
-LocalGraph::~LocalGraph() {
+LocalGraph::~LocalGraph()
+{
     /*for (const auto &c: nodes) {
         delete c.second;
     }*/
     nodes.clear();
 }
-//add the node with a given id and seq if the id is not already in the nodes
-void LocalGraph::add_node(const uint32_t &id, const std::string &seq, const Interval &pos) {
+// add the node with a given id and seq if the id is not already in the nodes
+void LocalGraph::add_node(
+    const uint32_t& id, const std::string& seq, const Interval& pos)
+{
     assert(seq.length() == pos.length);
-    assert(id < std::numeric_limits<uint32_t>::max() || assert_msg("WARNING, reached max local graph node size"));
+    assert(id < std::numeric_limits<uint32_t>::max()
+        || assert_msg("WARNING, reached max local graph node size"));
     auto it = nodes.find(id);
     if (it == nodes.end()) {
         LocalNodePtr n(std::make_shared<LocalNode>(seq, pos, id));
-        nodes[id] = n; //add the node to the map
-        //nodes[id] = make_shared<LocalNode>(seq, pos, id);
-        //cout << "Added node " << id << endl;
+        nodes[id] = n; // add the node to the map
+        // nodes[id] = make_shared<LocalNode>(seq, pos, id);
+        // cout << "Added node " << id << endl;
 
-        //add the node to the interval indexes for fast overlap queries
-        if (pos.length==0)
+        // add the node to the interval indexes for fast overlap queries
+        if (pos.length == 0)
             startIndexOfZeroLengthIntervals[pos.start] = n;
         else
             intervalTree.add(pos.start, pos.get_end(), n);
@@ -44,40 +47,44 @@ void LocalGraph::add_node(const uint32_t &id, const std::string &seq, const Inte
     }
 }
 
-void LocalGraph::add_edge(const uint32_t &from, const uint32_t &to) {
+void LocalGraph::add_edge(const uint32_t& from, const uint32_t& to)
+{
     auto from_it = nodes.find(from);
     auto to_it = nodes.find(to);
     assert((from_it != nodes.end()) && (to_it != nodes.end()));
     if ((from_it != nodes.end()) && (to_it != nodes.end())) {
         LocalNodePtr f = (nodes.find(from)->second);
         LocalNodePtr t = (nodes.find(to)->second);
-        assert(f->pos.get_end() <= t->pos.start || assert_msg(
-                f->pos.get_end() << ">" << t->pos.start << " so cannot add edge from node " << *f << " to node "
-                                 << *t));
+        assert(f->pos.get_end() <= t->pos.start
+            || assert_msg(f->pos.get_end()
+                << ">" << t->pos.start << " so cannot add edge from node " << *f
+                << " to node " << *t));
         f->outNodes.push_back(t);
-        //cout << "Added edge (" << f->id << ", " << t->id << ")" << endl;
+        // cout << "Added edge (" << f->id << ", " << t->id << ")" << endl;
     }
 }
 
-/*void LocalGraph::add_varsite (const uint16_t level, const uint32_t pre_site_id, const uint32_t post_site_id)
+/*void LocalGraph::add_varsite (const uint16_t level, const uint32_t pre_site_id, const
+uint32_t post_site_id)
 {
     assert(pre_site_id <= post_site_id);
     while (level >= index.size())
     {
         vector<pair<uint32_t, uint32_t>> levelv;
-	levelv.reserve(400);
-	//levelv = {};
-	index.insert(index.end(), 1, levelv);
+        levelv.reserve(400);
+        //levelv = {};
+        index.insert(index.end(), 1, levelv);
     }
     index[level].push_back(make_pair(pre_site_id, post_site_id));
     return;
 }*/
 
-void LocalGraph::write_gfa(const std::string &filepath) const {
+void LocalGraph::write_gfa(const std::string& filepath) const
+{
     std::ofstream handle;
     handle.open(filepath);
     handle << "H\tVN:Z:1.0\tbn:Z:--linear --singlearr" << std::endl;
-    for (const auto &node : nodes) {
+    for (const auto& node : nodes) {
         handle << "S\t" << node.second->id << "\t";
         if (node.second->seq.empty()) {
             handle << "*";
@@ -86,13 +93,15 @@ void LocalGraph::write_gfa(const std::string &filepath) const {
         }
         handle << "\tRC:i:" << node.second->covg << std::endl;
         for (uint32_t j = 0; j < node.second->outNodes.size(); ++j) {
-            handle << "L\t" << node.second->id << "\t+\t" << node.second->outNodes[j]->id << "\t+\t0M" << std::endl;
+            handle << "L\t" << node.second->id << "\t+\t"
+                   << node.second->outNodes[j]->id << "\t+\t0M" << std::endl;
         }
     }
     handle.close();
 }
 
-void LocalGraph::read_gfa(const std::string &filepath) {
+void LocalGraph::read_gfa(const std::string& filepath)
+{
     uint32_t id, from, to;
     std::string line;
     std::vector<std::string> split_line;
@@ -108,7 +117,8 @@ void LocalGraph::read_gfa(const std::string &filepath) {
                     split_line[2] = "";
                 }
                 id = std::stoi(split_line[1]);
-                add_node(id, (std::string) split_line[2], Interval(i, i + split_line[2].size()));
+                add_node(id, (std::string)split_line[2],
+                    Interval(i, i + split_line[2].size()));
                 i += split_line[2].size();
             }
         }
@@ -135,41 +145,53 @@ void LocalGraph::read_gfa(const std::string &filepath) {
     }
 }
 
-std::vector<PathPtr> LocalGraph::walk(const uint32_t &node_id, const uint32_t &pos, const uint32_t &len) const { //node_id: where to start the walk, pos: the position in the node_id, len = k+w-1 -> the length that the walk has to go through - we are sketching kmers in a graph
-    //cout << "walking graph from node " << node_id << " pos " << pos << " for length " << len << endl;
+std::vector<PathPtr> LocalGraph::walk(
+    const uint32_t& node_id, const uint32_t& pos, const uint32_t& len) const
+{ // node_id: where to start the walk, pos: the position in the node_id, len = k+w-1 ->
+  // the length that the walk has to go through - we are sketching kmers in a graph
+    // cout << "walking graph from node " << node_id << " pos " << pos << " for length "
+    // << len << endl;
     // walks from position pos in node node for length len bases
-    assert((nodes.at(node_id)->pos.start <= pos && nodes.at(node_id)->pos.get_end() >= pos) || assert_msg(
-            nodes.at(node_id)->pos.start << "<=" << pos << " and " << nodes.at(node_id)->pos.get_end() << ">="
-                                         << pos)); // if this fails, pos given lies on a different node
+    assert(
+        (nodes.at(node_id)->pos.start <= pos && nodes.at(node_id)->pos.get_end() >= pos)
+        || assert_msg(nodes.at(node_id)->pos.start
+            << "<=" << pos << " and " << nodes.at(node_id)->pos.get_end()
+            << ">=" << pos)); // if this fails, pos given lies on a different node
     std::vector<PathPtr> return_paths, walk_paths;
     return_paths.reserve(20);
     walk_paths.reserve(20);
     prg::Path p, p2;
     std::deque<Interval> d;
 
-    //cout << "pos+len: " << pos+len << " nodes.at(node_id)->pos.get_end(): " << nodes.at(node_id)->pos.get_end() << endl;
-    if (pos + len <= nodes.at(node_id)->pos.get_end()) { //checks if we can go until the end of the kmer
-        p.initialize(Interval(pos, pos + len)); //create the path containing this interval of the node
-        //cout << "return path: " << p << endl;
+    // cout << "pos+len: " << pos+len << " nodes.at(node_id)->pos.get_end(): " <<
+    // nodes.at(node_id)->pos.get_end() << endl;
+    if (pos + len
+        <= nodes.at(node_id)
+               ->pos.get_end()) { // checks if we can go until the end of the kmer
+        p.initialize(Interval(
+            pos, pos + len)); // create the path containing this interval of the node
+        // cout << "return path: " << p << endl;
         return_paths.push_back(std::make_shared<prg::Path>(p));
-        //cout << "return_paths size: " << return_paths.size() << endl; 
+        // cout << "return_paths size: " << return_paths.size() << endl;
         return return_paths;
     }
     uint32_t len_added = std::min(nodes.at(node_id)->pos.get_end() - pos, len);
 
-    //cout << "len: " << len << " len_added: " << len_added << endl;
+    // cout << "len: " << len << " len_added: " << len_added << endl;
     if (len_added < len) {
         for (auto it = nodes.at(node_id)->outNodes.begin();
              it != nodes.at(node_id)->outNodes.end(); ++it) {
-            //cout << "Following node: " << (*it)->id << " to add " << len-len_added << " more bases" << endl;
+            // cout << "Following node: " << (*it)->id << " to add " << len-len_added <<
+            // " more bases" << endl;
             walk_paths = walk((*it)->id, (*it)->pos.start, len - len_added);
-            //cout << "walk paths size: " << walk_paths.size() << endl;
-            for (auto &walk_path : walk_paths) {
-                // Note, would have just added start interval to each item in walk_paths, but can't seem to force result of it2 to be non-const
-                //cout << (*it2) << endl;
+            // cout << "walk paths size: " << walk_paths.size() << endl;
+            for (auto& walk_path : walk_paths) {
+                // Note, would have just added start interval to each item in
+                // walk_paths, but can't seem to force result of it2 to be non-const
+                // cout << (*it2) << endl;
                 p2.initialize(Interval(pos, nodes.at(node_id)->pos.get_end()));
                 p2.insert_to_the_end(walk_path->begin(), walk_path->end());
-                //cout << "path: " << p2 << " p2.length: " << p2.length << endl;
+                // cout << "path: " << p2 << " p2.length: " << p2.length << endl;
                 if (p2.length() == len) {
                     return_paths.push_back(std::make_shared<prg::Path>(p2));
                 }
@@ -179,12 +201,17 @@ std::vector<PathPtr> LocalGraph::walk(const uint32_t &node_id, const uint32_t &p
     return return_paths;
 }
 
-std::vector<PathPtr> LocalGraph::walk_back(const uint32_t &node_id, const uint32_t &pos, const uint32_t &len) const {
-    //cout << "start walking back from " << pos << " in node " << node_id << " for length " << len << endl;
+std::vector<PathPtr> LocalGraph::walk_back(
+    const uint32_t& node_id, const uint32_t& pos, const uint32_t& len) const
+{
+    // cout << "start walking back from " << pos << " in node " << node_id << " for
+    // length " << len << endl;
     // walks from position pos in node back through prg for length len bases
-    assert((nodes.at(node_id)->pos.start <= pos && nodes.at(node_id)->pos.get_end() >= pos) || assert_msg(
-            nodes.at(node_id)->pos.start << "<=" << pos << " and " << nodes.at(node_id)->pos.get_end() << ">="
-                                         << pos)); // if this fails, pos given lies on a different node
+    assert(
+        (nodes.at(node_id)->pos.start <= pos && nodes.at(node_id)->pos.get_end() >= pos)
+        || assert_msg(nodes.at(node_id)->pos.start
+            << "<=" << pos << " and " << nodes.at(node_id)->pos.get_end()
+            << ">=" << pos)); // if this fails, pos given lies on a different node
     std::vector<PathPtr> return_paths, walk_paths;
     return_paths.reserve(20);
     walk_paths.reserve(20);
@@ -193,26 +220,28 @@ std::vector<PathPtr> LocalGraph::walk_back(const uint32_t &node_id, const uint32
 
     if (nodes.at(node_id)->pos.start + len <= pos) {
         p.initialize(Interval(pos - len, pos));
-        //cout << "return path: " << p << endl;
+        // cout << "return path: " << p << endl;
         return_paths.push_back(std::make_shared<prg::Path>(p));
         return return_paths;
     }
 
     uint32_t len_added = std::min(pos - nodes.at(node_id)->pos.start, len);
-    //cout << "len: " << len << " len_added: " << len_added << endl;
+    // cout << "len: " << len << " len_added: " << len_added << endl;
 
     std::vector<LocalNodePtr>::iterator innode;
     if (len_added < len) {
         for (auto it = nodes.begin(); it != nodes.find(node_id); ++it) {
-            innode = find(it->second->outNodes.begin(), it->second->outNodes.end(), nodes.at(node_id));
+            innode = find(it->second->outNodes.begin(), it->second->outNodes.end(),
+                nodes.at(node_id));
             if (innode != it->second->outNodes.end()) {
-                walk_paths = walk_back(it->second->id, it->second->pos.get_end(), len - len_added);
+                walk_paths = walk_back(
+                    it->second->id, it->second->pos.get_end(), len - len_added);
                 for (uint32_t i = 0; i != walk_paths.size(); ++i) {
                     p2.initialize(*(walk_paths[i]));
                     p2.add_end_interval(Interval(nodes.at(node_id)->pos.start, pos));
-                    //cout << p2 << endl;
+                    // cout << p2 << endl;
                     if (p2.length() == len) {
-                        //cout << "output path: " << p2 << endl;
+                        // cout << "output path: " << p2 << endl;
                         return_paths.push_back(std::make_shared<prg::Path>(p2));
                     }
                 }
@@ -222,13 +251,15 @@ std::vector<PathPtr> LocalGraph::walk_back(const uint32_t &node_id, const uint32
     return return_paths;
 }
 
-LocalNodePtr LocalGraph::get_previous_node(const LocalNodePtr n) const {
+LocalNodePtr LocalGraph::get_previous_node(const LocalNodePtr n) const
+{
     // returns a previous node if there is one/many
     if (n->id == 0) {
         return nullptr;
     } else {
-        for (const auto &c : nodes) {
-            if (find(c.second->outNodes.begin(), c.second->outNodes.end(), n) != c.second->outNodes.end()) {
+        for (const auto& c : nodes) {
+            if (find(c.second->outNodes.begin(), c.second->outNodes.end(), n)
+                != c.second->outNodes.end()) {
                 return c.second;
             } else if (c.first > n->id) {
                 break;
@@ -239,9 +270,12 @@ LocalNodePtr LocalGraph::get_previous_node(const LocalNodePtr n) const {
     }
 }
 
-std::vector<LocalNodePtr> LocalGraph::nodes_along_string(const std::string &query_string, bool end_to_end) const {
-    // Note expects the query string to start at the start of the PRG - can change this later
-    std::vector<std::vector<LocalNodePtr>> u, v, w;   // u <=> v -> w
+std::vector<LocalNodePtr> LocalGraph::nodes_along_string(
+    const std::string& query_string, bool end_to_end) const
+{
+    // Note expects the query string to start at the start of the PRG - can change this
+    // later
+    std::vector<std::vector<LocalNodePtr>> u, v, w; // u <=> v -> w
     // ie reject paths in u, or extend and add to v
     // then set u=v and continue
     // final output w, which is filtered and a path returned
@@ -252,39 +286,46 @@ std::vector<LocalNodePtr> LocalGraph::nodes_along_string(const std::string &quer
     std::string candidate_string = "";
     bool extended = true;
 
-    assert(!nodes.empty()); //otherwise empty nodes -> segfault
+    assert(!nodes.empty()); // otherwise empty nodes -> segfault
 
     // if there is only one node in PRG, simple case, do simple string compare
-    if (nodes.size() == 1 and strcasecmp(query_string.c_str(), nodes.at(0)->seq.c_str()) == 0) {
-        return {nodes.at(0)};
+    if (nodes.size() == 1
+        and strcasecmp(query_string.c_str(), nodes.at(0)->seq.c_str()) == 0) {
+        return { nodes.at(0) };
     }
 
-    u = {{nodes.at(0)}};
+    u = { { nodes.at(0) } };
 
     while (!u.empty()) {
-        for (const auto &p : u) {
+        for (const auto& p : u) {
             candidate_string = "";
-            for (const auto &s : p) {
+            for (const auto& s : p) {
                 candidate_string += s->seq;
             }
 
             for (uint32_t j = 0; j != p.back()->outNodes.size(); ++j) {
-                // if the start of query_string matches extended candidate_string, want to query candidate path extensions
-                //if ( query_string.substr(0,candidate_string.size()+u[i].back()->outNodes[j]->seq.size()) == candidate_string+u[i].back()->outNodes[j]->seq)
+                // if the start of query_string matches extended candidate_string, want
+                // to query candidate path extensions
+                // if (
+                // query_string.substr(0,candidate_string.size()+u[i].back()->outNodes[j]->seq.size())
+                // == candidate_string+u[i].back()->outNodes[j]->seq)
                 auto comp_string = candidate_string + p.back()->outNodes[j]->seq;
                 auto comp_length = std::min(query_string.size(), comp_string.size());
-                if (strcasecmp(
-                        query_string.substr(0, comp_length).c_str(),
-                        comp_string.substr(0, comp_length).c_str()) == 0) {
-                    if ((!end_to_end and
-                         candidate_string.size() + p.back()->outNodes[j]->seq.size() >= query_string.size())
+                if (strcasecmp(query_string.substr(0, comp_length).c_str(),
+                        comp_string.substr(0, comp_length).c_str())
+                    == 0) {
+                    if ((!end_to_end
+                            and candidate_string.size()
+                                    + p.back()->outNodes[j]->seq.size()
+                                >= query_string.size())
                         or p.back()->outNodes[j]->outNodes.empty()) {
-                        // we have now found the whole of the query_string or reached end of graph
+                        // we have now found the whole of the query_string or reached
+                        // end of graph
                         auto p_copy = p;
                         p_copy.push_back(p_copy.back()->outNodes[j]);
                         while (!p_copy.back()->outNodes.empty() and extended) {
                             extended = false;
-                            for (const auto &n : p_copy.back()->outNodes) {
+                            for (const auto& n : p_copy.back()->outNodes) {
                                 if (n->pos.length == 0) {
                                     p_copy.push_back(n);
                                     extended = true;
@@ -302,9 +343,10 @@ std::vector<LocalNodePtr> LocalGraph::nodes_along_string(const std::string &quer
             }
         }
         u = v;
-        // sanity check, we don't care enough about finding the path to have exploding vectors
+        // sanity check, we don't care enough about finding the path to have exploding
+        // vectors
         if (u.size() > 10000)
-            u.erase(u.begin()+10000,u.end());
+            u.erase(u.begin() + 10000, u.end());
         v.clear();
     }
 
@@ -313,17 +355,18 @@ std::vector<LocalNodePtr> LocalGraph::nodes_along_string(const std::string &quer
         return npath;
     } else {
         BOOST_LOG_TRIVIAL(debug) << "have " << w.size() << "candidates";
-        // find the most exact match, the one which covers all sequence with minimal extra to end of graph, or longest
+        // find the most exact match, the one which covers all sequence with minimal
+        // extra to end of graph, or longest
         auto longest_length = 0;
         std::vector<LocalNodePtr> longest_path;
-        for (const auto &p : w) {
+        for (const auto& p : w) {
             candidate_string = "";
-            for (const auto &s : p) {
+            for (const auto& s : p) {
                 candidate_string += s->seq;
             }
             if (strcasecmp(query_string.c_str(), candidate_string.c_str()) == 0) {
                 return p;
-            } else if (candidate_string.size() > (uint) longest_length) {
+            } else if (candidate_string.size() > (uint)longest_length) {
                 longest_path = p;
                 longest_length = candidate_string.size();
             }
@@ -332,10 +375,11 @@ std::vector<LocalNodePtr> LocalGraph::nodes_along_string(const std::string &quer
     }
 }
 
-std::vector<LocalNodePtr> LocalGraph::top_path() const {
+std::vector<LocalNodePtr> LocalGraph::top_path() const
+{
     std::vector<LocalNodePtr> npath;
 
-    assert(!nodes.empty()); //otherwise empty nodes -> segfault
+    assert(!nodes.empty()); // otherwise empty nodes -> segfault
 
     npath.push_back(nodes.at(0));
     while (not npath.back()->outNodes.empty()) {
@@ -345,10 +389,11 @@ std::vector<LocalNodePtr> LocalGraph::top_path() const {
     return npath;
 }
 
-std::vector<LocalNodePtr> LocalGraph::bottom_path() const {
+std::vector<LocalNodePtr> LocalGraph::bottom_path() const
+{
     std::vector<LocalNodePtr> npath;
 
-    assert(!nodes.empty()); //otherwise empty nodes -> segfault
+    assert(!nodes.empty()); // otherwise empty nodes -> segfault
 
     npath.push_back(nodes.at(0));
     while (!npath.back()->outNodes.empty()) {
@@ -358,22 +403,25 @@ std::vector<LocalNodePtr> LocalGraph::bottom_path() const {
     return npath;
 }
 
-bool LocalGraph::operator==(const LocalGraph &y) const {
+bool LocalGraph::operator==(const LocalGraph& y) const
+{
     // false if have different numbers of nodes
-    if (y.nodes.size() != nodes.size()) {//cout << "different numbers of nodes" << endl; 
+    if (y.nodes.size()
+        != nodes.size()) { // cout << "different numbers of nodes" << endl;
         return false;
     }
 
     // false if have different nodes
-    for (const auto &c: nodes) {
-        // if node id doesn't exist 
+    for (const auto& c : nodes) {
+        // if node id doesn't exist
         auto it = y.nodes.find(c.first);
-        if (it == y.nodes.end()) {//cout << "node id doesn't exist" << endl;
+        if (it == y.nodes.end()) { // cout << "node id doesn't exist" << endl;
             return false;
         }
         // or node entries are different
         if (!(*c.second == *(it->second))) {
-            //cout << "node id " << c.first << " exists but has different values" << endl;
+            // cout << "node id " << c.first << " exists but has different values" <<
+            // endl;
             return false;
         }
     }
@@ -381,12 +429,11 @@ bool LocalGraph::operator==(const LocalGraph &y) const {
     return true;
 }
 
-bool LocalGraph::operator!=(const LocalGraph &y) const {
-    return !(*this == y);
-}
+bool LocalGraph::operator!=(const LocalGraph& y) const { return !(*this == y); }
 
-std::ostream &operator<<(std::ostream &out, LocalGraph const &data) {
-    for (const auto &c: data.nodes) {
+std::ostream& operator<<(std::ostream& out, LocalGraph const& data)
+{
+    for (const auto& c : data.nodes) {
         out << c.second->id << std::endl;
         for (uint32_t j = 0; j != c.second->outNodes.size(); ++j) {
             out << c.second->id << "->" << c.second->outNodes[j]->id << std::endl;

--- a/src/localnode.cpp
+++ b/src/localnode.cpp
@@ -1,35 +1,44 @@
-#include <iostream>
-#include <algorithm>
 #include "localnode.h"
 #include "interval.h"
 #include "utils.h" // for pointer_values_equal
+#include <algorithm>
+#include <iostream>
 
+LocalNode::LocalNode(std::string s, Interval p, uint32_t i)
+    : seq(s)
+    , pos(p)
+    , id(i)
+    , covg(p.length)
+    , sketch_next(pos.start)
+    , skip(false)
+{
+}
 
-LocalNode::LocalNode(std::string s, Interval p, uint32_t i) : seq(s), pos(p), id(i), covg(p.length),
-                                                              sketch_next(pos.start),
-                                                              skip(false) {}
-
-std::ostream &operator<<(std::ostream &out, LocalNode const &n) {
+std::ostream& operator<<(std::ostream& out, LocalNode const& n)
+{
     out << "(" << n.id << " " << n.pos << " " << n.seq << ")";
     return out;
 }
 
-bool LocalNode::operator==(const LocalNode &y) const {
-    if (seq != y.seq) {//cout << "different seq" << endl; 
+bool LocalNode::operator==(const LocalNode& y) const
+{
+    if (seq != y.seq) { // cout << "different seq" << endl;
         return false;
     }
-    //if (!(pos == y.pos)) {//cout << "different interval" << endl; 
-    //return false;}
-    if (id != y.id) {//cout << "different id" << endl; 
+    // if (!(pos == y.pos)) {//cout << "different interval" << endl;
+    // return false;}
+    if (id != y.id) { // cout << "different id" << endl;
         return false;
     }
-    if (outNodes.size() != y.outNodes.size()) {//cout << "differnet numbers of out edges" << endl; 
+    if (outNodes.size()
+        != y.outNodes.size()) { // cout << "differnet numbers of out edges" << endl;
         return false;
     }
     for (uint32_t i = 0; i != outNodes.size(); ++i) {
-        spointer_values_equal<LocalNode> eq = {outNodes[i]};
-        if (find_if(y.outNodes.begin(), y.outNodes.end(), eq) ==
-            y.outNodes.end()) {//cout << "the out edge points to a different node" << endl;
+        spointer_values_equal<LocalNode> eq = { outNodes[i] };
+        if (find_if(y.outNodes.begin(), y.outNodes.end(), eq)
+            == y.outNodes.end()) { // cout << "the out edge points to a different node"
+                                   // << endl;
             return false;
         }
     }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,54 +1,70 @@
-#include <iostream>
 #include <cstring>
+#include <iostream>
 
-int pandora_index(int argc, char *argv[]);
+int pandora_index(int argc, char* argv[]);
 
-int pandora_walk(int argc, char *argv[]);
+int pandora_walk(int argc, char* argv[]);
 
-int pandora_map(int argc, char *argv[]);
+int pandora_map(int argc, char* argv[]);
 
-int pandora_compare(int argc, char *argv[]);
+int pandora_compare(int argc, char* argv[]);
 
-int pandora_check_kmergraph(int argc, char *argv[]);
+int pandora_check_kmergraph(int argc, char* argv[]);
 
-int pandora_get_vcf_ref(int argc, char *argv[]);
+int pandora_get_vcf_ref(int argc, char* argv[]);
 
-int pandora_random_path(int argc, char *argv[]);
+int pandora_random_path(int argc, char* argv[]);
 
-int pandora_merge_index(int argc, char *argv[]);
+int pandora_merge_index(int argc, char* argv[]);
 
-
-static int usage() {
-    std::cerr << "\n"
-              << "Program: pandora\n"
-              << "Contact: Rachel Colquhoun <rmnorris@well.ox.ac.uk>\n\n"
-              << "Usage:   pandora <command> [options]\n\n"
-              << "Command: index         index PRG sequences from FASTA format\n"
-              << "         map           identify PRG ordering and sequence from reads for a single sample\n"
-              << "         compare	     identify and compare the PRG ordering and sequences for a set of samples\n"
-              << "         walk          outputs a path through the nodes in a GFA corresponding\n"
-              << "                       to input sequence, provided it exists\n"
-              << "         random_path   outputs a fasta of random paths through the PRGs\n"
-              << "         get_vcf_ref   outputs a fasta suitable for use as the VCF reference using input sequences\n"
-              << "         merge_index   allows multiple indexes to be merged (no compatibility check)\n"
-              << "\n"
-              << "Note: To map reads against PRG sequences, you need to first index the\n"
-              << "      PRGs with pandora index\n"
-              << std::endl;
+static int usage()
+{
+    std::cerr
+        << "\n"
+        << "Program: pandora\n"
+        << "Contact: Rachel Colquhoun <rmnorris@well.ox.ac.uk>\n\n"
+        << "Usage:   pandora <command> [options]\n\n"
+        << "Command: index         index PRG sequences from FASTA format\n"
+        << "         map           identify PRG ordering and sequence from reads for a "
+           "single sample\n"
+        << "         compare	     identify and compare the PRG ordering and "
+           "sequences for a set of samples\n"
+        << "         walk          outputs a path through the nodes in a GFA "
+           "corresponding\n"
+        << "                       to input sequence, provided it exists\n"
+        << "         random_path   outputs a fasta of random paths through the PRGs\n"
+        << "         get_vcf_ref   outputs a fasta suitable for use as the VCF "
+           "reference using input sequences\n"
+        << "         merge_index   allows multiple indexes to be merged (no "
+           "compatibility check)\n"
+        << "\n"
+        << "Note: To map reads against PRG sequences, you need to first index the\n"
+        << "      PRGs with pandora index\n"
+        << std::endl;
     return 1;
 }
 
-int main(int argc, char *argv[]) {
+int main(int argc, char* argv[])
+{
     int ret;
-    if (argc < 2) return usage();
-    if (strcmp(argv[1], "index") == 0) ret = pandora_index(argc - 1, argv + 1);
-    else if (strcmp(argv[1], "walk") == 0) ret = pandora_walk(argc - 1, argv + 1);
-    else if (strcmp(argv[1], "map") == 0) ret = pandora_map(argc - 1, argv + 1);
-    else if (strcmp(argv[1], "compare") == 0) ret = pandora_compare(argc - 1, argv + 1);
-    else if (strcmp(argv[1], "check_kmergraph") == 0) ret = pandora_check_kmergraph(argc - 1, argv + 1);
-    else if (strcmp(argv[1], "get_vcf_ref") == 0) ret = pandora_get_vcf_ref(argc - 1, argv + 1);
-    else if (strcmp(argv[1], "random_path") == 0) ret = pandora_random_path(argc - 1, argv + 1);
-    else if (strcmp(argv[1], "merge_index") == 0) ret = pandora_merge_index(argc - 1, argv + 1);
+    if (argc < 2)
+        return usage();
+    if (strcmp(argv[1], "index") == 0)
+        ret = pandora_index(argc - 1, argv + 1);
+    else if (strcmp(argv[1], "walk") == 0)
+        ret = pandora_walk(argc - 1, argv + 1);
+    else if (strcmp(argv[1], "map") == 0)
+        ret = pandora_map(argc - 1, argv + 1);
+    else if (strcmp(argv[1], "compare") == 0)
+        ret = pandora_compare(argc - 1, argv + 1);
+    else if (strcmp(argv[1], "check_kmergraph") == 0)
+        ret = pandora_check_kmergraph(argc - 1, argv + 1);
+    else if (strcmp(argv[1], "get_vcf_ref") == 0)
+        ret = pandora_get_vcf_ref(argc - 1, argv + 1);
+    else if (strcmp(argv[1], "random_path") == 0)
+        ret = pandora_random_path(argc - 1, argv + 1);
+    else if (strcmp(argv[1], "merge_index") == 0)
+        ret = pandora_merge_index(argc - 1, argv + 1);
     else {
         fprintf(stderr, "[main] unrecognized command '%s'\n", argv[1]);
         return 1;

--- a/src/map_main.cpp
+++ b/src/map_main.cpp
@@ -1,5 +1,7 @@
 /*
- * C++ Program to find (w,k)-minimizer hits between a fasta of reads and a set of gene PRGs and output a gfa of genes that there is evidence have been traversed and the order they have been seen.
+ * C++ Program to find (w,k)-minimizer hits between a fasta of reads and a set of gene
+ * PRGs and output a gfa of genes that there is evidence have been traversed and the
+ * order they have been seen.
  */
 /*
  * To do:
@@ -8,65 +10,77 @@
  * 3. Command line argument handling for option of dumped_db screening
  * 4. Change structure so not copying minimzers etc, but use pointers
  */
-#include <iostream>
-#include <cstdlib>
-#include <vector>
-#include <set>
 #include <algorithm>
-#include <map>
 #include <cassert>
+#include <cstdlib>
+#include <iostream>
+#include <map>
+#include <set>
+#include <vector>
 
-#include "utils.h"
+#include "estimate_parameters.h"
+#include "index.h"
 #include "localPRG.h"
 #include "localgraph.h"
+#include "noise_filtering.h"
 #include "pangenome/pangraph.h"
 #include "pangenome/pannode.h"
-#include "index.h"
-#include "estimate_parameters.h"
-#include "noise_filtering.h"
+#include "utils.h"
 
-#include "denovo_discovery/denovo_utils.h"
 #include "denovo_discovery/denovo_discovery.h"
-
+#include "denovo_discovery/denovo_utils.h"
 
 using std::set;
 using std::vector;
 
 namespace fs = boost::filesystem;
 
-static void show_map_usage() {
-    std::cerr << "Usage: pandora map -p PRG_FILE -r READ_FILE <option(s)>\n"
-              << "Options:\n"
-              << "\t-h,--help\t\t\tShow this help message\n"
-              << "\t-p,--prg_file PRG_FILE\t\tSpecify a fasta-style prg file\n"
-              << "\t-r,--read_file READ_FILE\tSpecify a file of reads in fasta format\n"
-              << "\t-o,--outdir OUTDIR\tSpecify directory of output\n"
-              << "\t-w W\t\t\t\tWindow size for (w,k)-minimizers, must be <=k, default 14\n"
-              << "\t-k K\t\t\t\tK-mer size for (w,k)-minimizers, default 15\n"
-              << "\t-m,--max_diff INT\t\tMaximum distance between consecutive hits within a cluster, default 500 (bps)\n"
-              << "\t-e,--error_rate FLOAT\t\tEstimated error rate for reads, default 0.11\n"
-              << "\t-t T\t\t\t\tNumber of threads, default 1\n"
-              << "\t--genome_size\tNUM_BP\tEstimated length of genome, used for coverage estimation\n"
-              << "\t--output_kg\t\t\tSave kmer graphs with fwd and rev coverage annotations for found localPRGs\n"
-              << "\t--output_vcf\t\t\tSave a vcf file for each found localPRG\n"
-              << "\t--vcf_refs REF_FASTA\t\tA fasta file with an entry for each LocalPRG giving reference sequence for\n"
-              << "\t\t\t\t\tVCF. Must have a perfect match in the graph and the same name as the graph\n"
-              << "\t--output_comparison_paths\tSave a fasta file for a random selection of paths through localPRG\n"
-              << "\t--output_covgs\tSave a file of covgs for each localPRG present, one number per base of fasta file\n"
-              << "\t--output_mapped_read_fa\tSave a file for each gene containing read parts which overlapped it\n"
-              << "\t--illumina\t\t\tData is from illumina rather than nanopore, so is shorter with low error rate\n"
-              << "\t--clean\t\t\tAdd a step to clean and detangle the pangraph\n"
-              << "\t--bin\t\t\tUse binomial model for kmer coverages, default is negative binomial\n"
-              << "\t--max_covg\t\t\tMaximum average coverage from reads to accept\n"
-              << "\t--genotype\t\t\tAdd extra step to carefully genotype sites\n"
-              << "\t--snps_only\t\t\tWhen genotyping, include only snp sites\n"
-              << "\t-d,--discover\t\t\tAdd denovo discovery\n"
-              << "\t--denovo_kmer_size\t\t\tKmer size to use for denovo discovery\n"
-              << "\t--log_level\t\t\tdebug,[info],warning,error\n"
-              << std::endl;
+static void show_map_usage()
+{
+    std::cerr
+        << "Usage: pandora map -p PRG_FILE -r READ_FILE <option(s)>\n"
+        << "Options:\n"
+        << "\t-h,--help\t\t\tShow this help message\n"
+        << "\t-p,--prg_file PRG_FILE\t\tSpecify a fasta-style prg file\n"
+        << "\t-r,--read_file READ_FILE\tSpecify a file of reads in fasta format\n"
+        << "\t-o,--outdir OUTDIR\tSpecify directory of output\n"
+        << "\t-w W\t\t\t\tWindow size for (w,k)-minimizers, must be <=k, default 14\n"
+        << "\t-k K\t\t\t\tK-mer size for (w,k)-minimizers, default 15\n"
+        << "\t-m,--max_diff INT\t\tMaximum distance between consecutive hits within a "
+           "cluster, default 500 (bps)\n"
+        << "\t-e,--error_rate FLOAT\t\tEstimated error rate for reads, default 0.11\n"
+        << "\t-t T\t\t\t\tNumber of threads, default 1\n"
+        << "\t--genome_size\tNUM_BP\tEstimated length of genome, used for coverage "
+           "estimation\n"
+        << "\t--output_kg\t\t\tSave kmer graphs with fwd and rev coverage annotations "
+           "for found localPRGs\n"
+        << "\t--output_vcf\t\t\tSave a vcf file for each found localPRG\n"
+        << "\t--vcf_refs REF_FASTA\t\tA fasta file with an entry for each LocalPRG "
+           "giving reference sequence for\n"
+        << "\t\t\t\t\tVCF. Must have a perfect match in the graph and the same name as "
+           "the graph\n"
+        << "\t--output_comparison_paths\tSave a fasta file for a random selection of "
+           "paths through localPRG\n"
+        << "\t--output_covgs\tSave a file of covgs for each localPRG present, one "
+           "number per base of fasta file\n"
+        << "\t--output_mapped_read_fa\tSave a file for each gene containing read parts "
+           "which overlapped it\n"
+        << "\t--illumina\t\t\tData is from illumina rather than nanopore, so is "
+           "shorter with low error rate\n"
+        << "\t--clean\t\t\tAdd a step to clean and detangle the pangraph\n"
+        << "\t--bin\t\t\tUse binomial model for kmer coverages, default is negative "
+           "binomial\n"
+        << "\t--max_covg\t\t\tMaximum average coverage from reads to accept\n"
+        << "\t--genotype\t\t\tAdd extra step to carefully genotype sites\n"
+        << "\t--snps_only\t\t\tWhen genotyping, include only snp sites\n"
+        << "\t-d,--discover\t\t\tAdd denovo discovery\n"
+        << "\t--denovo_kmer_size\t\t\tKmer size to use for denovo discovery\n"
+        << "\t--log_level\t\t\tdebug,[info],warning,error\n"
+        << std::endl;
 }
 
-int pandora_map(int argc, char *argv[]) {
+int pandora_map(int argc, char* argv[])
+{
     // if not enough arguments, print usage
     if (argc < 5) {
         std::cerr << "only provided " << argc << "arguments" << std::endl;
@@ -75,13 +89,16 @@ int pandora_map(int argc, char *argv[]) {
     }
 
     // otherwise, parse the parameters from the command line
-    string prgfile, reads_filepath, outdir = "pandora", vcf_refs_file, log_level="info";
-    uint32_t w = 14, k = 15, min_cluster_size = 10, genome_size = 5000000, max_covg = 300, max_num_kmers_to_average=100,
-            min_allele_covg_gt = 0, min_total_covg_gt = 0, min_diff_covg_gt = 0, min_kmer_covg=0, threads=1; // default parameters
+    string prgfile, reads_filepath, outdir = "pandora", vcf_refs_file,
+                                    log_level = "info";
+    uint32_t w = 14, k = 15, min_cluster_size = 10, genome_size = 5000000,
+             max_covg = 300, max_num_kmers_to_average = 100, min_allele_covg_gt = 0,
+             min_total_covg_gt = 0, min_diff_covg_gt = 0, min_kmer_covg = 0,
+             threads = 1; // default parameters
     uint16_t confidence_threshold = 1;
-    uint_least8_t denovo_kmer_size{11};
+    uint_least8_t denovo_kmer_size { 11 };
     int max_diff = 250;
-    float e_rate = 0.11, min_allele_fraction_covg_gt = 0, genotyping_error_rate=0.01;
+    float e_rate = 0.11, min_allele_fraction_covg_gt = 0, genotyping_error_rate = 0.01;
     bool output_kg = false, output_vcf = false;
     bool output_comparison_paths = false, output_mapped_read_fa = false;
     bool illumina = false, clean = false;
@@ -94,56 +111,70 @@ int pandora_map(int argc, char *argv[]) {
             return 0;
         } else if ((arg == "-p") || (arg == "--prg_file")) {
             if (i + 1 < argc) { // Make sure we aren't at the end of argv!
-                prgfile = argv[++i]; // Increment 'i' so we don't get the argument as the next argv[i].
+                prgfile = argv[++i]; // Increment 'i' so we don't get the argument as
+                                     // the next argv[i].
             } else { // Uh-oh, there was no argument to the destination option.
                 std::cerr << "--prg_file option requires one argument." << std::endl;
                 return 1;
             }
         } else if ((arg == "-r") || (arg == "--read_file")) {
             if (i + 1 < argc) { // Make sure we aren't at the end of argv!
-                reads_filepath = argv[++i]; // Increment 'i' so we don't get the argument as the next argv[i].
+                reads_filepath = argv[++i]; // Increment 'i' so we don't get the
+                                            // argument as the next argv[i].
             } else { // Uh-oh, there was no argument to the destination option.
                 std::cerr << "--read_file option requires one argument." << std::endl;
                 return 1;
             }
         } else if ((arg == "-o") || (arg == "--outdir")) {
             if (i + 1 < argc) { // Make sure we aren't at the end of argv!
-                outdir = argv[++i]; // Increment 'i' so we don't get the argument as the next argv[i].
+                outdir = argv[++i]; // Increment 'i' so we don't get the argument as the
+                                    // next argv[i].
             } else { // Uh-oh, there was no argument to the destination option.
                 std::cerr << "--outdir option requires one argument." << std::endl;
                 return 1;
             }
         } else if (arg == "-w") {
             if (i + 1 < argc) { // Make sure we aren't at the end of argv!
-                w = strtoul(argv[++i], nullptr, 10); // Increment 'i' so we don't get the argument as the next argv[i].
+                w = strtoul(
+                    argv[++i], nullptr, 10); // Increment 'i' so we don't get the
+                                             // argument as the next argv[i].
             } else { // Uh-oh, there was no argument to the destination option.
                 std::cerr << "-w option requires one argument." << std::endl;
                 return 1;
             }
         } else if (arg == "-k") {
             if (i + 1 < argc) { // Make sure we aren't at the end of argv!
-                k = strtoul(argv[++i], nullptr, 10); // Increment 'i' so we don't get the argument as the next argv[i].
+                k = strtoul(
+                    argv[++i], nullptr, 10); // Increment 'i' so we don't get the
+                                             // argument as the next argv[i].
             } else { // Uh-oh, there was no argument to the destination option.
                 std::cerr << "-k option requires one argument." << std::endl;
                 return 1;
             }
         } else if ((arg == "-m") || (arg == "--max_diff")) {
             if (i + 1 < argc) { // Make sure we aren't at the end of argv!
-                max_diff = strtol(argv[++i], nullptr, 10); // Increment 'i' so we don't get the argument as the next argv[i].
+                max_diff = strtol(
+                    argv[++i], nullptr, 10); // Increment 'i' so we don't get the
+                                             // argument as the next argv[i].
             } else { // Uh-oh, there was no argument to the destination option.
                 std::cerr << "--max_diff option requires one argument." << std::endl;
                 return 1;
             }
         } else if ((arg == "-c") || (arg == "--min_cluster_size")) {
             if (i + 1 < argc) { // Make sure we aren't at the end of argv!
-                min_cluster_size = strtoul(argv[++i], nullptr, 10); // Increment 'i' so we don't get the argument as the next argv[i].
+                min_cluster_size = strtoul(
+                    argv[++i], nullptr, 10); // Increment 'i' so we don't get the
+                                             // argument as the next argv[i].
             } else { // Uh-oh, there was no argument to the destination option.
-                std::cerr << "--min_cluster_size option requires one argument." << std::endl;
+                std::cerr << "--min_cluster_size option requires one argument."
+                          << std::endl;
                 return 1;
             }
         } else if ((arg == "-e") || (arg == "--error_rate")) {
             if (i + 1 < argc) { // Make sure we aren't at the end of argv!
-                e_rate = strtof(argv[++i], nullptr); // Increment 'i' so we don't get the argument as the next argv[i].
+                e_rate
+                    = strtof(argv[++i], nullptr); // Increment 'i' so we don't get the
+                                                  // argument as the next argv[i].
                 if (e_rate < 0.01) {
                     illumina = true;
                 }
@@ -153,7 +184,9 @@ int pandora_map(int argc, char *argv[]) {
             }
         } else if ((arg == "--genome_size")) {
             if (i + 1 < argc) { // Make sure we aren't at the end of argv!
-                genome_size = strtoul(argv[++i], nullptr, 10); // Increment 'i' so we don't get the argument as the next argv[i].
+                genome_size = strtoul(
+                    argv[++i], nullptr, 10); // Increment 'i' so we don't get the
+                                             // argument as the next argv[i].
             } else { // Uh-oh, there was no argument to the destination option.
                 std::cerr << "--genome_size option requires one argument." << std::endl;
                 return 1;
@@ -164,7 +197,8 @@ int pandora_map(int argc, char *argv[]) {
             output_vcf = true;
         } else if (arg == "--vcf_refs") {
             if (i + 1 < argc) { // Make sure we aren't at the end of argv!
-                vcf_refs_file = argv[++i]; // Increment 'i' so we don't get the argument as the next argv[i].
+                vcf_refs_file = argv[++i]; // Increment 'i' so we don't get the argument
+                                           // as the next argv[i].
             } else { // Uh-oh, there was no argument to the destination option.
                 std::cerr << "--vcf_refs option requires one argument." << std::endl;
                 return 1;
@@ -186,65 +220,92 @@ int pandora_map(int argc, char *argv[]) {
             bin = true;
         } else if ((arg == "--max_covg")) {
             if (i + 1 < argc) { // Make sure we aren't at the end of argv!
-                max_covg = strtoul(argv[++i], nullptr, 10); // Increment 'i' so we don't get the argument as the next argv[i].
+                max_covg = strtoul(
+                    argv[++i], nullptr, 10); // Increment 'i' so we don't get the
+                                             // argument as the next argv[i].
             } else { // Uh-oh, there was no argument to the destination option.
                 std::cerr << "--max_covg option requires one argument." << std::endl;
                 return 1;
             }
         } else if ((arg == "--max_num_kmers_to_average")) {
             if (i + 1 < argc) { // Make sure we aren't at the end of argv!
-                max_num_kmers_to_average = strtoul(argv[++i], nullptr, 10); // Increment 'i' so we don't get the argument as the next argv[i].
+                max_num_kmers_to_average = strtoul(
+                    argv[++i], nullptr, 10); // Increment 'i' so we don't get the
+                                             // argument as the next argv[i].
             } else { // Uh-oh, there was no argument to the destination option.
-                std::cerr << "--max_num_kmers_to_average option requires one argument." << std::endl;
+                std::cerr << "--max_num_kmers_to_average option requires one argument."
+                          << std::endl;
                 return 1;
             }
         } else if ((arg == "--min_allele_covg_gt")) {
             if (i + 1 < argc) { // Make sure we aren't at the end of argv!
-                min_allele_covg_gt = strtoul(argv[++i], nullptr, 10); // Increment 'i' so we don't get the argument as the next argv[i].
+                min_allele_covg_gt = strtoul(
+                    argv[++i], nullptr, 10); // Increment 'i' so we don't get the
+                                             // argument as the next argv[i].
             } else { // Uh-oh, there was no argument to the destination option.
-                std::cerr << "--min_allele_covg_gt option requires one argument." << std::endl;
+                std::cerr << "--min_allele_covg_gt option requires one argument."
+                          << std::endl;
                 return 1;
             }
         } else if ((arg == "--min_total_covg_gt")) {
             if (i + 1 < argc) { // Make sure we aren't at the end of argv!
-                min_total_covg_gt = strtoul(argv[++i], nullptr, 10); // Increment 'i' so we don't get the argument as the next argv[i].
+                min_total_covg_gt = strtoul(
+                    argv[++i], nullptr, 10); // Increment 'i' so we don't get the
+                                             // argument as the next argv[i].
             } else { // Uh-oh, there was no argument to the destination option.
-                std::cerr << "--min_total_covg_gt option requires one argument." << std::endl;
+                std::cerr << "--min_total_covg_gt option requires one argument."
+                          << std::endl;
                 return 1;
             }
         } else if ((arg == "--min_diff_covg_gt")) {
             if (i + 1 < argc) { // Make sure we aren't at the end of argv!
-                min_diff_covg_gt = strtoul(argv[++i], nullptr, 10); // Increment 'i' so we don't get the argument as the next argv[i].
+                min_diff_covg_gt = strtoul(
+                    argv[++i], nullptr, 10); // Increment 'i' so we don't get the
+                                             // argument as the next argv[i].
             } else { // Uh-oh, there was no argument to the destination option.
-                std::cerr << "--min_diff_covg_gt option requires one argument." << std::endl;
+                std::cerr << "--min_diff_covg_gt option requires one argument."
+                          << std::endl;
                 return 1;
             }
         } else if ((arg == "--min_allele_fraction_covg_gt")) {
             if (i + 1 < argc) { // Make sure we aren't at the end of argv!
-                min_allele_fraction_covg_gt = strtof(argv[++i], nullptr); // Increment 'i' so we don't get the argument as the next argv[i].
+                min_allele_fraction_covg_gt
+                    = strtof(argv[++i], nullptr); // Increment 'i' so we don't get the
+                                                  // argument as the next argv[i].
             } else { // Uh-oh, there was no argument to the destination option.
-                std::cerr << "--min_allele_fraction_covg_gt option requires one argument." << std::endl;
+                std::cerr
+                    << "--min_allele_fraction_covg_gt option requires one argument."
+                    << std::endl;
                 return 1;
             }
         } else if ((arg == "--genotyping_error_rate")) {
             if (i + 1 < argc) { // Make sure we aren't at the end of argv!
-                genotyping_error_rate = strtof(argv[++i], nullptr); // Increment 'i' so we don't get the argument as the next argv[i].
+                genotyping_error_rate
+                    = strtof(argv[++i], nullptr); // Increment 'i' so we don't get the
+                                                  // argument as the next argv[i].
             } else { // Uh-oh, there was no argument to the destination option.
-                std::cerr << "--genotyping_error_rate option requires one argument." << std::endl;
+                std::cerr << "--genotyping_error_rate option requires one argument."
+                          << std::endl;
                 return 1;
             }
         } else if ((arg == "--confidence_threshold")) {
             if (i + 1 < argc) { // Make sure we aren't at the end of argv!
-                confidence_threshold = (uint16_t)strtoul(argv[++i], nullptr, 10); // Increment 'i' so we don't get the argument as the next argv[i].
+                confidence_threshold = (uint16_t)strtoul(
+                    argv[++i], nullptr, 10); // Increment 'i' so we don't get the
+                                             // argument as the next argv[i].
             } else { // Uh-oh, there was no argument to the destination option.
-                std::cerr << "--confidence_threshold option requires one argument." << std::endl;
+                std::cerr << "--confidence_threshold option requires one argument."
+                          << std::endl;
                 return 1;
             }
         } else if ((arg == "--denovo_kmer_size")) {
             if (i + 1 < argc) { // Make sure we aren't at the end of argv!
-                denovo_kmer_size = (uint_least8_t)strtoul(argv[++i], nullptr, 10); // Increment 'i' so we don't get the argument as the next argv[i].
+                denovo_kmer_size = (uint_least8_t)strtoul(
+                    argv[++i], nullptr, 10); // Increment 'i' so we don't get the
+                                             // argument as the next argv[i].
             } else { // Uh-oh, there was no argument to the destination option.
-                std::cerr << "--denovo_kmer_size option requires one argument." << std::endl;
+                std::cerr << "--denovo_kmer_size option requires one argument."
+                          << std::endl;
                 return 1;
             }
         } else if ((arg == "--genotype")) {
@@ -255,20 +316,22 @@ int pandora_map(int argc, char *argv[]) {
             discover_denovo = true;
         } else if ((arg == "--log_level")) {
             if (i + 1 < argc) { // Make sure we aren't at the end of argv!
-                log_level = argv[++i]; // Increment 'i' so we don't get the argument as the next argv[i].
+                log_level = argv[++i]; // Increment 'i' so we don't get the argument as
+                                       // the next argv[i].
             } else { // Uh-oh, there was no argument to the destination option.
                 std::cerr << "--log_level option requires one argument." << std::endl;
                 return 1;
             }
         } else if (arg == "-t") {
             if (i + 1 < argc) { // Make sure we aren't at the end of argv!
-                threads = strtoul(argv[++i], nullptr, 10); // Increment 'i' so we don't get the argument as the next argv[i].
+                threads = strtoul(
+                    argv[++i], nullptr, 10); // Increment 'i' so we don't get the
+                                             // argument as the next argv[i].
             } else { // Uh-oh, there was no argument to the destination option.
                 std::cerr << "-t option requires one argument." << std::endl;
                 return 1;
             }
-        }
-        else {
+        } else {
             cerr << argv[i] << " could not be attributed to any parameter" << endl;
         }
     }
@@ -283,10 +346,10 @@ int pandora_map(int argc, char *argv[]) {
         e_rate = 0.001;
     }
     if (illumina and max_diff > 200) {
-        max_diff = 2*k + 1;
+        max_diff = 2 * k + 1;
     }
 
-    //then run the programme...
+    // then run the programme...
     cout << "START: " << now() << endl;
     cout << "\nUsing parameters: " << endl;
     cout << "\tprgfile\t\t" << prgfile << endl;
@@ -313,7 +376,7 @@ int pandora_map(int argc, char *argv[]) {
     cout << "\tdenovo_kmer_size\t" << denovo_kmer_size << endl;
     cout << "\tlog_level\t" << log_level << endl << endl;
 
-    auto g_log_level{boost::log::trivial::info};
+    auto g_log_level { boost::log::trivial::info };
     if (log_level == "debug")
         g_log_level = boost::log::trivial::debug;
     boost::log::core::get()->set_filter(boost::log::trivial::severity >= g_log_level);
@@ -326,14 +389,17 @@ int pandora_map(int argc, char *argv[]) {
     auto index = std::make_shared<Index>();
     index->load(prgfile, w, k);
     std::vector<std::shared_ptr<LocalPRG>> prgs;
-    read_prg_file(prgs, prgfile); //load all PRGs, exactly like in the index step
-    load_PRG_kmergraphs(prgs, w, k, prgfile); //load all kmer-minimizer graphs built in the index step
+    read_prg_file(prgs, prgfile); // load all PRGs, exactly like in the index step
+    load_PRG_kmergraphs(
+        prgs, w, k, prgfile); // load all kmer-minimizer graphs built in the index step
 
-    cout << now() << "Constructing pangenome::Graph from read file (this will take a while)" << endl;
+    cout << now()
+         << "Constructing pangenome::Graph from read file (this will take a while)"
+         << endl;
     auto pangraph = std::make_shared<pangenome::Graph>();
-    uint32_t covg = pangraph_from_read_file(reads_filepath, pangraph, index, prgs, w, k, max_diff, e_rate,
-                                            min_cluster_size, genome_size, illumina, clean, max_covg, threads);
-
+    uint32_t covg
+        = pangraph_from_read_file(reads_filepath, pangraph, index, prgs, w, k, max_diff,
+            e_rate, min_cluster_size, genome_size, illumina, clean, max_covg, threads);
 
     if (pangraph->nodes.empty()) {
         cout << "Found non of the LocalPRGs in the reads." << endl;
@@ -341,7 +407,8 @@ int pandora_map(int argc, char *argv[]) {
         return 0;
     }
 
-    cout << now() << "Writing pangenome::Graph to file " << outdir << "/pandora.pangraph.gfa" << endl;
+    cout << now() << "Writing pangenome::Graph to file " << outdir
+         << "/pandora.pangraph.gfa" << endl;
     write_pangraph_gfa(outdir + "/pandora.pangraph.gfa", pangraph);
 
     cout << now() << "Update LocalPRGs with hits" << endl;
@@ -349,71 +416,72 @@ int pandora_map(int argc, char *argv[]) {
     pangraph->add_hits_to_kmergraphs(prgs);
 
     cout << now() << "Estimate parameters for kmer graph model" << endl;
-    auto exp_depth_covg = estimate_parameters(pangraph, outdir, k, e_rate, covg, bin, sample_id);
+    auto exp_depth_covg
+        = estimate_parameters(pangraph, outdir, k, e_rate, covg, bin, sample_id);
     if (min_kmer_covg == 0)
-        min_kmer_covg = exp_depth_covg/10;
+        min_kmer_covg = exp_depth_covg / 10;
 
     std::cout << now() << "Find PRG paths and write to files:" << std::endl;
 
-
-
-    //paralell region!
-    //shared variable - synced with critical(consensus_fq)
+    // paralell region!
+    // shared variable - synced with critical(consensus_fq)
     Fastaq consensus_fq(true, true);
 
-    //shared variable - synced with critical(master_vcf)
+    // shared variable - synced with critical(master_vcf)
     VCF master_vcf;
 
-    //shared variable - synced with critical(candidate_regions)
+    // shared variable - synced with critical(candidate_regions)
     CandidateRegions candidate_regions;
 
-    //shared variable - will denote which nodes we have to remove after the parallel loop
-    //synced with critical(nodes_to_remove)
+    // shared variable - will denote which nodes we have to remove after the parallel
+    // loop synced with critical(nodes_to_remove)
     std::vector<pangenome::NodePtr> nodes_to_remove;
     nodes_to_remove.reserve(pangraph->nodes.size());
 
-    //this a read-only var, no need for sync
+    // this a read-only var, no need for sync
     VCFRefs vcf_refs;
     if (output_vcf and !vcf_refs_file.empty()) {
         vcf_refs.reserve(prgs.size());
         load_vcf_refs_file(vcf_refs_file, vcf_refs);
     }
 
-    //transforms the pangraph->nodes from map to vector so that we can run it in parallel
-    //TODO: use OMP task instead?
+    // transforms the pangraph->nodes from map to vector so that we can run it in
+    // parallel
+    // TODO: use OMP task instead?
     std::vector<pangenome::NodePtr> pangraphNodesAsVector;
     pangraphNodesAsVector.reserve(pangraph->nodes.size());
-    for (auto pan_id_to_node_mapping = pangraph->nodes.begin(); pan_id_to_node_mapping != pangraph->nodes.end(); ++pan_id_to_node_mapping)
+    for (auto pan_id_to_node_mapping = pangraph->nodes.begin();
+         pan_id_to_node_mapping != pangraph->nodes.end(); ++pan_id_to_node_mapping)
         pangraphNodesAsVector.push_back(pan_id_to_node_mapping->second);
 
-    //TODO: check the batch size
-    #pragma omp parallel for num_threads(threads) schedule(dynamic, 10)
+// TODO: check the batch size
+#pragma omp parallel for num_threads(threads) schedule(dynamic, 10)
     for (uint32_t i = 0; i < pangraphNodesAsVector.size(); ++i) {
-        //add some progress
-        if (i && i%100==0)
-            BOOST_LOG_TRIVIAL(info) << ((double)i)/pangraphNodesAsVector.size()*100 << "% done";
+        // add some progress
+        if (i && i % 100 == 0)
+            BOOST_LOG_TRIVIAL(info)
+                << ((double)i) / pangraphNodesAsVector.size() * 100 << "% done";
 
-        //get the node
-        const auto &pangraph_node = pangraphNodesAsVector[i];
+        // get the node
+        const auto& pangraph_node = pangraphNodesAsVector[i];
 
-        //get the vcf_ref, if applicable
+        // get the vcf_ref, if applicable
         std::string vcf_ref;
-        if (output_vcf
-            and !vcf_refs_file.empty()
+        if (output_vcf and !vcf_refs_file.empty()
             and vcf_refs.find(prgs[pangraph_node->prg_id]->name) != vcf_refs.end()) {
             vcf_ref = vcf_refs[prgs[pangraph_node->prg_id]->name];
         }
 
-        //add consensus path to fastaq
+        // add consensus path to fastaq
         std::vector<KmerNodePtr> kmp;
         std::vector<LocalNodePtr> lmp;
-        prgs[pangraph_node->prg_id]->add_consensus_path_to_fastaq(consensus_fq, pangraph_node, kmp, lmp, w, bin, covg,
-                                                                  max_num_kmers_to_average, 0);
+        prgs[pangraph_node->prg_id]->add_consensus_path_to_fastaq(consensus_fq,
+            pangraph_node, kmp, lmp, w, bin, covg, max_num_kmers_to_average, 0);
 
         if (kmp.empty()) {
-            //pan_id_to_node_mapping = pangraph->remove_node(pangraph_node);
-            //mark the node as to remove
-            #pragma omp critical(nodes_to_remove)
+// pan_id_to_node_mapping = pangraph->remove_node(pangraph_node);
+// mark the node as to remove
+#pragma omp critical(nodes_to_remove)
             {
                 nodes_to_remove.push_back(pangraph_node);
             }
@@ -421,74 +489,86 @@ int pandora_map(int argc, char *argv[]) {
         }
 
         if (output_kg) {
-            pangraph_node->kmer_prg_with_coverage.save(outdir + "/kmer_graphs/" + pangraph_node->get_name() + ".kg.gfa",
-                                     prgs[pangraph_node->prg_id]);
+            pangraph_node->kmer_prg_with_coverage.save(
+                outdir + "/kmer_graphs/" + pangraph_node->get_name() + ".kg.gfa",
+                prgs[pangraph_node->prg_id]);
         }
 
         if (output_vcf) {
-            //TODO: this takes a lot of time and should be optimized, but it is only called in this part, so maybe this should be low prioritized
-            prgs[pangraph_node->prg_id]->add_variants_to_vcf(master_vcf, pangraph_node, vcf_ref, kmp, lmp, min_kmer_covg);
+            // TODO: this takes a lot of time and should be optimized, but it is only
+            // called in this part, so maybe this should be low prioritized
+            prgs[pangraph_node->prg_id]->add_variants_to_vcf(
+                master_vcf, pangraph_node, vcf_ref, kmp, lmp, min_kmer_covg);
         }
 
         if (discover_denovo) {
-            const TmpPanNode pangraph_node_components {pangraph_node, prgs[pangraph_node->prg_id], kmp, lmp};
-            auto candidate_regions_for_pan_node { find_candidate_regions_for_pan_node(pangraph_node_components, denovo_kmer_size * 2) };
+            const TmpPanNode pangraph_node_components { pangraph_node,
+                prgs[pangraph_node->prg_id], kmp, lmp };
+            auto candidate_regions_for_pan_node { find_candidate_regions_for_pan_node(
+                pangraph_node_components, denovo_kmer_size * 2) };
 
-            #pragma omp critical(candidate_regions)
+#pragma omp critical(candidate_regions)
             {
-                candidate_regions.insert(candidate_regions_for_pan_node.begin(), candidate_regions_for_pan_node.end());
+                candidate_regions.insert(candidate_regions_for_pan_node.begin(),
+                    candidate_regions_for_pan_node.end());
             }
         }
     }
 
-    //build the pileup for candidate regions multithreadly
+    // build the pileup for candidate regions multithreadly
     if (discover_denovo) {
-        //the construct_pileup_construction_map function is intentionally left single threaded since it would require too much synchronization
-        const auto pileup_construction_map = construct_pileup_construction_map(candidate_regions);
+        // the construct_pileup_construction_map function is intentionally left single
+        // threaded since it would require too much synchronization
+        const auto pileup_construction_map
+            = construct_pileup_construction_map(candidate_regions);
 
-        load_all_candidate_regions_pileups_from_fastq(reads_filepath, candidate_regions, pileup_construction_map, threads);
+        load_all_candidate_regions_pileups_from_fastq(
+            reads_filepath, candidate_regions, pileup_construction_map, threads);
     }
 
-
-
-
-    //remove the nodes marked as to be removed
-    for (const auto &node_to_remove : nodes_to_remove)
+    // remove the nodes marked as to be removed
+    for (const auto& node_to_remove : nodes_to_remove)
         pangraph->remove_node(node_to_remove);
 
     consensus_fq.save(outdir + "/pandora.consensus.fq.gz");
     if (output_vcf)
-        master_vcf.save(outdir + "/pandora_consensus.vcf", true, true, true, true, true, true, true);
+        master_vcf.save(outdir + "/pandora_consensus.vcf", true, true, true, true, true,
+            true, true);
 
     if (pangraph->nodes.empty()) {
-        std::cout << "All nodes which were found have been removed during cleaning. Is your genome_size accurate?"
-             << " Genome size is assumed to be " << genome_size << " and can be updated with --genome_size" << std::endl
-             << "FINISH: " << now() << std::endl;
+        std::cout << "All nodes which were found have been removed during cleaning. Is "
+                     "your genome_size accurate?"
+                  << " Genome size is assumed to be " << genome_size
+                  << " and can be updated with --genome_size" << std::endl
+                  << "FINISH: " << now() << std::endl;
         return 0;
     }
 
-
     if (genotype) {
-        std::vector<uint32_t> exp_depth_covgs = {exp_depth_covg};
-        master_vcf.genotype(exp_depth_covgs, genotyping_error_rate, confidence_threshold, min_allele_covg_gt, min_allele_fraction_covg_gt,
-                            min_total_covg_gt, min_diff_covg_gt, snps_only);
+        std::vector<uint32_t> exp_depth_covgs = { exp_depth_covg };
+        master_vcf.genotype(exp_depth_covgs, genotyping_error_rate,
+            confidence_threshold, min_allele_covg_gt, min_allele_fraction_covg_gt,
+            min_total_covg_gt, min_diff_covg_gt, snps_only);
         if (snps_only)
-            master_vcf.save(outdir + "/pandora_genotyped.vcf", true, true, true, true, false, false, false);
+            master_vcf.save(outdir + "/pandora_genotyped.vcf", true, true, true, true,
+                false, false, false);
         else
-            master_vcf.save(outdir + "/pandora_genotyped.vcf", true, true, true, true, true, true, true);
+            master_vcf.save(outdir + "/pandora_genotyped.vcf", true, true, true, true,
+                true, true, true);
     }
 
     if (discover_denovo) {
         DenovoDiscovery denovo { denovo_kmer_size, e_rate };
-        const fs::path denovo_output_directory {fs::path(outdir) / "denovo_paths"};
+        const fs::path denovo_output_directory { fs::path(outdir) / "denovo_paths" };
 
-        for (auto &element : candidate_regions) {
-            auto &candidate_region {element.second};
-            denovo.find_paths_through_candidate_region(candidate_region); //TODO: this is hard to parallelize due to GATB's temp files
+        for (auto& element : candidate_regions) {
+            auto& candidate_region { element.second };
+            denovo.find_paths_through_candidate_region(
+                candidate_region); // TODO: this is hard to parallelize due to GATB's
+                                   // temp files
             candidate_region.write_denovo_paths_to_file(denovo_output_directory);
         }
     }
-
 
     if (output_mapped_read_fa)
         pangraph->save_mapped_read_strings(reads_filepath, outdir);
@@ -496,4 +576,3 @@ int pandora_map(int argc, char *argv[]) {
     std::cout << "FINISH: " << now() << "\n";
     return 0;
 }
-

--- a/src/merge_index_main.cpp
+++ b/src/merge_index_main.cpp
@@ -1,25 +1,23 @@
 #include <cstring>
-#include <vector>
-#include <iostream>
 #include <fstream>
+#include <iostream>
+#include <vector>
 
 #include <boost/filesystem.hpp>
 #include <boost/log/trivial.hpp>
 
-#include "utils.h"
 #include "localPRG.h"
+#include "utils.h"
 
-
-
-
-static void show_index_usage() {
+static void show_index_usage()
+{
     std::cerr << "Usage: pandora merge_index <index1> <index2> ...\n"
               << "Options:\n"
               << "\t--outfile\t\t\t\tFilename for merged index\n"
               << std::endl;
 }
 
-int pandora_merge_index(int argc, char *argv[]) // the "pandora merge_index" comand
+int pandora_merge_index(int argc, char* argv[]) // the "pandora merge_index" comand
 {
     // if not enough arguments, print usage
     if (argc < 2) {
@@ -37,8 +35,9 @@ int pandora_merge_index(int argc, char *argv[]) // the "pandora merge_index" com
             return 0;
         } else if (arg == "--outfile") {
             if (i + 1 < argc) { // Make sure we aren't at the end of argv!
-                outfile = argv[++i]; // Increment 'i' so we don't get the argument as the next argv[i].
-            } else {// Uh-oh, there was no argument to the destination option.
+                outfile = argv[++i]; // Increment 'i' so we don't get the argument as
+                                     // the next argv[i].
+            } else { // Uh-oh, there was no argument to the destination option.
                 std::cerr << "--outfile option requires one argument." << std::endl;
                 return 1;
             }
@@ -47,13 +46,12 @@ int pandora_merge_index(int argc, char *argv[]) // the "pandora merge_index" com
         }
     }
 
-
     boost::filesystem::path p(outfile);
     boost::filesystem::path dir = p.parent_path();
 
     // merge indexes
     auto index = std::make_shared<Index>();
-    for (const auto& new_index : indexes){
+    for (const auto& new_index : indexes) {
         index->load(new_index);
     }
 
@@ -62,4 +60,3 @@ int pandora_merge_index(int argc, char *argv[]) // the "pandora merge_index" com
 
     return 0;
 }
-

--- a/src/minihit.cpp
+++ b/src/minihit.cpp
@@ -1,65 +1,101 @@
+#include "minihit.h"
+#include "minirecord.h"
+#include "prg/path.h"
+#include <algorithm>
 #include <cassert>
 #include <functional>
 #include <iostream>
 #include <limits>
-#include <algorithm>
-#include "minirecord.h"
-#include "minihit.h"
-#include "prg/path.h"
-
 
 #define assert_msg(x) !(std::cerr << "Assertion failed: " << x << std::endl)
 
-MinimizerHit::MinimizerHit(const uint32_t i, const Minimizer &minimizer_from_read, const MiniRecord &minimizer_from_PRG) :
-        read_id{i}, read_start_position{minimizer_from_read.pos_of_kmer_in_read.start}, read_strand{minimizer_from_read.is_forward_strand}, minimizer_from_PRG{minimizer_from_PRG}{
+MinimizerHit::MinimizerHit(const uint32_t i, const Minimizer& minimizer_from_read,
+    const MiniRecord& minimizer_from_PRG)
+    : read_id { i }
+    , read_start_position { minimizer_from_read.pos_of_kmer_in_read.start }
+    , read_strand { minimizer_from_read.is_forward_strand }
+    , minimizer_from_PRG { minimizer_from_PRG }
+{
 
-    assert(minimizer_from_read.pos_of_kmer_in_read.length == minimizer_from_PRG.path.length());
-    assert(read_id < std::numeric_limits<uint32_t>::max() ||
-           assert_msg("Variable sizes too small to handle this number of reads"));
-    assert(minimizer_from_PRG.prg_id < std::numeric_limits<uint32_t>::max() ||
-           assert_msg("Variable sizes too small to handle this number of prgs"));
-    assert(minimizer_from_read.pos_of_kmer_in_read.length == minimizer_from_PRG.path.length());
+    assert(minimizer_from_read.pos_of_kmer_in_read.length
+        == minimizer_from_PRG.path.length());
+    assert(read_id < std::numeric_limits<uint32_t>::max()
+        || assert_msg("Variable sizes too small to handle this number of reads"));
+    assert(minimizer_from_PRG.prg_id < std::numeric_limits<uint32_t>::max()
+        || assert_msg("Variable sizes too small to handle this number of prgs"));
+    assert(minimizer_from_read.pos_of_kmer_in_read.length
+        == minimizer_from_PRG.path.length());
 }
 
-
-bool MinimizerHit::operator==(const MinimizerHit &y) const {
-    if (get_read_id() != y.get_read_id()) { return false; }
-    if (!(get_read_start_position() == y.get_read_start_position())) { return false; }
-    if (get_prg_id() != y.get_prg_id()) { return false; }
-    if (!(get_prg_path() == y.get_prg_path())) { return false; }
-    if (is_forward() != y.is_forward()) { return false; }
+bool MinimizerHit::operator==(const MinimizerHit& y) const
+{
+    if (get_read_id() != y.get_read_id()) {
+        return false;
+    }
+    if (!(get_read_start_position() == y.get_read_start_position())) {
+        return false;
+    }
+    if (get_prg_id() != y.get_prg_id()) {
+        return false;
+    }
+    if (!(get_prg_path() == y.get_prg_path())) {
+        return false;
+    }
+    if (is_forward() != y.is_forward()) {
+        return false;
+    }
     return true;
 }
 
-
-bool MinimizerHit::operator<(const MinimizerHit &y) const {
+bool MinimizerHit::operator<(const MinimizerHit& y) const
+{
     // first by the read they map too - should all be the same
-    if (get_read_id() < y.get_read_id()) { return true; }
-    if (y.get_read_id() < get_read_id()) { return false; }
+    if (get_read_id() < y.get_read_id()) {
+        return true;
+    }
+    if (y.get_read_id() < get_read_id()) {
+        return false;
+    }
 
     // then by the prg they map too
-    if (get_prg_id() < y.get_prg_id()) { return true; }
-    if (y.get_prg_id() < get_prg_id()) { return false; }
+    if (get_prg_id() < y.get_prg_id()) {
+        return true;
+    }
+    if (y.get_prg_id() < get_prg_id()) {
+        return false;
+    }
 
     // then by direction NB this bias is in favour of the forward direction
-    if (is_forward() < y.is_forward()) { return false; }
-    if (y.is_forward() < is_forward()) { return true; }
+    if (is_forward() < y.is_forward()) {
+        return false;
+    }
+    if (y.is_forward() < is_forward()) {
+        return true;
+    }
 
     // then by position on query string
-    if (get_read_start_position() < y.get_read_start_position()) { return true; }
-    if (y.get_read_start_position() < get_read_start_position()) { return false; }
+    if (get_read_start_position() < y.get_read_start_position()) {
+        return true;
+    }
+    if (y.get_read_start_position() < get_read_start_position()) {
+        return false;
+    }
 
     // then by position on target string
-    if (get_prg_path() < y.get_prg_path()) { return true; }
-    if (y.get_prg_path() < get_prg_path()) { return false; }
+    if (get_prg_path() < y.get_prg_path()) {
+        return true;
+    }
+    if (y.get_prg_path() < get_prg_path()) {
+        return false;
+    }
 
     return false;
 }
 
-
-std::ostream &operator<<(std::ostream &out, MinimizerHit const &m) {
-    out << "(" << m.get_read_id() << ", " << m.get_read_start_position() << ", " << m.get_prg_id() << ", " << m.get_prg_path() << ", "
-        << m.is_forward() << ", " << m.get_kmer_node_id() << ")";
+std::ostream& operator<<(std::ostream& out, MinimizerHit const& m)
+{
+    out << "(" << m.get_read_id() << ", " << m.get_read_start_position() << ", "
+        << m.get_prg_id() << ", " << m.get_prg_path() << ", " << m.is_forward() << ", "
+        << m.get_kmer_node_id() << ")";
     return out;
 }
-

--- a/src/minihits.cpp
+++ b/src/minihits.cpp
@@ -1,32 +1,36 @@
+#include "minihits.h"
+#include "minihit.h"
+#include "minimizer.h"
+#include "minirecord.h"
+#include "utils.h" // for pointer_values_equal
 #include <cassert>
 #include <functional>
 #include <iostream>
-#include <sstream>
 #include <memory>
-#include "minihits.h"
-#include "minihit.h"
-#include "minirecord.h"
-#include "minimizer.h"
-#include "utils.h" // for pointer_values_equal
-
+#include <sstream>
 
 #define assert_msg(x) !(std::cerr << "Assertion failed: " << x << std::endl)
 
-void MinimizerHits::add_hit(const uint32_t i, const Minimizer &minimizer_from_read, const MiniRecord &minimizer_from_PRG) {
-    MinimizerHitPtr mh(std::make_shared<MinimizerHit>(i, minimizer_from_read, minimizer_from_PRG));
+void MinimizerHits::add_hit(const uint32_t i, const Minimizer& minimizer_from_read,
+    const MiniRecord& minimizer_from_PRG)
+{
+    MinimizerHitPtr mh(
+        std::make_shared<MinimizerHit>(i, minimizer_from_read, minimizer_from_PRG));
     hits.insert(mh);
 }
 
 /*std::ostream& operator<< (std::ostream & out, MinimizerHits const& m) {
-    out << "(" << m.read_id << ", " << m.read_start_position << ", " << m.prg_id << ", " << m.prg_path << ", " << strand << ")";
-    return out ;
+    out << "(" << m.read_id << ", " << m.read_start_position << ", " << m.prg_id << ", "
+<< m.prg_path << ", " << strand << ")"; return out ;
 }*/
 
-bool pComp::operator()(const MinimizerHitPtr &lhs, const MinimizerHitPtr &rhs) {
+bool pComp::operator()(const MinimizerHitPtr& lhs, const MinimizerHitPtr& rhs)
+{
     return (*lhs) < (*rhs);
 }
 
-bool pEq::operator()(const MinimizerHitPtr &lhs, const MinimizerHitPtr &rhs) const {
+bool pEq::operator()(const MinimizerHitPtr& lhs, const MinimizerHitPtr& rhs) const
+{
     return *lhs == *rhs;
 }
 
@@ -39,52 +43,131 @@ bool pEq::operator()(const MinimizerHitPtr &lhs, const MinimizerHitPtr &rhs) con
     return hash<string>()(temp);
 }*/
 
-bool pComp_path::operator()(const MinimizerHitPtr &lhs, const MinimizerHitPtr &rhs) {
+bool pComp_path::operator()(const MinimizerHitPtr& lhs, const MinimizerHitPtr& rhs)
+{
     // should be same id
-    if (lhs->get_prg_id() < rhs->get_prg_id()) { return true; }
-    if (rhs->get_prg_id() < lhs->get_prg_id()) { return false; }
-    //want those that match against the same prg_path together
-    if (lhs->get_prg_path() < rhs->get_prg_path()) { return true; }
-    if (rhs->get_prg_path() < lhs->get_prg_path()) { return false; }
-    //separated into two categories, corresponding to a forward, and a rev-complement hit, note fwd come first
-    if (lhs->is_forward() > rhs->is_forward()) { return true; }
-    if (rhs->is_forward() > lhs->is_forward()) { return false; }
-    // finally, make sure that hits from separate reads aren't removed from the set as "=="
-    if (lhs->get_read_id() < rhs->get_read_id()) { return true; }
-    if (rhs->get_read_id() < lhs->get_read_id()) { return false; }
-    if (lhs->get_read_start_position() < rhs->get_read_start_position()) { return true; }
-    if (rhs->get_read_start_position() < lhs->get_read_start_position()) { return false; }
+    if (lhs->get_prg_id() < rhs->get_prg_id()) {
+        return true;
+    }
+    if (rhs->get_prg_id() < lhs->get_prg_id()) {
+        return false;
+    }
+    // want those that match against the same prg_path together
+    if (lhs->get_prg_path() < rhs->get_prg_path()) {
+        return true;
+    }
+    if (rhs->get_prg_path() < lhs->get_prg_path()) {
+        return false;
+    }
+    // separated into two categories, corresponding to a forward, and a rev-complement
+    // hit, note fwd come first
+    if (lhs->is_forward() > rhs->is_forward()) {
+        return true;
+    }
+    if (rhs->is_forward() > lhs->is_forward()) {
+        return false;
+    }
+    // finally, make sure that hits from separate reads aren't removed from the set as
+    // "=="
+    if (lhs->get_read_id() < rhs->get_read_id()) {
+        return true;
+    }
+    if (rhs->get_read_id() < lhs->get_read_id()) {
+        return false;
+    }
+    if (lhs->get_read_start_position() < rhs->get_read_start_position()) {
+        return true;
+    }
+    if (rhs->get_read_start_position() < lhs->get_read_start_position()) {
+        return false;
+    }
     return false;
 }
 
-bool clusterComp::operator()(const MinimizerHitCluster lhs, const MinimizerHitCluster rhs) {
-    if ((*lhs.begin())->get_read_id() < (*rhs.begin())->get_read_id()) { return true; }
-    if ((*rhs.begin())->get_read_id() < (*lhs.begin())->get_read_id()) { return false; }
-    if ((*lhs.begin())->get_read_start_position() < (*rhs.begin())->get_read_start_position()) { return true; }
-    if ((*rhs.begin())->get_read_start_position() < (*lhs.begin())->get_read_start_position()) { return false; }
-    if (lhs.size() > rhs.size()) { return true; } // want bigger first!
-    if (rhs.size() > lhs.size()) { return false; }
-    if ((*lhs.begin())->get_prg_id() < (*rhs.begin())->get_prg_id()) { return true; }
-    if ((*rhs.begin())->get_prg_id() < (*lhs.begin())->get_prg_id()) { return false; }
-    if ((*lhs.begin())->get_prg_path() < (*rhs.begin())->get_prg_path()) { return true; }
-    if ((*rhs.begin())->get_prg_path() < (*lhs.begin())->get_prg_path()) { return false; }
-    if ((*lhs.begin())->is_forward() < (*rhs.begin())->is_forward()) { return true; }
-    if ((*rhs.begin())->is_forward() < (*lhs.begin())->is_forward()) { return false; }
+bool clusterComp::operator()(
+    const MinimizerHitCluster lhs, const MinimizerHitCluster rhs)
+{
+    if ((*lhs.begin())->get_read_id() < (*rhs.begin())->get_read_id()) {
+        return true;
+    }
+    if ((*rhs.begin())->get_read_id() < (*lhs.begin())->get_read_id()) {
+        return false;
+    }
+    if ((*lhs.begin())->get_read_start_position()
+        < (*rhs.begin())->get_read_start_position()) {
+        return true;
+    }
+    if ((*rhs.begin())->get_read_start_position()
+        < (*lhs.begin())->get_read_start_position()) {
+        return false;
+    }
+    if (lhs.size() > rhs.size()) {
+        return true;
+    } // want bigger first!
+    if (rhs.size() > lhs.size()) {
+        return false;
+    }
+    if ((*lhs.begin())->get_prg_id() < (*rhs.begin())->get_prg_id()) {
+        return true;
+    }
+    if ((*rhs.begin())->get_prg_id() < (*lhs.begin())->get_prg_id()) {
+        return false;
+    }
+    if ((*lhs.begin())->get_prg_path() < (*rhs.begin())->get_prg_path()) {
+        return true;
+    }
+    if ((*rhs.begin())->get_prg_path() < (*lhs.begin())->get_prg_path()) {
+        return false;
+    }
+    if ((*lhs.begin())->is_forward() < (*rhs.begin())->is_forward()) {
+        return true;
+    }
+    if ((*rhs.begin())->is_forward() < (*lhs.begin())->is_forward()) {
+        return false;
+    }
     return false;
 }
 
-bool clusterComp_size::operator()(const MinimizerHitCluster lhs, const MinimizerHitCluster rhs) {
-    if ((*lhs.begin())->get_read_id() < (*rhs.begin())->get_read_id()) { return true; }
-    if ((*rhs.begin())->get_read_id() < (*lhs.begin())->get_read_id()) { return false; }
-    if (lhs.size() > rhs.size()) { return true; }
-    if (rhs.size() > lhs.size()) { return false; }
-    if ((*lhs.begin())->get_read_start_position() < (*rhs.begin())->get_read_start_position()) { return true; }
-    if ((*rhs.begin())->get_read_start_position() < (*lhs.begin())->get_read_start_position()) { return false; }
-    if ((*lhs.begin())->get_prg_id() < (*rhs.begin())->get_prg_id()) { return true; }
-    if ((*rhs.begin())->get_prg_id() < (*lhs.begin())->get_prg_id()) { return false; }
-    if ((*lhs.begin())->get_prg_path() < (*rhs.begin())->get_prg_path()) { return true; }
-    if ((*rhs.begin())->get_prg_path() < (*lhs.begin())->get_prg_path()) { return false; }
-    if ((*lhs.begin())->is_forward() < (*rhs.begin())->is_forward()) { return true; }
-    if ((*rhs.begin())->is_forward() < (*lhs.begin())->is_forward()) { return false; }
+bool clusterComp_size::operator()(
+    const MinimizerHitCluster lhs, const MinimizerHitCluster rhs)
+{
+    if ((*lhs.begin())->get_read_id() < (*rhs.begin())->get_read_id()) {
+        return true;
+    }
+    if ((*rhs.begin())->get_read_id() < (*lhs.begin())->get_read_id()) {
+        return false;
+    }
+    if (lhs.size() > rhs.size()) {
+        return true;
+    }
+    if (rhs.size() > lhs.size()) {
+        return false;
+    }
+    if ((*lhs.begin())->get_read_start_position()
+        < (*rhs.begin())->get_read_start_position()) {
+        return true;
+    }
+    if ((*rhs.begin())->get_read_start_position()
+        < (*lhs.begin())->get_read_start_position()) {
+        return false;
+    }
+    if ((*lhs.begin())->get_prg_id() < (*rhs.begin())->get_prg_id()) {
+        return true;
+    }
+    if ((*rhs.begin())->get_prg_id() < (*lhs.begin())->get_prg_id()) {
+        return false;
+    }
+    if ((*lhs.begin())->get_prg_path() < (*rhs.begin())->get_prg_path()) {
+        return true;
+    }
+    if ((*rhs.begin())->get_prg_path() < (*lhs.begin())->get_prg_path()) {
+        return false;
+    }
+    if ((*lhs.begin())->is_forward() < (*rhs.begin())->is_forward()) {
+        return true;
+    }
+    if ((*rhs.begin())->is_forward() < (*lhs.begin())->is_forward()) {
+        return false;
+    }
     return false;
 }

--- a/src/minimizer.cpp
+++ b/src/minimizer.cpp
@@ -1,46 +1,78 @@
-#include <iostream>
+#include "minimizer.h"
+#include "interval.h"
+#include "prg/path.h"
 #include <cassert>
 #include <cmath>
-#include "minimizer.h"
-#include "prg/path.h"
-#include "interval.h"
+#include <iostream>
 
-
-Minimizer::Minimizer(uint64_t s, uint32_t a, uint32_t b, bool c) : canonical_kmer_hash(s), pos_of_kmer_in_read(Interval(a, b)), is_forward_strand(c) {
-    assert(s <= pow(4, pos_of_kmer_in_read.length)); // used to check kmer length same as interval length.
-    // Can't any more but at least know if s is too big for a kmer of interval size to have generated it.
+Minimizer::Minimizer(uint64_t s, uint32_t a, uint32_t b, bool c)
+    : canonical_kmer_hash(s)
+    , pos_of_kmer_in_read(Interval(a, b))
+    , is_forward_strand(c)
+{
+    assert(s <= pow(4, pos_of_kmer_in_read.length)); // used to check kmer length same
+                                                     // as interval length.
+    // Can't any more but at least know if s is too big for a kmer of interval size to
+    // have generated it.
 }
 
-Minimizer::~Minimizer() {
-    //if (path != NULL) {delete path;}
+Minimizer::~Minimizer()
+{
+    // if (path != NULL) {delete path;}
 }
 
-bool Minimizer::operator<(const Minimizer &y) const {
-    if (canonical_kmer_hash < y.canonical_kmer_hash) { return true; }
-    if (y.canonical_kmer_hash < canonical_kmer_hash) { return false; }
+bool Minimizer::operator<(const Minimizer& y) const
+{
+    if (canonical_kmer_hash < y.canonical_kmer_hash) {
+        return true;
+    }
+    if (y.canonical_kmer_hash < canonical_kmer_hash) {
+        return false;
+    }
 
-    if (pos_of_kmer_in_read.start < y.pos_of_kmer_in_read.start) { return true; }
-    if (y.pos_of_kmer_in_read.start < pos_of_kmer_in_read.start) { return false; }
+    if (pos_of_kmer_in_read.start < y.pos_of_kmer_in_read.start) {
+        return true;
+    }
+    if (y.pos_of_kmer_in_read.start < pos_of_kmer_in_read.start) {
+        return false;
+    }
 
-    if (pos_of_kmer_in_read.length < y.pos_of_kmer_in_read.length) { return true; }
-    if (y.pos_of_kmer_in_read.length < pos_of_kmer_in_read.length) { return false; }
+    if (pos_of_kmer_in_read.length < y.pos_of_kmer_in_read.length) {
+        return true;
+    }
+    if (y.pos_of_kmer_in_read.length < pos_of_kmer_in_read.length) {
+        return false;
+    }
 
-    if (is_forward_strand < y.is_forward_strand) { return false; }
-    if (y.is_forward_strand < is_forward_strand) { return true; }
+    if (is_forward_strand < y.is_forward_strand) {
+        return false;
+    }
+    if (y.is_forward_strand < is_forward_strand) {
+        return true;
+    }
 
     // if both are completely equal (based on strict weak ordering)
     // then just return false since equality doesn't yield less than
     return false;
 }
 
-bool Minimizer::operator==(const Minimizer &y) const {
-    if (canonical_kmer_hash != y.canonical_kmer_hash) { return false; }
-    if (!(pos_of_kmer_in_read == y.pos_of_kmer_in_read)) { return false; }
-    if (is_forward_strand != y.is_forward_strand) { return false; }
+bool Minimizer::operator==(const Minimizer& y) const
+{
+    if (canonical_kmer_hash != y.canonical_kmer_hash) {
+        return false;
+    }
+    if (!(pos_of_kmer_in_read == y.pos_of_kmer_in_read)) {
+        return false;
+    }
+    if (is_forward_strand != y.is_forward_strand) {
+        return false;
+    }
     return true;
 }
 
-std::ostream &operator<<(std::ostream &out, Minimizer const &m) {
-    out << "(" << m.canonical_kmer_hash << ", " << m.pos_of_kmer_in_read << ", " << m.is_forward_strand << ")";
+std::ostream& operator<<(std::ostream& out, Minimizer const& m)
+{
+    out << "(" << m.canonical_kmer_hash << ", " << m.pos_of_kmer_in_read << ", "
+        << m.is_forward_strand << ")";
     return out;
 }

--- a/src/minirecord.cpp
+++ b/src/minirecord.cpp
@@ -1,31 +1,44 @@
+#include "minirecord.h"
 #include <cassert>
 #include <functional>
 #include <iostream>
-#include "minirecord.h"
-
 
 MiniRecord::MiniRecord() {};
 
-MiniRecord::MiniRecord(const uint32_t p, const prg::Path q, const uint32_t n, const bool c) : prg_id(p), path(q),
-                                                                                         knode_id(n), strand(c) {};
+MiniRecord::MiniRecord(
+    const uint32_t p, const prg::Path q, const uint32_t n, const bool c)
+    : prg_id(p)
+    , path(q)
+    , knode_id(n)
+    , strand(c) {};
 
 MiniRecord::~MiniRecord() {};
 
-bool MiniRecord::operator==(const MiniRecord &y) const {
-    //cout << prg_id << "," << y.prg_id << endl;
-    //cout << path << "," << y.path << endl;
-    if (prg_id != y.prg_id) { return false; }
-    if (!(path == y.path)) { return false; }
-    if (strand != y.strand) { return false; }
+bool MiniRecord::operator==(const MiniRecord& y) const
+{
+    // cout << prg_id << "," << y.prg_id << endl;
+    // cout << path << "," << y.path << endl;
+    if (prg_id != y.prg_id) {
+        return false;
+    }
+    if (!(path == y.path)) {
+        return false;
+    }
+    if (strand != y.strand) {
+        return false;
+    }
     return true;
 }
 
-std::ostream &operator<<(std::ostream &out, MiniRecord const &m) {
-    out << "(" << m.prg_id << ", " << m.path << ", " << m.knode_id << ", " << m.strand << ")";
+std::ostream& operator<<(std::ostream& out, MiniRecord const& m)
+{
+    out << "(" << m.prg_id << ", " << m.path << ", " << m.knode_id << ", " << m.strand
+        << ")";
     return out;
 }
 
-std::istream &operator>>(std::istream &in, MiniRecord &m) {
+std::istream& operator>>(std::istream& in, MiniRecord& m)
+{
     in.ignore(1, '(');
     in >> m.prg_id;
     in.ignore(2, ' ');

--- a/src/noise_filtering.cpp
+++ b/src/noise_filtering.cpp
@@ -1,20 +1,21 @@
-#include <iostream>
-#include <map>
-#include <unordered_set>
-#include <set>
-#include <utility>
-#include <vector>
-#include <fstream>
-#include <cassert>
-#include "utils.h"
+#include "de_bruijn/graph.h"
+#include "minihit.h"
 #include "pangenome/pangraph.h"
 #include "pangenome/pannode.h"
 #include "pangenome/panread.h"
-#include "de_bruijn/graph.h"
-#include "minihit.h"
+#include "utils.h"
+#include <cassert>
+#include <fstream>
+#include <iostream>
+#include <map>
+#include <set>
+#include <unordered_set>
+#include <utility>
+#include <vector>
 
-
-uint_least32_t node_plus_orientation_to_num(const uint_least32_t node_id, const bool orientation) {
+uint_least32_t node_plus_orientation_to_num(
+    const uint_least32_t node_id, const bool orientation)
+{
     assert(node_id < UINT_LEAST32_MAX / 2);
     uint_least32_t r = 2 * node_id;
     if (orientation) {
@@ -23,7 +24,9 @@ uint_least32_t node_plus_orientation_to_num(const uint_least32_t node_id, const 
     return r;
 }
 
-void num_to_node_plus_orientation(uint_least32_t &node_id, bool &orientation, const uint_least32_t num) {
+void num_to_node_plus_orientation(
+    uint_least32_t& node_id, bool& orientation, const uint_least32_t num)
+{
     if (num % 2 == 1) {
         orientation = true;
         node_id = (num - 1) / 2;
@@ -33,26 +36,30 @@ void num_to_node_plus_orientation(uint_least32_t &node_id, bool &orientation, co
     }
 }
 
-uint_least32_t rc_num(const uint_least32_t &num) {
+uint_least32_t rc_num(const uint_least32_t& num)
+{
     return num + 1 * (num % 2 == 0) - 1 * (num % 2 == 1);
 }
 
-void hashed_node_ids_to_ids_and_orientations(const std::deque<uint_least32_t> &hashed_node_ids,
-                                             std::vector<uint_least32_t> &node_ids,
-                                             std::vector<bool> &node_orients) {
+void hashed_node_ids_to_ids_and_orientations(
+    const std::deque<uint_least32_t>& hashed_node_ids,
+    std::vector<uint_least32_t>& node_ids, std::vector<bool>& node_orients)
+{
     node_ids.clear();
     node_orients.clear();
 
     uint_least32_t node_id;
     bool orientation;
-    for (const auto &i : hashed_node_ids) {
+    for (const auto& i : hashed_node_ids) {
         num_to_node_plus_orientation(node_id, orientation, i);
         node_ids.push_back(node_id);
         node_orients.push_back(orientation);
     }
 }
 
-bool overlap_forwards(const std::deque<uint_least32_t> &node1, const std::deque<uint_least32_t> &node2) {
+bool overlap_forwards(
+    const std::deque<uint_least32_t>& node1, const std::deque<uint_least32_t>& node2)
+{
     // second deque should extend first by 1
     assert(node1.size() >= node2.size());
     uint32_t i = node1.size() - node2.size() + 1;
@@ -67,7 +74,9 @@ bool overlap_forwards(const std::deque<uint_least32_t> &node1, const std::deque<
     return true;
 }
 
-bool overlap_backwards(const std::deque<uint_least32_t> &node1, const std::deque<uint_least32_t> &node2) {
+bool overlap_backwards(
+    const std::deque<uint_least32_t>& node1, const std::deque<uint_least32_t>& node2)
+{
     for (uint32_t i = 1; i < std::min(node1.size() + 1, node2.size()); ++i) {
         if (node2[i] != node1[i - 1]) {
             return false;
@@ -76,13 +85,15 @@ bool overlap_backwards(const std::deque<uint_least32_t> &node1, const std::deque
     return true;
 }
 
-std::deque<uint_least32_t> rc_hashed_node_ids(const std::deque<uint_least32_t> &hashed_node_ids) {
+std::deque<uint_least32_t> rc_hashed_node_ids(
+    const std::deque<uint_least32_t>& hashed_node_ids)
+{
     /*for (const auto &n : hashed_node_ids)
     {
         cout << n << " ";
     }*/
     std::deque<uint_least32_t> d;
-    for (const auto &i : hashed_node_ids) {
+    for (const auto& i : hashed_node_ids) {
         d.push_front(rc_num(i));
     }
     /*cout << " is now ";
@@ -94,17 +105,23 @@ std::deque<uint_least32_t> rc_hashed_node_ids(const std::deque<uint_least32_t> &
     return d;
 }
 
-std::deque<uint_least32_t> extend_hashed_pg_node_ids_backwards(const debruijn::Graph &dbg,
-                                                               const std::deque<uint32_t> &dbg_node_ids) {
-    std::deque<uint_least32_t> hashed_pg_node_ids = dbg.nodes.at(dbg_node_ids.at(0))->hashed_node_ids;
+std::deque<uint_least32_t> extend_hashed_pg_node_ids_backwards(
+    const debruijn::Graph& dbg, const std::deque<uint32_t>& dbg_node_ids)
+{
+    std::deque<uint_least32_t> hashed_pg_node_ids
+        = dbg.nodes.at(dbg_node_ids.at(0))->hashed_node_ids;
     std::deque<uint_least32_t> rev_node;
 
     for (uint32_t i = 1; i < dbg_node_ids.size(); ++i) {
-        rev_node = rc_hashed_node_ids(dbg.nodes.at(dbg_node_ids.at(i))->hashed_node_ids);
-        if (overlap_backwards(hashed_pg_node_ids, dbg.nodes.at(dbg_node_ids.at(i))->hashed_node_ids)) {
-            hashed_pg_node_ids.push_front(dbg.nodes.at(dbg_node_ids[i])->hashed_node_ids[0]);
+        rev_node
+            = rc_hashed_node_ids(dbg.nodes.at(dbg_node_ids.at(i))->hashed_node_ids);
+        if (overlap_backwards(hashed_pg_node_ids,
+                dbg.nodes.at(dbg_node_ids.at(i))->hashed_node_ids)) {
+            hashed_pg_node_ids.push_front(
+                dbg.nodes.at(dbg_node_ids[i])->hashed_node_ids[0]);
         } else if (overlap_backwards(hashed_pg_node_ids, rev_node)) {
-            hashed_pg_node_ids.push_front(rc_num(dbg.nodes.at(dbg_node_ids[i])->hashed_node_ids.back()));
+            hashed_pg_node_ids.push_front(
+                rc_num(dbg.nodes.at(dbg_node_ids[i])->hashed_node_ids.back()));
         } else {
             hashed_pg_node_ids.clear();
             break;
@@ -113,17 +130,23 @@ std::deque<uint_least32_t> extend_hashed_pg_node_ids_backwards(const debruijn::G
     return hashed_pg_node_ids;
 }
 
-std::deque<uint_least32_t> extend_hashed_pg_node_ids_forwards(const debruijn::Graph &dbg,
-                                                              const std::deque<uint32_t> &dbg_node_ids) {
-    std::deque<uint_least32_t> hashed_pg_node_ids = dbg.nodes.at(dbg_node_ids.at(0))->hashed_node_ids;
+std::deque<uint_least32_t> extend_hashed_pg_node_ids_forwards(
+    const debruijn::Graph& dbg, const std::deque<uint32_t>& dbg_node_ids)
+{
+    std::deque<uint_least32_t> hashed_pg_node_ids
+        = dbg.nodes.at(dbg_node_ids.at(0))->hashed_node_ids;
     std::deque<uint_least32_t> rev_node;
 
     for (uint32_t i = 1; i < dbg_node_ids.size(); ++i) {
-        rev_node = rc_hashed_node_ids(dbg.nodes.at(dbg_node_ids.at(i))->hashed_node_ids);
-        if (overlap_forwards(hashed_pg_node_ids, dbg.nodes.at(dbg_node_ids.at(i))->hashed_node_ids)) {
-            hashed_pg_node_ids.push_back(dbg.nodes.at(dbg_node_ids[i])->hashed_node_ids.back());
+        rev_node
+            = rc_hashed_node_ids(dbg.nodes.at(dbg_node_ids.at(i))->hashed_node_ids);
+        if (overlap_forwards(hashed_pg_node_ids,
+                dbg.nodes.at(dbg_node_ids.at(i))->hashed_node_ids)) {
+            hashed_pg_node_ids.push_back(
+                dbg.nodes.at(dbg_node_ids[i])->hashed_node_ids.back());
         } else if (overlap_forwards(hashed_pg_node_ids, rev_node)) {
-            hashed_pg_node_ids.push_back(rc_num(dbg.nodes.at(dbg_node_ids[i])->hashed_node_ids[0]));
+            hashed_pg_node_ids.push_back(
+                rc_num(dbg.nodes.at(dbg_node_ids[i])->hashed_node_ids[0]));
         } else {
             hashed_pg_node_ids.clear();
             break;
@@ -132,10 +155,10 @@ std::deque<uint_least32_t> extend_hashed_pg_node_ids_forwards(const debruijn::Gr
     return hashed_pg_node_ids;
 }
 
-void dbg_node_ids_to_ids_and_orientations(const debruijn::Graph &dbg,
-                                          const std::deque<uint32_t> &dbg_node_ids,
-                                          std::vector<uint_least32_t> &node_ids,
-                                          std::vector<bool> &node_orients) {
+void dbg_node_ids_to_ids_and_orientations(const debruijn::Graph& dbg,
+    const std::deque<uint32_t>& dbg_node_ids, std::vector<uint_least32_t>& node_ids,
+    std::vector<bool>& node_orients)
+{
     node_ids.clear();
     node_orients.clear();
 
@@ -143,13 +166,14 @@ void dbg_node_ids_to_ids_and_orientations(const debruijn::Graph &dbg,
         return;
     }
 
-    std::deque<uint_least32_t> hashed_pg_node_ids = extend_hashed_pg_node_ids_backwards(dbg, dbg_node_ids);
+    std::deque<uint_least32_t> hashed_pg_node_ids
+        = extend_hashed_pg_node_ids_backwards(dbg, dbg_node_ids);
     if (hashed_pg_node_ids.empty())
         hashed_pg_node_ids = extend_hashed_pg_node_ids_forwards(dbg, dbg_node_ids);
     if (hashed_pg_node_ids.empty()) {
-        for (const auto &n : dbg_node_ids) {
+        for (const auto& n : dbg_node_ids) {
             std::cout << "(";
-            for (const auto &m : dbg.nodes.at(n)->hashed_node_ids) {
+            for (const auto& m : dbg.nodes.at(n)->hashed_node_ids) {
                 std::cout << m << " ";
             }
             std::cout << ") ";
@@ -160,15 +184,17 @@ void dbg_node_ids_to_ids_and_orientations(const debruijn::Graph &dbg,
     hashed_node_ids_to_ids_and_orientations(hashed_pg_node_ids, node_ids, node_orients);
 }
 
-void construct_debruijn_graph(std::shared_ptr<pangenome::Graph> pangraph, debruijn::Graph &dbg) {
+void construct_debruijn_graph(
+    std::shared_ptr<pangenome::Graph> pangraph, debruijn::Graph& dbg)
+{
     dbg.nodes.clear();
     dbg.node_hash.clear();
-    //cout << "Removed old nodes" << endl;
+    // cout << "Removed old nodes" << endl;
 
     debruijn::OrientedNodePtr prev, current;
     std::deque<uint_least32_t> hashed_ids;
 
-    for (const auto &r : pangraph->reads) {
+    for (const auto& r : pangraph->reads) {
         if (r.second->get_nodes().size() < dbg.size) {
             // can't add anything for this read
             continue;
@@ -179,8 +205,9 @@ void construct_debruijn_graph(std::shared_ptr<pangenome::Graph> pangraph, debrui
         hashed_ids.clear();
 
         for (uint32_t i = 0; i < r.second->get_nodes().size(); ++i) {
-            hashed_ids.push_back(node_plus_orientation_to_num(r.second->get_nodes()[i].lock()->node_id,
-                                                              r.second->node_orientations[i]));
+            hashed_ids.push_back(
+                node_plus_orientation_to_num(r.second->get_nodes()[i].lock()->node_id,
+                    r.second->node_orientations[i]));
 
             if (hashed_ids.size() == dbg.size) {
                 current = dbg.add_node(hashed_ids, r.first);
@@ -194,12 +221,13 @@ void construct_debruijn_graph(std::shared_ptr<pangenome::Graph> pangraph, debrui
     }
 }
 
-void remove_leaves(std::shared_ptr<pangenome::Graph> pangraph,
-                   debruijn::Graph &dbg,
-                   uint_least32_t covg_thresh) {
+void remove_leaves(std::shared_ptr<pangenome::Graph> pangraph, debruijn::Graph& dbg,
+    uint_least32_t covg_thresh)
+{
     std::cout << now() << "Remove leaves of debruijn graph from pangraph" << std::endl;
-    std::cout << "Start with " << pangraph->nodes.size() << " pg.nodes, " << pangraph->reads.size() << " pg.reads, and "
-              << dbg.nodes.size() << " dbg.nodes" << std::endl;
+    std::cout << "Start with " << pangraph->nodes.size() << " pg.nodes, "
+              << pangraph->reads.size() << " pg.reads, and " << dbg.nodes.size()
+              << " dbg.nodes" << std::endl;
     bool leaves_exist = true;
     std::unordered_set<uint32_t> leaves;
     std::vector<uint_least32_t> node_ids;
@@ -217,22 +245,23 @@ void remove_leaves(std::shared_ptr<pangenome::Graph> pangraph,
         }
         std::cout << "leaves exist is " << leaves_exist << std::endl;
 
-        for (const auto &i : leaves) {
+        for (const auto& i : leaves) {
             std::cout << std::endl << "looking at leaf " << i << ": ";
-            for (const auto &j : dbg.nodes[i]->hashed_node_ids) {
+            for (const auto& j : dbg.nodes[i]->hashed_node_ids) {
                 std::cout << j << " ";
             }
             std::cout << std::endl;
 
             // look up the node ids and orientations associated with this node
-            hashed_node_ids_to_ids_and_orientations(dbg.nodes[i]->hashed_node_ids, node_ids, node_orients);
+            hashed_node_ids_to_ids_and_orientations(
+                dbg.nodes[i]->hashed_node_ids, node_ids, node_orients);
             std::cout << "looked up node ids" << std::endl;
 
             // remove the last node from corresponding reads
             assert(not dbg.nodes[i]->read_ids.empty());
-            for (const auto &r : dbg.nodes[i]->read_ids) {
+            for (const auto& r : dbg.nodes[i]->read_ids) {
                 std::cout << "remove from read " << r << ": ";
-                for (const auto &n : pangraph->reads[r]->get_nodes()) {
+                for (const auto& n : pangraph->reads[r]->get_nodes()) {
                     std::cout << n.lock()->node_id << " ";
                 }
                 std::cout << std::endl;
@@ -244,53 +273,58 @@ void remove_leaves(std::shared_ptr<pangenome::Graph> pangraph,
                     std::cout << "remove from read ";
                     pos = pangraph->reads[r]->find_position(node_ids, node_orients);
                     std::cout << " pos " << pos.first << " " << pos.second;
-                    assert(pos.first == 0 or pos.first + node_ids.size() == pangraph->reads[r]->get_nodes().size());
+                    assert(pos.first == 0
+                        or pos.first + node_ids.size()
+                            == pangraph->reads[r]->get_nodes().size());
                     if (pos.first == 0) {
                         node = pangraph->reads[r]->get_nodes()[0];
-                        pangraph->reads[r]->remove_node_with_iterator(pangraph->reads[r]->get_nodes().begin());
+                        pangraph->reads[r]->remove_node_with_iterator(
+                            pangraph->reads[r]->get_nodes().begin());
                         node.lock()->remove_read(pangraph->reads[r]);
-                    } else if (pos.first + node_ids.size() == pangraph->reads[r]->get_nodes().size()) {
+                    } else if (pos.first + node_ids.size()
+                        == pangraph->reads[r]->get_nodes().size()) {
                         node = pangraph->reads[r]->get_nodes().back();
-                        pangraph->reads[r]->remove_all_nodes_with_this_id((--pangraph->reads[r]->get_nodes().end())->lock()->node_id);
+                        pangraph->reads[r]->remove_all_nodes_with_this_id(
+                            (--pangraph->reads[r]->get_nodes().end())->lock()->node_id);
                         node.lock()->remove_read(pangraph->reads[r]);
                     }
                     std::cout << "read is now " << r << ": ";
-                    for (const auto &n : pangraph->reads[r]->get_nodes()) {
+                    for (const auto& n : pangraph->reads[r]->get_nodes()) {
                         std::cout << n.lock()->node_id << " ";
                     }
                     std::cout << "done" << std::endl;
                 }
             }
             auto node_shared_ptr_from_weak_ptr = node.lock();
-            if (node_shared_ptr_from_weak_ptr and node_shared_ptr_from_weak_ptr->covg == 0) {
+            if (node_shared_ptr_from_weak_ptr
+                and node_shared_ptr_from_weak_ptr->covg == 0) {
                 pangraph->remove_node(node_shared_ptr_from_weak_ptr);
             }
 
             // remove dbg node
             dbg.remove_node(i);
 
-            //cout << "pg is now: " << endl << pg << endl;
+            // cout << "pg is now: " << endl << pg << endl;
         }
     }
-    std::cout << "There are now " << pangraph->nodes.size() << " pg.nodes, " << pangraph->reads.size() << " pg.reads, and "
-              << dbg.nodes.size() << " dbg.nodes" << std::endl;
+    std::cout << "There are now " << pangraph->nodes.size() << " pg.nodes, "
+              << pangraph->reads.size() << " pg.reads, and " << dbg.nodes.size()
+              << " dbg.nodes" << std::endl;
 }
 
-void find_reads_along_tig(const debruijn::Graph &dbg,
-                          std::deque<uint32_t> &dbg_node_ids,
-                          std::shared_ptr<pangenome::Graph> pangraph,
-                          std::vector<uint_least32_t> &pg_node_ids,
-                          std::vector<bool> &pg_node_orients,
-                          std::unordered_set<pangenome::ReadPtr> &reads_along_tig,
-                          bool &all_reads_along_tig) {
+void find_reads_along_tig(const debruijn::Graph& dbg,
+    std::deque<uint32_t>& dbg_node_ids, std::shared_ptr<pangenome::Graph> pangraph,
+    std::vector<uint_least32_t>& pg_node_ids, std::vector<bool>& pg_node_orients,
+    std::unordered_set<pangenome::ReadPtr>& reads_along_tig, bool& all_reads_along_tig)
+{
     // collect the reads covering that tig
-    for (const auto &n : dbg_node_ids) {
-        for (const auto &r : dbg.nodes.at(n)->read_ids) {
+    for (const auto& n : dbg_node_ids) {
+        for (const auto& r : dbg.nodes.at(n)->read_ids) {
             reads_along_tig.insert(pangraph->reads.at(r));
         }
     }
     std::cout << "candidate reads ";
-    for (const auto &r : reads_along_tig) {
+    for (const auto& r : reads_along_tig) {
         std::cout << r->id << " ";
     }
     std::cout << std::endl;
@@ -300,9 +334,9 @@ void find_reads_along_tig(const debruijn::Graph &dbg,
     all_reads_along_tig = true;
     std::cout << "kept reads along tig: ";
     for (auto r = reads_along_tig.begin(); r != reads_along_tig.end();) {
-        if ((*r)->get_nodes().size() > dbg.size and
-            (*r)->find_position(pg_node_ids, pg_node_orients, dbg.size + 1).first ==
-            std::numeric_limits<uint32_t>::max()) {
+        if ((*r)->get_nodes().size() > dbg.size
+            and (*r)->find_position(pg_node_ids, pg_node_orients, dbg.size + 1).first
+                == std::numeric_limits<uint32_t>::max()) {
             r = reads_along_tig.erase(r);
             all_reads_along_tig = false;
         } else {
@@ -310,14 +344,13 @@ void find_reads_along_tig(const debruijn::Graph &dbg,
             ++r;
         }
     }
-    //cout << endl;
+    // cout << endl;
 }
 
 void remove_middle_nodes_of_tig_from_read(std::shared_ptr<pangenome::Graph> pangenome,
-                                          debruijn::Graph &dbg,
-                                          pangenome::ReadPtr r,
-                                          const std::vector<uint_least32_t> &node_ids,
-                                          const std::vector<bool> &node_orients) {
+    debruijn::Graph& dbg, pangenome::ReadPtr r,
+    const std::vector<uint_least32_t>& node_ids, const std::vector<bool>& node_orients)
+{
     // suppose tig is subset of read
     // want to remove nodes from position pos (where tig starts in read) + dbg.size()
     // to position start + tig.size()-dbg.size()
@@ -326,27 +359,34 @@ void remove_middle_nodes_of_tig_from_read(std::shared_ptr<pangenome::Graph> pang
     std::pair<uint32_t, uint32_t> pos = r->find_position(node_ids, node_orients);
     std::cout << "found pos " << pos.first << " " << pos.second << std::endl;
     auto start_shift = pos.first;
-    if (pos.first > 0 or pos.second < r->get_nodes().size() - 1 or node_ids.size() == r->get_nodes().size())
-        start_shift += std::max((int) 0, (int) pos.second - (int) node_ids.size()) + dbg.size;
+    if (pos.first > 0 or pos.second < r->get_nodes().size() - 1
+        or node_ids.size() == r->get_nodes().size())
+        start_shift
+            += std::max((int)0, (int)pos.second - (int)node_ids.size()) + dbg.size;
     else {
-        std::vector<uint_least32_t> sub_node_ids(node_ids.begin() + dbg.size, node_ids.end());
-        std::vector<bool> sub_node_orients(node_orients.begin() + dbg.size, node_orients.end());
-        std::pair<uint32_t, uint32_t> sub_pos = r->find_position(sub_node_ids, sub_node_orients);
+        std::vector<uint_least32_t> sub_node_ids(
+            node_ids.begin() + dbg.size, node_ids.end());
+        std::vector<bool> sub_node_orients(
+            node_orients.begin() + dbg.size, node_orients.end());
+        std::pair<uint32_t, uint32_t> sub_pos
+            = r->find_position(sub_node_ids, sub_node_orients);
         if (sub_pos.first > 0)
             start_shift = sub_pos.first;
     }
 
-
     auto end_shift = pos.second;
-    if (pos.first > 0 or pos.second < r->get_nodes().size() - 1 or node_ids.size() == r->get_nodes().size()) {
+    if (pos.first > 0 or pos.second < r->get_nodes().size() - 1
+        or node_ids.size() == r->get_nodes().size()) {
         end_shift -= dbg.size - 1;
     } else {
-        std::vector<uint_least32_t> sub_node_ids(node_ids.begin(), node_ids.end() - dbg.size);
-        std::vector<bool> sub_node_orients(node_orients.begin(), node_orients.end() - dbg.size);
-        std::pair<uint32_t, uint32_t> sub_pos = r->find_position(sub_node_ids, sub_node_orients);
+        std::vector<uint_least32_t> sub_node_ids(
+            node_ids.begin(), node_ids.end() - dbg.size);
+        std::vector<bool> sub_node_orients(
+            node_orients.begin(), node_orients.end() - dbg.size);
+        std::pair<uint32_t, uint32_t> sub_pos
+            = r->find_position(sub_node_ids, sub_node_orients);
         if (sub_pos.second < pos.second)
             end_shift = sub_pos.second + 1;
-
     }
 
     std::cout << "remove nodes " << start_shift << " to " << end_shift << std::endl;
@@ -365,9 +405,9 @@ void remove_middle_nodes_of_tig_from_read(std::shared_ptr<pangenome::Graph> pang
 // then we would remove the 3 internal kmers from the dbg
 // and node 6 from the pg->
 // If the tig is smaller than k+2 long, currently does nothing
-void filter_unitigs(std::shared_ptr<pangenome::Graph> pangraph,
-                    debruijn::Graph &dbg,
-                    const uint_least32_t &threshold) {
+void filter_unitigs(std::shared_ptr<pangenome::Graph> pangraph, debruijn::Graph& dbg,
+    const uint_least32_t& threshold)
+{
     std::cout << now() << "Filter unitigs using threshold " << threshold << std::endl;
     std::vector<uint_least32_t> node_ids;
     std::vector<bool> node_orients;
@@ -380,35 +420,38 @@ void filter_unitigs(std::shared_ptr<pangenome::Graph> pangraph,
         // look up the node ids and orientations associated with this node
         dbg_node_ids_to_ids_and_orientations(dbg, d, node_ids, node_orients);
         std::cout << "tig: ";
-        for (const auto &n : node_ids) {
+        for (const auto& n : node_ids) {
             std::cout << n << " ";
         }
         std::cout << std::endl;
 
         // collect the reads covering that tig
-        find_reads_along_tig(dbg, d, pangraph, node_ids, node_orients, reads_along_tig, all_reads_tig);
+        find_reads_along_tig(
+            dbg, d, pangraph, node_ids, node_orients, reads_along_tig, all_reads_tig);
 
         // now if the number of reads covering tig falls below threshold, remove the
         // middle nodes of this tig from the reads
         if (reads_along_tig.size() <= threshold) {
-            std::cout << "not enough reads, so remove the tig from the reads" << std::endl;
-            for (const auto &r : reads_along_tig) {
+            std::cout << "not enough reads, so remove the tig from the reads"
+                      << std::endl;
+            for (const auto& r : reads_along_tig) {
                 std::cout << "read " << r->id << " was ";
-                for (const auto &n : r->get_nodes()) {
+                for (const auto& n : r->get_nodes()) {
                     std::cout << n.lock()->node_id << " ";
                 }
                 std::cout << std::endl;
-                remove_middle_nodes_of_tig_from_read(pangraph, dbg, r, node_ids, node_orients);
+                remove_middle_nodes_of_tig_from_read(
+                    pangraph, dbg, r, node_ids, node_orients);
                 std::cout << "read " << r->id << " is now ";
-                for (const auto &n : r->get_nodes()) {
+                for (const auto& n : r->get_nodes()) {
                     std::cout << n.lock()->node_id << " ";
                 }
                 std::cout << std::endl;
             }
             // also remove read_ids from each of the corresponding nodes of dbg
-            //cout << "now remove read from dbg nodes" << endl;
+            // cout << "now remove read from dbg nodes" << endl;
             for (uint32_t i = 1; i < d.size() - 1; ++i) {
-                for (const auto &r :reads_along_tig) {
+                for (const auto& r : reads_along_tig) {
                     dbg.remove_read_from_node(r->id, d[i]);
                 }
             }
@@ -419,8 +462,9 @@ void filter_unitigs(std::shared_ptr<pangenome::Graph> pangraph,
     }
 }
 
-void detangle_pangraph_with_debruijn_graph(std::shared_ptr<pangenome::Graph> pangraph,
-                                           debruijn::Graph &dbg) {
+void detangle_pangraph_with_debruijn_graph(
+    std::shared_ptr<pangenome::Graph> pangraph, debruijn::Graph& dbg)
+{
     std::cout << now() << "Detangle pangraph with debruijn graph" << std::endl;
     std::vector<uint_least32_t> node_ids;
     std::vector<bool> node_orients;
@@ -439,35 +483,37 @@ void detangle_pangraph_with_debruijn_graph(std::shared_ptr<pangenome::Graph> pan
         cout << endl;*/
 
         // collect the reads covering that tig
-        find_reads_along_tig(dbg, d, pangraph, node_ids, node_orients, reads_along_tig, all_reads_tig);
+        find_reads_along_tig(
+            dbg, d, pangraph, node_ids, node_orients, reads_along_tig, all_reads_tig);
 
         // for each node on tig, for each read covering that node,
         // if we find a read which doesn't lie along whole tig,
         // split that node by reads and create a new node on the tig
         if (!all_reads_tig and !reads_along_tig.empty()) {
-            //cout << "not all reads contain tig" << endl;
+            // cout << "not all reads contain tig" << endl;
             for (uint32_t i = 0; i < node_ids.size(); ++i) {
-                //cout << "for node " << pg->nodes[node_ids[i]]->node_id << endl;
-                for (const auto &r : pangraph->nodes[node_ids[i]]->reads) {
-                    //cout << "for read " << r->id << endl;
+                // cout << "for node " << pg->nodes[node_ids[i]]->node_id << endl;
+                for (const auto& r : pangraph->nodes[node_ids[i]]->reads) {
+                    // cout << "for read " << r->id << endl;
                     if (reads_along_tig.find(r) == reads_along_tig.end()) {
-                        //cout << "split node" << endl;
-                        pangraph->split_node_by_reads(reads_along_tig, node_ids, node_orients, node_ids[i]);
-                        //cout << "done" << endl;
+                        // cout << "split node" << endl;
+                        pangraph->split_node_by_reads(
+                            reads_along_tig, node_ids, node_orients, node_ids[i]);
+                        // cout << "done" << endl;
                         break;
                     }
                 }
-                //cout << pg << endl;
+                // cout << pg << endl;
             }
         }
     }
 }
 
 void clean_pangraph_with_debruijn_graph(std::shared_ptr<pangenome::Graph> pangraph,
-                                        const uint_least32_t size,
-                                        const uint_least32_t threshold,
-                                        const bool illumina) {
-    std::cout << now() << "Construct de Bruijn Graph from PanGraph with size " << (uint32_t) size << std::endl;
+    const uint_least32_t size, const uint_least32_t threshold, const bool illumina)
+{
+    std::cout << now() << "Construct de Bruijn Graph from PanGraph with size "
+              << (uint32_t)size << std::endl;
     debruijn::Graph dbg(size);
     construct_debruijn_graph(pangraph, dbg);
 
@@ -484,14 +530,10 @@ void clean_pangraph_with_debruijn_graph(std::shared_ptr<pangenome::Graph> pangra
     detangle_pangraph_with_debruijn_graph(pangraph, dbg);
 }
 
+enum NodeDirection { forward, reverse };
 
-enum NodeDirection {
-    forward,
-    reverse
-};
-
-
-NodeDirection get_pangraph_node_direction(const debruijn::Node &debruijn_node) {
+NodeDirection get_pangraph_node_direction(const debruijn::Node& debruijn_node)
+{
     bool forward_node = debruijn_node.hashed_node_ids[0] % 2 != 0;
     if (forward_node)
         return NodeDirection::forward;
@@ -499,53 +541,53 @@ NodeDirection get_pangraph_node_direction(const debruijn::Node &debruijn_node) {
         return NodeDirection::reverse;
 }
 
-
-uint32_t get_pangraph_node_id(const debruijn::Node &debruijn_node) {
+uint32_t get_pangraph_node_id(const debruijn::Node& debruijn_node)
+{
     auto direction = get_pangraph_node_direction(debruijn_node);
     if (direction == NodeDirection::forward)
-        return (uint32_t) (debruijn_node.hashed_node_ids[0] - 1) / 2;
+        return (uint32_t)(debruijn_node.hashed_node_ids[0] - 1) / 2;
     else
-        return (uint32_t) debruijn_node.hashed_node_ids[0] / 2;
+        return (uint32_t)debruijn_node.hashed_node_ids[0] / 2;
 }
-
 
 namespace gfa {
-    namespace dump {
-        void header(std::ofstream &gfa_fhandle) {
-            gfa_fhandle << "H\tVN:Z:1.0" << std::endl;
-        }
+namespace dump {
+    void header(std::ofstream& gfa_fhandle)
+    {
+        gfa_fhandle << "H\tVN:Z:1.0" << std::endl;
+    }
 
+    void nodes(std::shared_ptr<pangenome::Graph> pangraph, std::ofstream& gfa_fhandle)
+    {
+        for (const auto& node : pangraph->nodes)
+            gfa_fhandle << "S\t" << node.second->get_name()
+                        << "\tN\tFC:i:" << node.second->covg << std::endl;
+    }
 
-        void nodes(std::shared_ptr<pangenome::Graph> pangraph, std::ofstream &gfa_fhandle) {
-            for (const auto &node : pangraph->nodes)
-                gfa_fhandle << "S\t" << node.second->get_name() << "\tN\tFC:i:" << node.second->covg << std::endl;
-        }
+    void edge(const pangenome::Node& first_node,
+        const NodeDirection& first_node_direction, const pangenome::Node& second_node,
+        const NodeDirection& second_node_direction, std::ofstream& gfa_fhandle)
+    {
+        gfa_fhandle << "L\t" << first_node.get_name() << "\t";
+        if (first_node_direction == NodeDirection::forward)
+            gfa_fhandle << "-";
+        else
+            gfa_fhandle << "+";
 
-        void edge(const pangenome::Node &first_node,
-                  const NodeDirection &first_node_direction,
-                  const pangenome::Node &second_node,
-                  const NodeDirection &second_node_direction,
-                  std::ofstream &gfa_fhandle) {
-            gfa_fhandle << "L\t" << first_node.get_name() << "\t";
-            if (first_node_direction == NodeDirection::forward)
-                gfa_fhandle << "-";
-            else
-                gfa_fhandle << "+";
+        gfa_fhandle << "\t" << second_node.get_name() << "\t";
+        if (second_node_direction == NodeDirection::forward)
+            gfa_fhandle << "-";
+        else
+            gfa_fhandle << "+";
 
-            gfa_fhandle << "\t" << second_node.get_name() << "\t";
-            if (second_node_direction == NodeDirection::forward)
-                gfa_fhandle << "-";
-            else
-                gfa_fhandle << "+";
-
-            gfa_fhandle << "\t0M" << std::endl;
-        }
+        gfa_fhandle << "\t0M" << std::endl;
     }
 }
+}
 
-
-pangenome::Node convert_node_debruijn_pangraph(const debruijn::Node &debruijn_node,
-                                               std::shared_ptr<pangenome::Graph> pangraph) {
+pangenome::Node convert_node_debruijn_pangraph(
+    const debruijn::Node& debruijn_node, std::shared_ptr<pangenome::Graph> pangraph)
+{
     auto node_id = get_pangraph_node_id(debruijn_node);
     assert(pangraph->nodes.find(node_id) != pangraph->nodes.end());
 
@@ -554,8 +596,9 @@ pangenome::Node convert_node_debruijn_pangraph(const debruijn::Node &debruijn_no
     return node;
 }
 
-
-void write_pangraph_gfa(const std::string &filepath, std::shared_ptr<pangenome::Graph> pangraph) {
+void write_pangraph_gfa(
+    const std::string& filepath, std::shared_ptr<pangenome::Graph> pangraph)
+{
     std::ofstream gfa_fhandle;
     gfa_fhandle.open(filepath);
     gfa::dump::header(gfa_fhandle);
@@ -564,22 +607,24 @@ void write_pangraph_gfa(const std::string &filepath, std::shared_ptr<pangenome::
     debruijn::Graph debruijn_graph(1);
     construct_debruijn_graph(pangraph, debruijn_graph);
 
-    for (const auto &debruijn_node_id_entry : debruijn_graph.nodes) {
+    for (const auto& debruijn_node_id_entry : debruijn_graph.nodes) {
         auto first_debruijn_node = *debruijn_node_id_entry.second;
 
         auto first_node = convert_node_debruijn_pangraph(first_debruijn_node, pangraph);
         auto first_node_direction = get_pangraph_node_direction(first_debruijn_node);
 
-        for (const auto &second_debruijn_node_id: first_debruijn_node.out_nodes) {
-            assert(debruijn_graph.nodes.find(second_debruijn_node_id) != debruijn_graph.nodes.end());
-            auto &second_debruijn_node = *debruijn_graph.nodes[second_debruijn_node_id];
+        for (const auto& second_debruijn_node_id : first_debruijn_node.out_nodes) {
+            assert(debruijn_graph.nodes.find(second_debruijn_node_id)
+                != debruijn_graph.nodes.end());
+            auto& second_debruijn_node = *debruijn_graph.nodes[second_debruijn_node_id];
 
-            auto second_node = convert_node_debruijn_pangraph(second_debruijn_node, pangraph);
-            auto second_node_direction = get_pangraph_node_direction(second_debruijn_node);
+            auto second_node
+                = convert_node_debruijn_pangraph(second_debruijn_node, pangraph);
+            auto second_node_direction
+                = get_pangraph_node_direction(second_debruijn_node);
 
-            gfa::dump::edge(first_node, first_node_direction,
-                            second_node, second_node_direction,
-                            gfa_fhandle);
+            gfa::dump::edge(first_node, first_node_direction, second_node,
+                second_node_direction, gfa_fhandle);
 
             auto erased = second_debruijn_node.out_nodes.erase(first_debruijn_node.id);
             if (erased)

--- a/src/pangenome/ns.cpp
+++ b/src/pangenome/ns.cpp
@@ -1,19 +1,18 @@
 #include <iostream>
 #include <memory>
 
-
 namespace pangenome {
-    class Node;
+class Node;
 
-    class Read;
+class Read;
 
-    class Sample;
-    struct SamplePtrSorterBySampleId;
+class Sample;
+struct SamplePtrSorterBySampleId;
 
-    class Graph;
+class Graph;
 
-    typedef std::shared_ptr<pangenome::Node> NodePtr;
-    typedef std::weak_ptr<pangenome::Node> WeakNodePtr;
-    typedef std::shared_ptr<pangenome::Read> ReadPtr;
-    typedef std::shared_ptr<pangenome::Sample> SamplePtr;
+typedef std::shared_ptr<pangenome::Node> NodePtr;
+typedef std::weak_ptr<pangenome::Node> WeakNodePtr;
+typedef std::shared_ptr<pangenome::Read> ReadPtr;
+typedef std::shared_ptr<pangenome::Sample> SamplePtr;
 }

--- a/src/pangenome/pangraph.cpp
+++ b/src/pangenome/pangraph.cpp
@@ -1,32 +1,33 @@
-#include <iostream>
-#include <unordered_map>
-#include <unordered_set>
-#include <set>
-#include <memory>
-#include <vector>
-#include <fstream>
-#include <cassert>
 #include <algorithm>
 #include <boost/filesystem.hpp>
+#include <cassert>
+#include <fstream>
+#include <iostream>
+#include <memory>
+#include <set>
+#include <unordered_map>
+#include <unordered_set>
+#include <vector>
 
-#include "utils.h"
+#include "fastaq_handler.h"
+#include "kmergraphwithcoverage.h"
+#include "minihit.h"
 #include "pangenome/pangraph.h"
 #include "pangenome/pannode.h"
 #include "pangenome/panread.h"
 #include "pangenome/pansample.h"
-#include "minihit.h"
-#include "kmergraphwithcoverage.h"
-#include "fastaq_handler.h"
-
+#include "utils.h"
 
 #define assert_msg(x) !(std::cerr << "Assertion failed: " << x << std::endl)
 
 using namespace pangenome;
 
-pangenome::Graph::Graph(const std::vector<std::string> &sample_names) : next_id{0} {
+pangenome::Graph::Graph(const std::vector<std::string>& sample_names)
+    : next_id { 0 }
+{
     nodes.reserve(6000);
 
-    //add the samples
+    // add the samples
     uint32_t sample_id = 0;
     for (const auto& sample_name : sample_names) {
         auto samplePointer = std::make_shared<Sample>(sample_name, sample_id++);
@@ -34,8 +35,8 @@ pangenome::Graph::Graph(const std::vector<std::string> &sample_names) : next_id{
     }
 }
 
-
-void pangenome::Graph::add_read(const uint32_t &read_id) {
+void pangenome::Graph::add_read(const uint32_t& read_id)
+{
     auto it = reads.find(read_id);
     bool found = it != reads.end();
     if (not found) {
@@ -45,19 +46,21 @@ void pangenome::Graph::add_read(const uint32_t &read_id) {
     }
 }
 
-void pangenome::Graph::add_node(const std::shared_ptr<LocalPRG> &prg, uint32_t node_id) {
+void pangenome::Graph::add_node(const std::shared_ptr<LocalPRG>& prg, uint32_t node_id)
+{
     NodePtr node_ptr;
     auto it = nodes.find(node_id);
     bool found_node = it != nodes.end();
     if (not found_node) {
-        node_ptr = std::make_shared<Node>(prg, node_id, samples.size()); //TODO: refactor this - holding the reference to PRG is enough
+        node_ptr = std::make_shared<Node>(
+            prg, node_id, samples.size()); // TODO: refactor this - holding the
+                                           // reference to PRG is enough
         assert(node_ptr != nullptr);
         nodes[node_id] = node_ptr;
     }
     assert(node_id < std::numeric_limits<uint32_t>::max()
-           or assert_msg("WARNING, node_id reached max pangraph node size"));
+        or assert_msg("WARNING, node_id reached max pangraph node size"));
 }
-
 
 /**
  * Updated the node information with this new read mapping to it
@@ -65,18 +68,19 @@ void pangenome::Graph::add_node(const std::shared_ptr<LocalPRG> &prg, uint32_t n
  * @param node_ptr
  * @param read_ptr
  */
-//TODO: this should be a method of the Node class
-void update_node_info_with_this_read(const NodePtr &node_ptr,  const ReadPtr &read_ptr) {
+// TODO: this should be a method of the Node class
+void update_node_info_with_this_read(const NodePtr& node_ptr, const ReadPtr& read_ptr)
+{
     node_ptr->covg += 1;
     node_ptr->reads.insert(read_ptr);
     assert(node_ptr->covg == node_ptr->reads.size());
 }
 
 // Checks that all hits in the cluster are from the given prg and read
-void check_correct_hits(const uint32_t prg_id,
-                        const uint32_t read_id,
-                        const std::set<MinimizerHitPtr, pComp> &cluster) {
-    for (const auto &hit_ptr : cluster) {
+void check_correct_hits(const uint32_t prg_id, const uint32_t read_id,
+    const std::set<MinimizerHitPtr, pComp>& cluster)
+{
+    for (const auto& hit_ptr : cluster) {
         bool hits_correspond_to_correct_read = read_id == hit_ptr->get_read_id();
         assert(hits_correspond_to_correct_read);
 
@@ -85,62 +89,70 @@ void check_correct_hits(const uint32_t prg_id,
     }
 }
 
-//TODO: this should be a method of the Read class
+// TODO: this should be a method of the Read class
 // Add the node to the vector of nodes along read
 // as well as its orientation (unless the previous node along
 // the read was the same node and orientation)
 // Store the hits on the read
-void update_read_info_with_node_and_cluster(
-        ReadPtr &read_ptr,
-        const NodePtr &node_ptr,
-        const std::set<MinimizerHitPtr, pComp> &cluster) {
+void update_read_info_with_node_and_cluster(ReadPtr& read_ptr, const NodePtr& node_ptr,
+    const std::set<MinimizerHitPtr, pComp>& cluster)
+{
     read_ptr->add_hits(node_ptr, cluster);
 }
 
-
 void pangenome::Graph::add_hits_between_PRG_and_read(
-        const std::shared_ptr<LocalPRG> &prg, //the prg from where this cluster of hits come
-        const uint32_t read_id, //the read id from where this cluster of reads come - TODO: this can be derived from the cluster
-        std::set<MinimizerHitPtr, pComp> &cluster //the cluster itself
-) {
-    check_correct_hits(prg->id, read_id, cluster); //assure this cluster corresponds to the given prg and read
+    const std::shared_ptr<LocalPRG>&
+        prg, // the prg from where this cluster of hits come
+    const uint32_t read_id, // the read id from where this cluster of reads come - TODO:
+                            // this can be derived from the cluster
+    std::set<MinimizerHitPtr, pComp>& cluster // the cluster itself
+)
+{
+    check_correct_hits(prg->id, read_id,
+        cluster); // assure this cluster corresponds to the given prg and read
 
-    //add and get the new read
+    // add and get the new read
     add_read(read_id);
     auto read_ptr = get_read(read_id);
     assert(read_ptr != nullptr);
 
-    //add and get the new node
+    // add and get the new node
     add_node(prg);
     auto node_ptr = get_node(prg);
 
-    //update the info
+    // update the info
     update_node_info_with_this_read(node_ptr, read_ptr);
     update_read_info_with_node_and_cluster(read_ptr, node_ptr, cluster);
 }
 
-//TODO: this should be a method of class Sample
-void update_sample_info_with_this_node(const SamplePtr &sample, const NodePtr& node, const std::vector<KmerNodePtr> &kmp) {
+// TODO: this should be a method of class Sample
+void update_sample_info_with_this_node(
+    const SamplePtr& sample, const NodePtr& node, const std::vector<KmerNodePtr>& kmp)
+{
     sample->add_path(node->node_id, kmp);
 }
 
-//TODO: this should be a method of class Node
-void update_node_info_with_this_sample(const NodePtr& node, const SamplePtr &sample) {
+// TODO: this should be a method of class Node
+void update_node_info_with_this_sample(const NodePtr& node, const SamplePtr& sample)
+{
     if (node->samples.find(sample) == node->samples.end())
         node->samples.insert(sample);
     node->covg += 1;
 }
 
-void pangenome::Graph::add_hits_between_PRG_and_sample (const NodePtr& node, const SamplePtr &sample, const std::vector<KmerNodePtr> &kmp) {
+void pangenome::Graph::add_hits_between_PRG_and_sample(
+    const NodePtr& node, const SamplePtr& sample, const std::vector<KmerNodePtr>& kmp)
+{
     update_sample_info_with_this_node(sample, node, kmp);
     update_node_info_with_this_sample(node, sample);
 }
 
 // Remove the node n, and all references to it
-std::unordered_map<uint32_t, NodePtr>::iterator pangenome::Graph::remove_node(NodePtr n) {
-    //cout << "Remove graph node " << *n << endl;
+std::unordered_map<uint32_t, NodePtr>::iterator pangenome::Graph::remove_node(NodePtr n)
+{
+    // cout << "Remove graph node " << *n << endl;
     // removes all instances of node n and references to it in reads
-    for (const auto &r : n->reads) {
+    for (const auto& r : n->reads) {
         r->remove_all_nodes_with_this_id(n->node_id);
     }
 
@@ -154,9 +166,10 @@ std::unordered_map<uint32_t, NodePtr>::iterator pangenome::Graph::remove_node(No
 // Remove read from each node which contains it
 // and from the graph
 // Remove nodes which no longer have any reads
-void pangenome::Graph::remove_read(const uint32_t read_id) {
-    for (const auto &n : reads[read_id]->nodes) {
-        //cout << "looking at read node " << n->node_id;
+void pangenome::Graph::remove_read(const uint32_t read_id)
+{
+    for (const auto& n : reads[read_id]->nodes) {
+        // cout << "looking at read node " << n->node_id;
         auto nSharedPtr = n.lock();
         nSharedPtr->covg -= 1;
         nSharedPtr->reads.erase(reads[read_id]);
@@ -167,11 +180,15 @@ void pangenome::Graph::remove_read(const uint32_t read_id) {
     reads.erase(read_id);
 }
 
-// Remove a single instance of a node from a read while iterating through the nodes of the read
-std::vector<WeakNodePtr>::iterator pangenome::Graph::remove_node_from_read(std::vector<WeakNodePtr>::iterator node_it, ReadPtr read_ptr) {
+// Remove a single instance of a node from a read while iterating through the nodes of
+// the read
+std::vector<WeakNodePtr>::iterator pangenome::Graph::remove_node_from_read(
+    std::vector<WeakNodePtr>::iterator node_it, ReadPtr read_ptr)
+{
     auto node_ptr = node_it->lock();
 
-    BOOST_LOG_TRIVIAL(debug) << "remove node " << node_ptr->node_id << " from read " << read_ptr->id;
+    BOOST_LOG_TRIVIAL(debug) << "remove node " << node_ptr->node_id << " from read "
+                             << read_ptr->id;
     // remove node from read
     node_it = read_ptr->remove_node_with_iterator(node_it);
 
@@ -188,15 +205,15 @@ std::vector<WeakNodePtr>::iterator pangenome::Graph::remove_node_from_read(std::
 
 // remove the all instances of the pattern of nodes/orienations from graph
 
-
-void pangenome::Graph::remove_low_covg_nodes(const uint32_t &thresh) {
+void pangenome::Graph::remove_low_covg_nodes(const uint32_t& thresh)
+{
     BOOST_LOG_TRIVIAL(debug) << "Remove nodes with covg <= " << thresh << std::endl;
     for (auto it = nodes.begin(); it != nodes.end();) {
-        //cout << "look at node " << *(it->second) << endl;
+        // cout << "look at node " << *(it->second) << endl;
         if (it->second->covg <= thresh) {
-            //cout << "delete node " << it->second->name;
+            // cout << "delete node " << it->second->name;
             it = remove_node(it->second);
-            //cout << " so pangraph now has " << nodes.size() << " nodes" << endl;
+            // cout << " so pangraph now has " << nodes.size() << " nodes" << endl;
         } else {
             ++it;
         }
@@ -205,9 +222,12 @@ void pangenome::Graph::remove_low_covg_nodes(const uint32_t &thresh) {
 }
 
 // Create a copy of the node with node_id and replace the old copy with
-// the new one in each of the reads in reads_along_tig (by looking for the context of node_id)
-void pangenome::Graph::split_node_by_reads(std::unordered_set<ReadPtr> &reads_along_tig, std::vector<uint_least32_t> &node_ids,
-                                const std::vector<bool> &node_orients, const uint_least32_t node_id) {
+// the new one in each of the reads in reads_along_tig (by looking for the context of
+// node_id)
+void pangenome::Graph::split_node_by_reads(std::unordered_set<ReadPtr>& reads_along_tig,
+    std::vector<uint_least32_t>& node_ids, const std::vector<bool>& node_orients,
+    const uint_least32_t node_id)
+{
     if (reads_along_tig.empty()) {
         return;
     }
@@ -216,35 +236,36 @@ void pangenome::Graph::split_node_by_reads(std::unordered_set<ReadPtr> &reads_al
     // (in the context of node_ids) with a new node
     while (nodes.find(next_id) != nodes.end()) {
         next_id++;
-        assert(next_id < std::numeric_limits<uint32_t>::max() ||
-               assert_msg("WARNING, next_id reached max pangraph node size"));
+        assert(next_id < std::numeric_limits<uint32_t>::max()
+            || assert_msg("WARNING, next_id reached max pangraph node size"));
     }
 
     // define new node
-    NodePtr n = std::make_shared<Node>(nodes[node_id]->prg, next_id, nodes[node_id]->kmer_prg_with_coverage.get_total_number_samples());
+    NodePtr n = std::make_shared<Node>(nodes[node_id]->prg, next_id,
+        nodes[node_id]->kmer_prg_with_coverage.get_total_number_samples());
     n->covg -= 1;
     nodes[next_id] = n;
 
     // switch old node to new node in reads
     std::unordered_multiset<ReadPtr>::iterator rit;
     std::pair<uint32_t, uint32_t> pos;
-    for (const auto &r : reads_along_tig) {
+    for (const auto& r : reads_along_tig) {
         // ignore if this node does not contain this read
         rit = nodes[node_id]->reads.find(r);
         if (rit == nodes[node_id]->reads.end()) {
             continue;
         }
 
-        //find iterator to the node in the read
+        // find iterator to the node in the read
         pos = r->find_position(node_ids, node_orients);
         auto it = r->find_node_by_id(node_id);
 
         // replace the node in the read
         if (it != r->nodes.end()) {
-            //cout << "replace node " << (*it)->node_id << " in this read" << endl;
-            //cout << "read was " << *r << endl;
+            // cout << "replace node " << (*it)->node_id << " in this read" << endl;
+            // cout << "read was " << *r << endl;
             r->replace_node_with_iterator(it, n);
-            //cout << "read is now " << *r << endl;
+            // cout << "read is now " << *r << endl;
             nodes[node_id]->reads.erase(rit);
             nodes[node_id]->covg -= 1;
             if (nodes[node_id]->covg == 0) {
@@ -253,7 +274,8 @@ void pangenome::Graph::split_node_by_reads(std::unordered_set<ReadPtr> &reads_al
             n->reads.insert(r);
             n->covg += 1;
             //} else {
-            //    cout  << "read does not contain this node in context of the tig" << endl;
+            //    cout  << "read does not contain this node in context of the tig" <<
+            //    endl;
         }
     }
 
@@ -266,9 +288,8 @@ void pangenome::Graph::split_node_by_reads(std::unordered_set<ReadPtr> &reads_al
     }
 }
 
-
-/*Graph::unordered_set<ReadPtr> find_reads_on_node_path(const vector<uint16_t> node_path_ids,
-                                                      const vector<bool> node_path_orients)
+/*Graph::unordered_set<ReadPtr> find_reads_on_node_path(const vector<uint16_t>
+node_path_ids, const vector<bool> node_path_orients)
 {
     unordered_set<ReadPtr> reads_on_node_path;
 
@@ -284,7 +305,8 @@ void pangenome::Graph::split_node_by_reads(std::unordered_set<ReadPtr> &reads_al
     // remove reads which deviate from path
     for (auto rit = reads_on_node_path.begin(); rit != reads_on_node_path.end();)
     {
-        if ((*rit)->find_position(node_path_ids, node_path_orients) == std::numeric_limits<uint>::max())
+        if ((*rit)->find_position(node_path_ids, node_path_orients) ==
+std::numeric_limits<uint>::max())
         {
             rit = reads_on_node_path.erase(rit);
         } else {
@@ -294,73 +316,93 @@ void pangenome::Graph::split_node_by_reads(std::unordered_set<ReadPtr> &reads_al
     return reads_on_node_path;
 }*/
 
-
 // For each node in pangraph, make a copy of the kmergraph and use the hits
 // stored on each read containing the node to add coverage to this graph
-void pangenome::Graph::add_hits_to_kmergraphs(const std::vector<std::shared_ptr<LocalPRG>> &prgs,
-                                   const uint32_t &sample_id) {
-    for (const auto &node_entries: nodes) {
-        Node &pangraph_node = *node_entries.second;
-        assert(pangraph_node.kmer_prg_with_coverage.kmer_prg != nullptr and not pangraph_node.kmer_prg_with_coverage.kmer_prg->nodes.empty());
+void pangenome::Graph::add_hits_to_kmergraphs(
+    const std::vector<std::shared_ptr<LocalPRG>>& prgs, const uint32_t& sample_id)
+{
+    for (const auto& node_entries : nodes) {
+        Node& pangraph_node = *node_entries.second;
+        assert(pangraph_node.kmer_prg_with_coverage.kmer_prg != nullptr
+            and not pangraph_node.kmer_prg_with_coverage.kmer_prg->nodes.empty());
 
-        uint32_t num_hits[2] = {0, 0};
+        uint32_t num_hits[2] = { 0, 0 };
 
         // add hits
-        for (const auto &read_ptr: pangraph_node.reads) {
-            const Read &read = *read_ptr;
+        for (const auto& read_ptr : pangraph_node.reads) {
+            const Read& read = *read_ptr;
 
             auto hits = read.get_hits_as_unordered_map();
-            for (const auto &minimizer_hit_ptr : hits.at(pangraph_node.prg_id)) {
-                const auto &minimizer_hit = *minimizer_hit_ptr;
+            for (const auto& minimizer_hit_ptr : hits.at(pangraph_node.prg_id)) {
+                const auto& minimizer_hit = *minimizer_hit_ptr;
 
-                assert(minimizer_hit.get_kmer_node_id() < pangraph_node.kmer_prg_with_coverage.kmer_prg->nodes.size());
-                assert(pangraph_node.kmer_prg_with_coverage.kmer_prg->nodes[minimizer_hit.get_kmer_node_id()] != nullptr);
+                assert(minimizer_hit.get_kmer_node_id()
+                    < pangraph_node.kmer_prg_with_coverage.kmer_prg->nodes.size());
+                assert(pangraph_node.kmer_prg_with_coverage.kmer_prg
+                           ->nodes[minimizer_hit.get_kmer_node_id()]
+                    != nullptr);
 
-                pangraph_node.kmer_prg_with_coverage.increment_covg(minimizer_hit.get_kmer_node_id(), minimizer_hit.is_forward(), sample_id);
+                pangraph_node.kmer_prg_with_coverage.increment_covg(
+                    minimizer_hit.get_kmer_node_id(), minimizer_hit.is_forward(),
+                    sample_id);
 
-                if (pangraph_node.kmer_prg_with_coverage.get_covg(minimizer_hit.get_kmer_node_id(), minimizer_hit.is_forward(), sample_id) ==
-                    1000) {
-                    BOOST_LOG_TRIVIAL(debug) << "Adding hit " << minimizer_hit
-                                             << " resulted in high coverage on node "
-                                             << *pangraph_node.kmer_prg_with_coverage.kmer_prg->nodes[minimizer_hit.get_kmer_node_id()];
+                if (pangraph_node.kmer_prg_with_coverage.get_covg(
+                        minimizer_hit.get_kmer_node_id(), minimizer_hit.is_forward(),
+                        sample_id)
+                    == 1000) {
+                    BOOST_LOG_TRIVIAL(debug)
+                        << "Adding hit " << minimizer_hit
+                        << " resulted in high coverage on node "
+                        << *pangraph_node.kmer_prg_with_coverage.kmer_prg
+                                ->nodes[minimizer_hit.get_kmer_node_id()];
                 }
                 num_hits[minimizer_hit.is_forward()] += 1;
             }
         }
 
-        BOOST_LOG_TRIVIAL(debug) << "Added " << num_hits[1] << " hits in the forward direction and "
-                                 << num_hits[0]
-                                 << " hits in the reverse";
+        BOOST_LOG_TRIVIAL(debug)
+            << "Added " << num_hits[1] << " hits in the forward direction and "
+            << num_hits[0] << " hits in the reverse";
         pangraph_node.kmer_prg_with_coverage.set_num_reads(pangraph_node.covg);
     }
 }
 
-// For each node in reference pangraph, copy the coverages over to sample_id in this pangraph
-void pangenome::Graph::copy_coverages_to_kmergraphs(const Graph &ref_pangraph, const uint32_t &sample_id) {
+// For each node in reference pangraph, copy the coverages over to sample_id in this
+// pangraph
+void pangenome::Graph::copy_coverages_to_kmergraphs(
+    const Graph& ref_pangraph, const uint32_t& sample_id)
+{
     const uint32_t ref_sample_id = 0;
-    for (const auto &ref_node_entry : ref_pangraph.nodes){
-        const Node &ref_node = *ref_node_entry.second;
+    for (const auto& ref_node_entry : ref_pangraph.nodes) {
+        const Node& ref_node = *ref_node_entry.second;
         assert(nodes.find(ref_node.node_id) != nodes.end());
-        Node &pangraph_node = *nodes[ref_node.node_id];
+        Node& pangraph_node = *nodes[ref_node.node_id];
 
-        for (auto & kmergraph_node_ptr : pangraph_node.kmer_prg_with_coverage.kmer_prg->nodes){
-            const auto &knode_id = kmergraph_node_ptr->id;
+        for (auto& kmergraph_node_ptr :
+            pangraph_node.kmer_prg_with_coverage.kmer_prg->nodes) {
+            const auto& knode_id = kmergraph_node_ptr->id;
             assert(knode_id < ref_node.kmer_prg_with_coverage.kmer_prg->nodes.size());
-            pangraph_node.kmer_prg_with_coverage.set_covg(knode_id, (uint16_t)(ref_node.kmer_prg_with_coverage.get_covg(knode_id, 0, ref_sample_id)), 0, sample_id);
-            pangraph_node.kmer_prg_with_coverage.set_covg(knode_id, (uint16_t)(ref_node.kmer_prg_with_coverage.get_covg(knode_id, 1, ref_sample_id)), 1, sample_id);
+            pangraph_node.kmer_prg_with_coverage.set_covg(knode_id,
+                (uint16_t)(ref_node.kmer_prg_with_coverage.get_covg(
+                    knode_id, 0, ref_sample_id)),
+                0, sample_id);
+            pangraph_node.kmer_prg_with_coverage.set_covg(knode_id,
+                (uint16_t)(ref_node.kmer_prg_with_coverage.get_covg(
+                    knode_id, 1, ref_sample_id)),
+                1, sample_id);
         }
     }
 }
 
-
-std::vector<LocalNodePtr>
-pangenome::Graph::infer_node_vcf_reference_path(const Node &node, const std::shared_ptr<LocalPRG> &prg_ptr,
-                                                const uint32_t &w, const std::unordered_map<std::string,std::string> &vcf_refs,
-                                                const uint32_t& max_num_kmers_to_average) const {
+std::vector<LocalNodePtr> pangenome::Graph::infer_node_vcf_reference_path(
+    const Node& node, const std::shared_ptr<LocalPRG>& prg_ptr, const uint32_t& w,
+    const std::unordered_map<std::string, std::string>& vcf_refs,
+    const uint32_t& max_num_kmers_to_average) const
+{
     BOOST_LOG_TRIVIAL(info) << "Infer VCF reference path";
-    const auto &prg = *prg_ptr;
-    if (vcf_refs.find(prg.name) != vcf_refs.end()){
-        const auto &vcf_reference_sequence = vcf_refs.at(prg.name);
+    const auto& prg = *prg_ptr;
+    if (vcf_refs.find(prg.name) != vcf_refs.end()) {
+        const auto& vcf_reference_sequence = vcf_refs.at(prg.name);
         const auto reference_path = prg.get_valid_vcf_reference(vcf_reference_sequence);
         if (!reference_path.empty())
             return reference_path;
@@ -368,26 +410,32 @@ pangenome::Graph::infer_node_vcf_reference_path(const Node &node, const std::sha
     return get_node_closest_vcf_reference(node, w, prg, max_num_kmers_to_average);
 }
 
-std::vector<LocalNodePtr>
-pangenome::Graph::get_node_closest_vcf_reference(const Node &node, const uint32_t &w, const LocalPRG &prg,
-                                                 const uint32_t& max_num_kmers_to_average) const {
-     //TODO: check if this is correct
-     auto kmer_prg_with_coverage = node.kmer_prg_with_coverage; //TODO: is this indeed an assignment op?
+std::vector<LocalNodePtr> pangenome::Graph::get_node_closest_vcf_reference(
+    const Node& node, const uint32_t& w, const LocalPRG& prg,
+    const uint32_t& max_num_kmers_to_average) const
+{
+    // TODO: check if this is correct
+    auto kmer_prg_with_coverage
+        = node.kmer_prg_with_coverage; // TODO: is this indeed an assignment op?
     kmer_prg_with_coverage.zeroCoverages();
 
-    for (const auto &sample_entry: this->samples) {
-        const auto &sample = sample_entry.second;
-        if (sample->paths.find(node.prg_id) == sample->paths.end()){
-            BOOST_LOG_TRIVIAL(debug) << "Could not find sample path for sample " << sample->name << " and prg " << node.prg_id;
+    for (const auto& sample_entry : this->samples) {
+        const auto& sample = sample_entry.second;
+        if (sample->paths.find(node.prg_id) == sample->paths.end()) {
+            BOOST_LOG_TRIVIAL(debug) << "Could not find sample path for sample "
+                                     << sample->name << " and prg " << node.prg_id;
             continue;
         }
 
-        BOOST_LOG_TRIVIAL(debug) << "Increment coverages for path for sample " << sample->name << " and prg " << node.prg_id;
-        const auto &sample_paths = sample->paths.at(node.prg_id);
-        for (const auto &sample_path : sample_paths) {
+        BOOST_LOG_TRIVIAL(debug) << "Increment coverages for path for sample "
+                                 << sample->name << " and prg " << node.prg_id;
+        const auto& sample_paths = sample->paths.at(node.prg_id);
+        for (const auto& sample_path : sample_paths) {
             for (uint32_t i = 0; i != sample_path.size(); ++i) {
-                assert(sample_path[i]->id < kmer_prg_with_coverage.kmer_prg->nodes.size()
-                       and kmer_prg_with_coverage.kmer_prg->nodes[sample_path[i]->id] != nullptr);
+                assert(
+                    sample_path[i]->id < kmer_prg_with_coverage.kmer_prg->nodes.size()
+                    and kmer_prg_with_coverage.kmer_prg->nodes[sample_path[i]->id]
+                        != nullptr);
                 kmer_prg_with_coverage.increment_covg(sample_path[i]->id, 0, 0);
                 kmer_prg_with_coverage.increment_covg(sample_path[i]->id, 1, 0);
             }
@@ -409,19 +457,24 @@ pangenome::Graph::get_node_closest_vcf_reference(const Node &node, const uint32_
     }
 }
 
-same_prg_id::same_prg_id(const NodePtr &p) : q(p->prg_id) {};
+same_prg_id::same_prg_id(const NodePtr& p)
+    : q(p->prg_id) {};
 
-bool same_prg_id::operator()(const std::pair<uint32_t, NodePtr> &n) const { return (n.second->prg_id == q); }
+bool same_prg_id::operator()(const std::pair<uint32_t, NodePtr>& n) const
+{
+    return (n.second->prg_id == q);
+}
 
-bool pangenome::Graph::operator==(const Graph &y) const {
+bool pangenome::Graph::operator==(const Graph& y) const
+{
     // false if have different numbers of nodes
     /*if (y.nodes.size() != nodes.size()) {
-        cout << "different num nodes " << nodes.size() << "!=" << y.nodes.size() << endl;
-        return false;
+        cout << "different num nodes " << nodes.size() << "!=" << y.nodes.size() <<
+    endl; return false;
     }*/
 
     // false if have different nodes
-    for (const auto &c: nodes) {
+    for (const auto& c : nodes) {
         // if node id doesn't exist
         auto it = find_if(y.nodes.begin(), y.nodes.end(), same_prg_id(c.second));
         if (it == y.nodes.end()) {
@@ -429,7 +482,7 @@ bool pangenome::Graph::operator==(const Graph &y) const {
             return false;
         }
     }
-    for (const auto &c: y.nodes) {
+    for (const auto& c : y.nodes) {
         // if node id doesn't exist
         auto it = find_if(nodes.begin(), nodes.end(), same_prg_id(c.second));
         if (it == nodes.end()) {
@@ -442,28 +495,29 @@ bool pangenome::Graph::operator==(const Graph &y) const {
     return true;
 }
 
-bool pangenome::Graph::operator!=(const Graph &y) const {
-    return !(*this == y);
-}
+bool pangenome::Graph::operator!=(const Graph& y) const { return !(*this == y); }
 
 // Saves a presence/absence/copynumber matrix for each node and each sample
-void pangenome::Graph::save_matrix(const std::string &filepath, const std::vector<std::string> &sample_names) {
+void pangenome::Graph::save_matrix(
+    const std::string& filepath, const std::vector<std::string>& sample_names)
+{
     // write a presence/absence matrix for samples and nodes
     std::ofstream handle;
     handle.open(filepath);
 
     // save header line with sample names
-    for (const auto &name : sample_names) {
+    for (const auto& name : sample_names) {
         handle << "\t" << name;
     }
     handle << std::endl;
 
     // for each node, save number of each sample
-    for (const auto &n : nodes) {
+    for (const auto& n : nodes) {
         handle << n.second->name;
-        for (const auto &name : sample_names) {
+        for (const auto& name : sample_names) {
             if (samples.find(name) == samples.end()
-                or samples[name]->paths.find(n.second->node_id) == samples[name]->paths.end()) {
+                or samples[name]->paths.find(n.second->node_id)
+                    == samples[name]->paths.end()) {
                 handle << "\t0";
             } else {
                 handle << "\t" << samples[name]->paths[n.second->node_id].size();
@@ -473,7 +527,9 @@ void pangenome::Graph::save_matrix(const std::string &filepath, const std::vecto
     }
 }
 
-void pangenome::Graph::save_mapped_read_strings(const std::string &readfilepath, const std::string &outdir, const int32_t buff) {
+void pangenome::Graph::save_mapped_read_strings(
+    const std::string& readfilepath, const std::string& outdir, const int32_t buff)
+{
     BOOST_LOG_TRIVIAL(debug) << "Save mapped read strings and coordinates";
     std::ofstream outhandle;
     FastaqHandler readfile(readfilepath);
@@ -481,17 +537,19 @@ void pangenome::Graph::save_mapped_read_strings(const std::string &readfilepath,
 
     // for each node in pangraph, find overlaps and write to a file
     std::vector<std::vector<uint32_t>> read_overlap_coordinates;
-    for (const auto &node_ptr : nodes) {
+    for (const auto& node_ptr : nodes) {
         std::cout << "Find coordinates for node " << node_ptr.second->name;
         node_ptr.second->get_read_overlap_coordinates(read_overlap_coordinates);
         std::cout << "." << std::endl;
         fs::create_directories(outdir + "/" + node_ptr.second->get_name());
-        outhandle.open(outdir + "/" + node_ptr.second->get_name() + "/" + node_ptr.second->get_name() + ".reads.fa");
-        for (const auto &coord : read_overlap_coordinates) {
+        outhandle.open(outdir + "/" + node_ptr.second->get_name() + "/"
+            + node_ptr.second->get_name() + ".reads.fa");
+        for (const auto& coord : read_overlap_coordinates) {
             readfile.get_id(coord[0]);
-            start = (uint32_t) std::max((int32_t) coord[1] - buff, 0);
-            end = std::min(coord[2] + (uint32_t) buff, (uint32_t) readfile.read.length());
-            outhandle << ">" << readfile.name << " pandora: " << coord[0] << " " << start << ":" << end;
+            start = (uint32_t)std::max((int32_t)coord[1] - buff, 0);
+            end = std::min(coord[2] + (uint32_t)buff, (uint32_t)readfile.read.length());
+            outhandle << ">" << readfile.name << " pandora: " << coord[0] << " "
+                      << start << ":" << end;
             if (coord[3])
                 outhandle << " + " << std::endl;
             else
@@ -511,13 +569,14 @@ void pangenome::Graph::save_mapped_read_strings(const std::string &readfilepath,
     readfile.close();
 }
 
-std::ostream &pangenome::operator<<(std::ostream &out, const pangenome::Graph &m) {
-    //cout << "printing pangraph" << endl;
-    for (const auto &n : m.nodes) {
+std::ostream& pangenome::operator<<(std::ostream& out, const pangenome::Graph& m)
+{
+    // cout << "printing pangraph" << endl;
+    for (const auto& n : m.nodes) {
         std::cout << n.second->prg_id << std::endl;
         std::cout << *n.second << std::endl;
     }
-    for (const auto &n : m.reads) {
+    for (const auto& n : m.reads) {
         std::cout << *(n.second) << std::endl;
     }
 

--- a/src/pangenome/pannode.cpp
+++ b/src/pangenome/pannode.cpp
@@ -1,28 +1,39 @@
-#include <iostream>
-#include <fstream>
-#include <cassert>
+#include "pangenome/pannode.h"
+#include "localPRG.h"
+#include "minihit.h"
+#include "pangenome/panread.h"
+#include "pangenome/pansample.h"
+#include "utils.h"
 #include <algorithm>
 #include <boost/log/trivial.hpp>
-#include "pangenome/pannode.h"
-#include "pangenome/pansample.h"
-#include "pangenome/panread.h"
-#include "minihit.h"
-#include "utils.h"
-#include "localPRG.h"
-
+#include <cassert>
+#include <fstream>
+#include <iostream>
 
 #define assert_msg(x) !(std::cerr << "Assertion failed: " << x << std::endl)
 
 using namespace pangenome;
 
-//constructors
-pangenome::Node::Node(const std::shared_ptr<LocalPRG> &prg) : Node(prg, prg->id) {}
-pangenome::Node::Node(const std::shared_ptr<LocalPRG> &prg,
-     uint32_t node_id,
-     uint32_t total_number_samples //total number of samples that we have in this node
-) : prg(prg), prg_id(prg->id), node_id(node_id), name(prg->name), covg(0),
-    kmer_prg_with_coverage(const_cast<KmerGraph*>(&prg->kmer_prg), //TODO: this is very dangerous, KmerGraphWithCoverage::kmer_prg must be made const
-    total_number_samples) {}
+// constructors
+pangenome::Node::Node(const std::shared_ptr<LocalPRG>& prg)
+    : Node(prg, prg->id)
+{
+}
+pangenome::Node::Node(const std::shared_ptr<LocalPRG>& prg, uint32_t node_id,
+    uint32_t total_number_samples // total number of samples that we have in this node
+    )
+    : prg(prg)
+    , prg_id(prg->id)
+    , node_id(node_id)
+    , name(prg->name)
+    , covg(0)
+    , kmer_prg_with_coverage(
+          const_cast<KmerGraph*>(
+              &prg->kmer_prg), // TODO: this is very dangerous,
+                               // KmerGraphWithCoverage::kmer_prg must be made const
+          total_number_samples)
+{
+}
 
 /*// copy constructor
 Node::Node(const Node& other)
@@ -54,17 +65,19 @@ Node& Node::operator=(const Node& other)
     return *this;
 }*/
 
-void pangenome::Node::remove_read(ReadPtr r) {
-    //removes single copy of read
+void pangenome::Node::remove_read(ReadPtr r)
+{
+    // removes single copy of read
     auto it = find(reads.begin(), reads.end(), r);
     if (it != reads.end()) {
         covg -= 1;
         reads.erase(it);
-        //it = find(reads.begin(), reads.end(), r);
+        // it = find(reads.begin(), reads.end(), r);
     }
 }
 
-std::string pangenome::Node::get_name() const {
+std::string pangenome::Node::get_name() const
+{
     if (prg_id != node_id) {
         return name + "." + std::to_string(node_id);
     } else {
@@ -72,20 +85,25 @@ std::string pangenome::Node::get_name() const {
     }
 }
 
-void pangenome::Node::add_path(const std::vector<KmerNodePtr> &kmp, const uint32_t &sample_id) {
+void pangenome::Node::add_path(
+    const std::vector<KmerNodePtr>& kmp, const uint32_t& sample_id)
+{
     for (uint32_t i = 0; i != kmp.size(); ++i) {
-        assert(kmp[i]->id < kmer_prg_with_coverage.kmer_prg->nodes.size() and kmer_prg_with_coverage.kmer_prg->nodes[kmp[i]->id] != nullptr);
+        assert(kmp[i]->id < kmer_prg_with_coverage.kmer_prg->nodes.size()
+            and kmer_prg_with_coverage.kmer_prg->nodes[kmp[i]->id] != nullptr);
         kmer_prg_with_coverage.increment_covg(kmp[i]->id, 0, sample_id);
         kmer_prg_with_coverage.increment_covg(kmp[i]->id, 1, sample_id);
     }
 }
 
-void pangenome::Node::get_read_overlap_coordinates(std::vector<std::vector<uint32_t>> &read_overlap_coordinates) {
+void pangenome::Node::get_read_overlap_coordinates(
+    std::vector<std::vector<uint32_t>>& read_overlap_coordinates)
+{
     read_overlap_coordinates.reserve(reads.size());
     std::vector<uint32_t> coordinate;
 
     auto read_count = 0;
-    for (const auto &read_ptr : reads) {
+    for (const auto& read_ptr : reads) {
         read_count++;
         auto hits = read_ptr->get_hits_as_unordered_map();
         if (hits.at(prg_id).size() < 2)
@@ -94,36 +112,39 @@ void pangenome::Node::get_read_overlap_coordinates(std::vector<std::vector<uint3
         auto hit_ptr_iter = hits.at(prg_id).begin();
         uint32_t start = (*hit_ptr_iter)->get_read_start_position();
         uint32_t end = 0;
-        for (const auto &hit_ptr : hits.at(prg_id)) {
+        for (const auto& hit_ptr : hits.at(prg_id)) {
             start = std::min(start, hit_ptr->get_read_start_position());
-            end = std::max(end, hit_ptr->get_read_start_position() + hit_ptr->get_prg_path().length());
+            end = std::max(end,
+                hit_ptr->get_read_start_position() + hit_ptr->get_prg_path().length());
         }
 
-        assert(end > start or assert_msg(
-                "Error finding the read overlap coordinates for node " << name << " and read " << read_ptr->id
-                                                                       << " (the " << read_count << "th on this node)"
-                                                                       << std::endl << "Found end " << end
-                                                                       << " after found start " << start));
-        coordinate = {read_ptr->id, start, end, (*hit_ptr_iter)->is_forward()};
+        assert(end > start
+            or assert_msg("Error finding the read overlap coordinates for node "
+                << name << " and read " << read_ptr->id << " (the " << read_count
+                << "th on this node)" << std::endl
+                << "Found end " << end << " after found start " << start));
+        coordinate = { read_ptr->id, start, end, (*hit_ptr_iter)->is_forward() };
         read_overlap_coordinates.push_back(coordinate);
     }
 
     if (not read_overlap_coordinates.empty()) {
         sort(read_overlap_coordinates.begin(), read_overlap_coordinates.end(),
-             [](const std::vector<uint32_t> &a, const std::vector<uint32_t> &b) {
-                 for (uint32_t i = 0; i < a.size(); ++i) {
-                     if (a[i] != b[i]) { return a[i] < b[i]; }
-                 }
-                 return false;
-             });
+            [](const std::vector<uint32_t>& a, const std::vector<uint32_t>& b) {
+                for (uint32_t i = 0; i < a.size(); ++i) {
+                    if (a[i] != b[i]) {
+                        return a[i] < b[i];
+                    }
+                }
+                return false;
+            });
     }
-
 }
 
-void pangenome::Node::construct_multisample_vcf(VCF &master_vcf,
-                                     const std::vector<LocalNodePtr> &vcf_reference_path,
-                                     const std::shared_ptr<LocalPRG> &prg, const uint32_t w,
-                                     const uint32_t &min_kmer_covg) {
+void pangenome::Node::construct_multisample_vcf(VCF& master_vcf,
+    const std::vector<LocalNodePtr>& vcf_reference_path,
+    const std::shared_ptr<LocalPRG>& prg, const uint32_t w,
+    const uint32_t& min_kmer_covg)
+{
     // create a vcf with respect to this ref
     VCF vcf;
     prg->build_vcf(vcf, vcf_reference_path);
@@ -131,22 +152,25 @@ void pangenome::Node::construct_multisample_vcf(VCF &master_vcf,
 
     BOOST_LOG_TRIVIAL(debug) << "Initial build:\n" << vcf;
 
-    for (const auto &sample: samples) {
+    for (const auto& sample : samples) {
         uint32_t count = 0;
-        for (const auto &sample_kmer_path : sample->paths[prg_id]) {
-            const auto sample_local_path = prg->localnode_path_from_kmernode_path(sample_kmer_path, w);
+        for (const auto& sample_kmer_path : sample->paths[prg_id]) {
+            const auto sample_local_path
+                = prg->localnode_path_from_kmernode_path(sample_kmer_path, w);
             if (count == 0) {
-                prg->add_sample_gt_to_vcf(vcf, vcf_reference_path, sample_local_path, sample->name);
+                prg->add_sample_gt_to_vcf(
+                    vcf, vcf_reference_path, sample_local_path, sample->name);
                 BOOST_LOG_TRIVIAL(debug) << "With sample added:\n" << vcf;
-                prg->add_sample_covgs_to_vcf(vcf, kmer_prg_with_coverage, vcf_reference_path, min_kmer_covg, sample->name,
-                                             sample->sample_id);
+                prg->add_sample_covgs_to_vcf(vcf, kmer_prg_with_coverage,
+                    vcf_reference_path, min_kmer_covg, sample->name, sample->sample_id);
                 BOOST_LOG_TRIVIAL(debug) << "With sample coverages added:\n" << vcf;
             } else {
                 auto path_specific_sample_name = sample->name + std::to_string(count);
-                prg->add_sample_gt_to_vcf(vcf, vcf_reference_path, sample_local_path, path_specific_sample_name);
-                prg->add_sample_covgs_to_vcf(vcf, kmer_prg_with_coverage, vcf_reference_path, min_kmer_covg,
-                                             path_specific_sample_name,
-                                             sample->sample_id);
+                prg->add_sample_gt_to_vcf(vcf, vcf_reference_path, sample_local_path,
+                    path_specific_sample_name);
+                prg->add_sample_covgs_to_vcf(vcf, kmer_prg_with_coverage,
+                    vcf_reference_path, min_kmer_covg, path_specific_sample_name,
+                    sample->sample_id);
             }
             count++;
         }
@@ -158,30 +182,27 @@ void pangenome::Node::construct_multisample_vcf(VCF &master_vcf,
     master_vcf.append_vcf(vcf);
 }
 
-bool pangenome::Node::operator==(const Node &y) const {
-    return (node_id == y.node_id);
-}
+bool pangenome::Node::operator==(const Node& y) const { return (node_id == y.node_id); }
 
-bool pangenome::Node::operator!=(const Node &y) const {
-    return (node_id != y.node_id);
-}
+bool pangenome::Node::operator!=(const Node& y) const { return (node_id != y.node_id); }
 
-bool pangenome::Node::operator<(const Node &y) const {
-    return (node_id < y.node_id);
-}
+bool pangenome::Node::operator<(const Node& y) const { return (node_id < y.node_id); }
 
-std::ostream &pangenome::operator<<(std::ostream &out, pangenome::Node const &n) {
+std::ostream& pangenome::operator<<(std::ostream& out, pangenome::Node const& n)
+{
     out << n.node_id << "," << n.prg_id << " covg: " << n.covg;
     return out;
 }
 
-std::set<ReadCoordinate>
-pangenome::Node::get_read_overlap_coordinates(const prg::Path &local_path, const uint32_t &min_number_hits) {
+std::set<ReadCoordinate> pangenome::Node::get_read_overlap_coordinates(
+    const prg::Path& local_path, const uint32_t& min_number_hits)
+{
     std::set<ReadCoordinate> read_overlap_coordinates;
 
-    for (const auto &current_read: this->reads) {
+    for (const auto& current_read : this->reads) {
         auto hits = current_read->get_hits_as_unordered_map();
-        const auto read_hits_inside_path { find_hits_inside_path(hits.at(this->prg_id), local_path) };
+        const auto read_hits_inside_path { find_hits_inside_path(
+            hits.at(this->prg_id), local_path) };
 
         if (read_hits_inside_path.size() < min_number_hits) {
             continue;
@@ -191,14 +212,17 @@ pangenome::Node::get_read_overlap_coordinates(const prg::Path &local_path, const
         uint32_t start { (*read_hits_iter)->get_read_start_position() };
         uint32_t end { 0 };
 
-        for (const auto &read_hit : read_hits_inside_path) {
+        for (const auto& read_hit : read_hits_inside_path) {
             start = std::min(start, read_hit->get_read_start_position());
-            end = std::max(end, read_hit->get_read_start_position() + read_hit->get_prg_path().length());
+            end = std::max(end,
+                read_hit->get_read_start_position()
+                    + read_hit->get_prg_path().length());
         }
 
         assert(end > start);
 
-        read_overlap_coordinates.emplace(current_read->id, start, end, (*read_hits_iter)->is_forward());
+        read_overlap_coordinates.emplace(
+            current_read->id, start, end, (*read_hits_iter)->is_forward());
     }
     return read_overlap_coordinates;
 }

--- a/src/pangenome/panread.cpp
+++ b/src/pangenome/panread.cpp
@@ -1,81 +1,98 @@
-#include <iostream>
-#include <fstream>
+#include "pangenome/panread.h"
+#include "minihits.h"
+#include "pangenome/pannode.h"
+#include <algorithm>
 #include <cassert>
 #include <climits>
-#include <unordered_set>
-#include <set>
+#include <fstream>
+#include <iostream>
 #include <memory>
+#include <set>
+#include <unordered_set>
 #include <utility>
-#include <algorithm>
-#include "pangenome/panread.h"
-#include "pangenome/pannode.h"
-#include "minihits.h"
-
 
 #define assert_msg(x) !(std::cerr << "Assertion failed: " << x << std::endl)
 
 using namespace pangenome;
 
-Read::Read(const uint32_t i) : id(i), hits(0), node_orientations(0), nodes(0) {}
+Read::Read(const uint32_t i)
+    : id(i)
+    , hits(0)
+    , node_orientations(0)
+    , nodes(0)
+{
+}
 
-Read::~Read() {
+Read::~Read()
+{
     for (MinimizerHit* minihit : hits)
         delete minihit;
 }
 
-std::vector<WeakNodePtr>::iterator Read::find_node_by_id (uint32_t node_id) {
-    return find_if(nodes.begin(), nodes.end(), [&node_id](const WeakNodePtr &weakNodePtr) {
-        return weakNodePtr.lock()->node_id == node_id;
-    });
+std::vector<WeakNodePtr>::iterator Read::find_node_by_id(uint32_t node_id)
+{
+    return find_if(
+        nodes.begin(), nodes.end(), [&node_id](const WeakNodePtr& weakNodePtr) {
+            return weakNodePtr.lock()->node_id == node_id;
+        });
 }
 
-void Read::add_hits(const NodePtr &node_ptr, const std::set<MinimizerHitPtr, pComp> &cluster) {
-    //TODO: review this method...
+void Read::add_hits(
+    const NodePtr& node_ptr, const std::set<MinimizerHitPtr, pComp>& cluster)
+{
+    // TODO: review this method...
     auto before_size = hits.size();
 
-    for (const auto &clusterHitSmrtPointer : cluster)
+    for (const auto& clusterHitSmrtPointer : cluster)
         hits.push_back(new MinimizerHit(*clusterHitSmrtPointer));
-    std::sort(hits.begin(), hits.end(), [](const MinimizerHit * const lhs, const MinimizerHit * const rhs) {
-        return (*lhs) < (*rhs);
-    }); //TODO: might not need this...
-    auto last = std::unique(hits.begin(), hits.end(), [](const MinimizerHit * const lhs, const MinimizerHit * const rhs) {
-        return (*lhs) == (*rhs);
-    });
+    std::sort(hits.begin(), hits.end(),
+        [](const MinimizerHit* const lhs, const MinimizerHit* const rhs) {
+            return (*lhs) < (*rhs);
+        }); // TODO: might not need this...
+    auto last = std::unique(hits.begin(), hits.end(),
+        [](const MinimizerHit* const lhs, const MinimizerHit* const rhs) {
+            return (*lhs) == (*rhs);
+        });
     hits.erase(last, hits.end());
     hits.shrink_to_fit();
 
     assert(hits.size() == before_size + cluster.size());
 
-    //add the orientation/node accordingly
+    // add the orientation/node accordingly
     bool orientation = !cluster.empty() and (*cluster.begin())->is_forward();
-    if (get_nodes().empty()
-        or node_ptr != get_nodes().back().lock()
+    if (get_nodes().empty() or node_ptr != get_nodes().back().lock()
         or orientation != node_orientations.back()
-        //or we think there really are 2 copies of gene
-            ) {
+        // or we think there really are 2 copies of gene
+    ) {
         add_node(node_ptr);
         add_orientation(orientation);
     }
 }
 
+std::unordered_map<uint32_t, std::vector<MinimizerHitPtr>>
+Read::get_hits_as_unordered_map() const
+{
+    std::unordered_map<uint32_t, std::vector<MinimizerHitPtr>>
+        hitsMap; // this will map node_ids from the pangenome::Graph to their minimizer
+                 // hits
+    for (const MinimizerHit* const minihit : hits) {
+        // gets the nodeId
+        uint32_t nodeId = minihit->get_prg_id(); // prg_id == node_id in
+                                                 // pangenome::Graph
 
-std::unordered_map<uint32_t, std::vector<MinimizerHitPtr>> Read::get_hits_as_unordered_map() const {
-    std::unordered_map<uint32_t, std::vector<MinimizerHitPtr>> hitsMap; //this will map node_ids from the pangenome::Graph to their minimizer hits
-    for (const MinimizerHit * const minihit : hits) {
-        //gets the nodeId
-        uint32_t nodeId = minihit->get_prg_id(); //prg_id == node_id in pangenome::Graph
-
-        //checks if we have an entry for this nodeId in hitsMap
+        // checks if we have an entry for this nodeId in hitsMap
         if (hitsMap.find(nodeId) == hitsMap.end())
-            //no, add it
+            // no, add it
             hitsMap[nodeId] = std::vector<MinimizerHitPtr>();
 
-        //add this minihit to hitsMap
-        hitsMap[nodeId].push_back(std::make_shared<MinimizerHit>(*minihit)); //TODO: I think here we don't really need to create a shared pointer - a raw pointer is fine
+        // add this minihit to hitsMap
+        hitsMap[nodeId].push_back(std::make_shared<MinimizerHit>(
+            *minihit)); // TODO: I think here we don't really need to create a shared
+                        // pointer - a raw pointer is fine
     }
 
-    //add empty hits if we have them - for backwards compatibility
-    for (const WeakNodePtr &node : nodes) {
+    // add empty hits if we have them - for backwards compatibility
+    for (const WeakNodePtr& node : nodes) {
         auto node_id = node.lock()->node_id;
         if (hitsMap.find(node_id) == hitsMap.end())
             hitsMap[node_id] = {};
@@ -89,9 +106,10 @@ std::unordered_map<uint32_t, std::vector<MinimizerHitPtr>> Read::get_hits_as_uno
 // NB will find the first such instance if there is more than one
 
 // find the position range where overlaps node_ids and node_orients in read
-std::pair<uint32_t, uint32_t>
-Read::find_position(const std::vector<uint_least32_t> &node_ids, const std::vector<bool> &node_orients,
-                    const uint16_t min_overlap) {
+std::pair<uint32_t, uint32_t> Read::find_position(
+    const std::vector<uint_least32_t>& node_ids, const std::vector<bool>& node_orients,
+    const uint16_t min_overlap)
+{
     /*cout << "searching for ";
     for (const auto &n : node_ids)
     {
@@ -109,23 +127,27 @@ Read::find_position(const std::vector<uint_least32_t> &node_ids, const std::vect
     uint32_t search_pos = 0;
     uint32_t found_pos = 0;
 
-    //cout << "searching forwards for " << node_ids[0] << " " << node_orients[0];
-    //cout << " and backwards for " << node_ids.back() << " " << !node_orients.back() << endl;
+    // cout << "searching forwards for " << node_ids[0] << " " << node_orients[0];
+    // cout << " and backwards for " << node_ids.back() << " " << !node_orients.back()
+    // << endl;
 
     for (uint32_t i = 0; i < nodes.size(); ++i) {
-        //cout << "compare nodes pos " << i << " with node_ids 0" << endl;
+        // cout << "compare nodes pos " << i << " with node_ids 0" << endl;
         // if first node matches at position i going forwards...
-        if (nodes[i].lock()->node_id == node_ids[0] and node_orientations[i] == node_orients[0]) {
-            //cout << "start node " << i << " fwd " << nodes[i]->node_id << " " << node_orientations[i];
-            //cout << " matches " << node_ids[0] << " and " << node_orients[0] << endl;
+        if (nodes[i].lock()->node_id == node_ids[0]
+            and node_orientations[i] == node_orients[0]) {
+            // cout << "start node " << i << " fwd " << nodes[i]->node_id << " " <<
+            // node_orientations[i]; cout << " matches " << node_ids[0] << " and " <<
+            // node_orients[0] << endl;
 
             search_pos = 0;
             found_pos = 0;
             while (i + found_pos < nodes.size()
-                   and nodes[i + found_pos].lock()->node_id == node_ids[search_pos]
-                   and node_orientations[i + found_pos] == node_orients[search_pos]) {
-                //cout << "fwd " << search_pos << " " << i + found_pos << endl;
-                if (search_pos == node_ids.size() - 1 or i + found_pos == nodes.size() - 1) {
+                and nodes[i + found_pos].lock()->node_id == node_ids[search_pos]
+                and node_orientations[i + found_pos] == node_orients[search_pos]) {
+                // cout << "fwd " << search_pos << " " << i + found_pos << endl;
+                if (search_pos == node_ids.size() - 1
+                    or i + found_pos == nodes.size() - 1) {
                     if (found_pos + 1 >= min_overlap) {
                         return std::make_pair(i, i + found_pos);
                     } else {
@@ -135,28 +157,32 @@ Read::find_position(const std::vector<uint_least32_t> &node_ids, const std::vect
                 search_pos++;
                 found_pos++;
             }
-            //cout << "end fwd" << endl;
+            // cout << "end fwd" << endl;
         }
 
-        // if i+node_ids.size() is over the end of nodes, consider partial matches which skip the
-        // first <size_overhang> nodes
-        //cout << "compare nodes pos " << 0 << " with node_ids " << i + node_ids.size() - nodes.size() << endl;
+        // if i+node_ids.size() is over the end of nodes, consider partial matches which
+        // skip the first <size_overhang> nodes
+        // cout << "compare nodes pos " << 0 << " with node_ids " << i + node_ids.size()
+        // - nodes.size() << endl;
         if (i + node_ids.size() > nodes.size()
             and nodes[0].lock()->node_id == node_ids[i + node_ids.size() - nodes.size()]
-            and node_orientations[0] == node_orients[i + node_orients.size() - nodes.size()]) {
+            and node_orientations[0]
+                == node_orients[i + node_orients.size() - nodes.size()]) {
 
-            //cout << "start node " << i << " truncated fwd " << nodes[0]->node_id;
-            //cout << " " << node_orientations[0];
-            //cout << " matches " << node_ids[i + node_ids.size() - nodes.size()];
-            //cout << " and " << node_orients[i + node_ids.size() - nodes.size()] << endl;
+            // cout << "start node " << i << " truncated fwd " << nodes[0]->node_id;
+            // cout << " " << node_orientations[0];
+            // cout << " matches " << node_ids[i + node_ids.size() - nodes.size()];
+            // cout << " and " << node_orients[i + node_ids.size() - nodes.size()] <<
+            // endl;
 
             search_pos = i + node_ids.size() - nodes.size();
             found_pos = 0;
             while (found_pos < nodes.size()
-                   and nodes[found_pos].lock()->node_id == node_ids[search_pos]
-                   and node_orientations[found_pos] == node_orients[search_pos]) {
-                //cout << "fwd " << search_pos << " " << found_pos << endl;
-                if (search_pos == node_ids.size() - 1 or found_pos == nodes.size() - 1) {
+                and nodes[found_pos].lock()->node_id == node_ids[search_pos]
+                and node_orientations[found_pos] == node_orients[search_pos]) {
+                // cout << "fwd " << search_pos << " " << found_pos << endl;
+                if (search_pos == node_ids.size() - 1
+                    or found_pos == nodes.size() - 1) {
                     if (found_pos + 1 >= min_overlap) {
                         return std::make_pair(0, found_pos);
                     } else {
@@ -168,22 +194,29 @@ Read::find_position(const std::vector<uint_least32_t> &node_ids, const std::vect
             }
         }
 
-        //cout << "compare nodes pos " << nodes.size() -1 -i << " with node_ids " << 0 << endl;
+        // cout << "compare nodes pos " << nodes.size() -1 -i << " with node_ids " << 0
+        // << endl;
         if (nodes[nodes.size() - 1 - i].lock()->node_id == node_ids[0]
-            and node_orientations[node_orientations.size() - 1 - i] == !node_orients[0]) {
-            //cout << "start node " << i << " bwd " << nodes[nodes.size() -1 -i]->node_id;
-            //cout << " " << node_orientations[nodes.size() -1 -i];
-            //cout << " matches " << node_ids[0] << " and " << !node_orients[0] << endl;
+            and node_orientations[node_orientations.size() - 1 - i]
+                == !node_orients[0]) {
+            // cout << "start node " << i << " bwd " << nodes[nodes.size() -1
+            // -i]->node_id; cout << " " << node_orientations[nodes.size() -1 -i]; cout
+            // << " matches " << node_ids[0] << " and " << !node_orients[0] << endl;
 
             search_pos = 0;
             found_pos = 0;
             while (i + found_pos < nodes.size()
-                   and nodes[nodes.size() - 1 - i - found_pos].lock()->node_id == node_ids[search_pos]
-                   and node_orientations[nodes.size() - 1 - i - found_pos] == !node_orients[search_pos]) {
-                //cout << "bwd " << search_pos << " " << nodes.size() -1 -i -found_pos << endl;
-                if (search_pos == node_ids.size() - 1 or i + 1 + found_pos == nodes.size()) {
+                and nodes[nodes.size() - 1 - i - found_pos].lock()->node_id
+                    == node_ids[search_pos]
+                and node_orientations[nodes.size() - 1 - i - found_pos]
+                    == !node_orients[search_pos]) {
+                // cout << "bwd " << search_pos << " " << nodes.size() -1 -i -found_pos
+                // << endl;
+                if (search_pos == node_ids.size() - 1
+                    or i + 1 + found_pos == nodes.size()) {
                     if (found_pos + 1 >= min_overlap) {
-                        return std::make_pair(nodes.size() - 1 - i - found_pos, nodes.size() - 1 - i);
+                        return std::make_pair(
+                            nodes.size() - 1 - i - found_pos, nodes.size() - 1 - i);
                     } else {
                         break;
                     }
@@ -191,33 +224,43 @@ Read::find_position(const std::vector<uint_least32_t> &node_ids, const std::vect
                 search_pos++;
                 found_pos++;
             }
-            //cout << "end bwd" << endl;
+            // cout << "end bwd" << endl;
         }
 
-        // if we are considering matches which overlap the start backwards, also consider ones which overlap
-        // the end backwards by the same amount
-        //cout << "compare nodes pos " << nodes.size() -1 << " with node_ids " << nodes.size() -1 - i << endl;
+        // if we are considering matches which overlap the start backwards, also
+        // consider ones which overlap the end backwards by the same amount
+        // cout << "compare nodes pos " << nodes.size() -1 << " with node_ids " <<
+        // nodes.size() -1 - i << endl;
         if (i + node_ids.size() > nodes.size()
-            //and nodes[nodes.size() -1 -i]->node_id == node_ids[i + node_ids.size() - nodes.size()]
-            //and node_orientations[node_orientations.size() -1  -i] == !node_orients[i + node_orients.size() - nodes.size()])
-            and nodes.back().lock()->node_id == node_ids[i + node_ids.size() - nodes.size()]
-            and node_orientations.back() == !node_orients[i + node_orients.size() - nodes.size()]) {
-            //cout << "start node " << i << " truncated bwd " << nodes.back()->node_id;
-            //cout << " " << node_orientations.back();
+            // and nodes[nodes.size() -1 -i]->node_id == node_ids[i + node_ids.size() -
+            // nodes.size()] and node_orientations[node_orientations.size() -1  -i] ==
+            // !node_orients[i + node_orients.size() - nodes.size()])
+            and nodes.back().lock()->node_id
+                == node_ids[i + node_ids.size() - nodes.size()]
+            and node_orientations.back()
+                == !node_orients[i + node_orients.size() - nodes.size()]) {
+            // cout << "start node " << i << " truncated bwd " << nodes.back()->node_id;
+            // cout << " " << node_orientations.back();
             // //cout << " matches " << node_ids[node_ids.size() - nodes.size()-1 - i];
-            // //cout << " and " << !node_orients[node_ids.size() - nodes.size()-1 - i] << endl;
-            //cout << " matches " << node_ids[i + node_ids.size() - nodes.size()];
-            //cout << " and " << !node_orients[i + node_ids.size() - nodes.size()] << endl;
+            // //cout << " and " << !node_orients[node_ids.size() - nodes.size()-1 - i]
+            // << endl;
+            // cout << " matches " << node_ids[i + node_ids.size() - nodes.size()];
+            // cout << " and " << !node_orients[i + node_ids.size() - nodes.size()] <<
+            // endl;
 
             search_pos = i + node_ids.size() - nodes.size();
             found_pos = 0;
             while (found_pos < nodes.size()
-                   and nodes[nodes.size() - 1 - found_pos].lock()->node_id == node_ids[search_pos]
-                   and node_orientations[nodes.size() - 1 - found_pos] == !node_orients[search_pos]) {
-                //cout << "bwd " << search_pos << " " << found_pos << endl;
-                if (search_pos == node_ids.size() - 1 or i + 1 + found_pos == nodes.size()) {
+                and nodes[nodes.size() - 1 - found_pos].lock()->node_id
+                    == node_ids[search_pos]
+                and node_orientations[nodes.size() - 1 - found_pos]
+                    == !node_orients[search_pos]) {
+                // cout << "bwd " << search_pos << " " << found_pos << endl;
+                if (search_pos == node_ids.size() - 1
+                    or i + 1 + found_pos == nodes.size()) {
                     if (found_pos + 1 >= min_overlap) {
-                        return std::make_pair(nodes.size() - 1 - found_pos, nodes.size() - 1);
+                        return std::make_pair(
+                            nodes.size() - 1 - found_pos, nodes.size() - 1);
                     } else {
                         break;
                     }
@@ -227,11 +270,13 @@ Read::find_position(const std::vector<uint_least32_t> &node_ids, const std::vect
             }
         }
     }
-    return std::make_pair(std::numeric_limits<uint32_t>::max(), std::numeric_limits<uint32_t>::max());
+    return std::make_pair(
+        std::numeric_limits<uint32_t>::max(), std::numeric_limits<uint32_t>::max());
 }
 
-void Read::remove_all_nodes_with_this_id(const uint32_t node_id) {
-    //removes all copies of node
+void Read::remove_all_nodes_with_this_id(const uint32_t node_id)
+{
+    // removes all copies of node
     auto it = find_node_by_id(node_id);
     while (it != nodes.end()) {
         uint32_t d = distance(nodes.begin(), it);
@@ -241,7 +286,9 @@ void Read::remove_all_nodes_with_this_id(const uint32_t node_id) {
     }
 }
 
-std::vector<WeakNodePtr>::iterator Read::remove_node_with_iterator(std::vector<WeakNodePtr>::iterator nit) {
+std::vector<WeakNodePtr>::iterator Read::remove_node_with_iterator(
+    std::vector<WeakNodePtr>::iterator nit)
+{
     //(*nit)->covg -= 1;
     uint32_t d = distance(nodes.begin(), nit);
     node_orientations.erase(node_orientations.begin() + d);
@@ -249,36 +296,36 @@ std::vector<WeakNodePtr>::iterator Read::remove_node_with_iterator(std::vector<W
     return nit;
 }
 
-void Read::replace_node_with_iterator(std::vector<WeakNodePtr>::iterator n_original, NodePtr n) {
-    //hits[n->node_id].insert(hits[(*n_original)->node_id].begin(),hits[(*n_original)->node_id].end() );
+void Read::replace_node_with_iterator(
+    std::vector<WeakNodePtr>::iterator n_original, NodePtr n)
+{
+    // hits[n->node_id].insert(hits[(*n_original)->node_id].begin(),hits[(*n_original)->node_id].end()
+    // );
     auto it = nodes.erase(n_original);
     nodes.insert(it, n);
-    //hits.erase((*n_original)->node_id);
-
+    // hits.erase((*n_original)->node_id);
 }
 
-bool Read::operator==(const Read &y) const {
-    if (id != y.id) { return false; }
+bool Read::operator==(const Read& y) const
+{
+    if (id != y.id) {
+        return false;
+    }
 
     return true;
 }
 
-bool Read::operator!=(const Read &y) const {
-    return !(*this == y);
-}
+bool Read::operator!=(const Read& y) const { return !(*this == y); }
 
-bool Read::operator<(const Read &y) const {
-    return (id < y.id);
-}
+bool Read::operator<(const Read& y) const { return (id < y.id); }
 
-
-std::ostream &pangenome::operator<<(std::ostream &out, const pangenome::Read &r) {
+std::ostream& pangenome::operator<<(std::ostream& out, const pangenome::Read& r)
+{
     out << r.id << "\t";
 
-    for (const auto &i : r.nodes) {
+    for (const auto& i : r.nodes) {
         out << *(i.lock()) << " ";
     }
     out << std::endl;
     return out;
 }
-

--- a/src/pangenome/pansample.cpp
+++ b/src/pangenome/pansample.cpp
@@ -1,46 +1,50 @@
-#include <iostream>
-#include <string>
-#include <fstream>
-#include <cassert>
-#include <unordered_set>
-#include <algorithm>
 #include "pangenome/pansample.h"
 #include "pangenome/pannode.h"
-
+#include <algorithm>
+#include <cassert>
+#include <fstream>
+#include <iostream>
+#include <string>
+#include <unordered_set>
 
 #define assert_msg(x) !(std::cerr << "Assertion failed: " << x << std::endl)
 
 using namespace pangenome;
 
-Sample::Sample(const std::string &s, const uint32_t &id) : name(s), sample_id(id) {}
+Sample::Sample(const std::string& s, const uint32_t& id)
+    : name(s)
+    , sample_id(id)
+{
+}
 
-void Sample::add_path(const uint32_t node_id, const std::vector<KmerNodePtr> &c) {
+void Sample::add_path(const uint32_t node_id, const std::vector<KmerNodePtr>& c)
+{
     if (paths.find(node_id) == paths.end()) {
-        paths[node_id] = {c};
+        paths[node_id] = { c };
     } else {
         paths[node_id].push_back(c);
     }
 }
 
-bool Sample::operator==(const Sample &y) const {
-    if (name != y.name) { return false; }
+bool Sample::operator==(const Sample& y) const
+{
+    if (name != y.name) {
+        return false;
+    }
     return true;
 }
 
-bool Sample::operator!=(const Sample &y) const {
-    return !(*this == y);
-}
+bool Sample::operator!=(const Sample& y) const { return !(*this == y); }
 
-bool Sample::operator<(const Sample &y) const {
-    return (name < y.name);
-}
+bool Sample::operator<(const Sample& y) const { return (name < y.name); }
 
-std::ostream &pangenome::operator<<(std::ostream &out, pangenome::Sample const &s) {
+std::ostream& pangenome::operator<<(std::ostream& out, pangenome::Sample const& s)
+{
     out << s.name << ":\t";
-    for (const auto &p : s.paths) {
+    for (const auto& p : s.paths) {
         for (uint32_t i = 0; i != p.second.size(); ++i) {
             out << p.first << "\t";
-            for (const auto &n : p.second[i]){
+            for (const auto& n : p.second[i]) {
                 out << *n;
             }
             out << std::endl;
@@ -49,7 +53,8 @@ std::ostream &pangenome::operator<<(std::ostream &out, pangenome::Sample const &
     return out;
 }
 
-
-bool pangenome::SamplePtrSorterBySampleId::operator()(const pangenome::SamplePtr &lhs, const pangenome::SamplePtr &rhs) const {
+bool pangenome::SamplePtrSorterBySampleId::operator()(
+    const pangenome::SamplePtr& lhs, const pangenome::SamplePtr& rhs) const
+{
     return lhs->sample_id < rhs->sample_id;
 }

--- a/src/prg/ns.cpp
+++ b/src/prg/ns.cpp
@@ -1,12 +1,11 @@
 #include <iostream>
 
-
 namespace prg {
-    class Path;
+class Path;
 
-    Path get_union(const Path &x, const Path &y);
+Path get_union(const Path& x, const Path& y);
 
-    std::ostream &operator<<(std::ostream &out, const Path &p);
+std::ostream& operator<<(std::ostream& out, const Path& p);
 
-    std::istream &operator>>(std::istream &in, Path &p);
+std::istream& operator>>(std::istream& in, Path& p);
 }

--- a/src/prg/path.cpp
+++ b/src/prg/path.cpp
@@ -1,92 +1,103 @@
+#include "prg/path.h"
 #include <cassert>
 #include <localPRG.h>
-#include "prg/path.h"
-
 
 #define assert_msg(x) !(std::cerr << "Assertion failed: " << x << std::endl)
 
-uint32_t prg::Path::get_start() const {
+uint32_t prg::Path::get_start() const
+{
     if (path.size() < 1)
         return 0;
     return path.front().start;
 }
 
-uint32_t prg::Path::get_end() const {
+uint32_t prg::Path::get_end() const
+{
     if (path.size() < 1)
         return 0;
-    return path.back().start + (uint32_t) path.back().length;
+    return path.back().start + (uint32_t)path.back().length;
 }
 
-uint32_t prg::Path::length() const {
+uint32_t prg::Path::length() const
+{
     uint32_t length = 0;
-    for (const auto &interval: path)
+    for (const auto& interval : path)
         length += interval.length;
     return length;
 }
 
-void prg::Path::add_end_interval(const Interval &i) {
+void prg::Path::add_end_interval(const Interval& i)
+{
     memoizedDirty = true;
-    assert (i.start >= get_end() || assert_msg(
-            "tried to add interval starting at " << i.start << " to end of path finishing at " << get_end()));
+    assert(i.start >= get_end()
+        || assert_msg("tried to add interval starting at "
+            << i.start << " to end of path finishing at " << get_end()));
     path.push_back(i);
 }
 
-std::vector<LocalNodePtr> prg::Path::nodes_along_path(const LocalPRG &localPrg) {
-    //sanity check
-    assert ((isMemoized == false || (isMemoized == true && localPRGIdOfMemoizedLocalNodePath == localPrg.id)) ||
-            assert_msg(
-                    "Memoization bug: memoized a local node path for PRG with id"
-                            << localPRGIdOfMemoizedLocalNodePath
-                            <<
-                            " but PRG id " << localPrg.id
-                            << " is also trying to use this memoized path"));
+std::vector<LocalNodePtr> prg::Path::nodes_along_path(const LocalPRG& localPrg)
+{
+    // sanity check
+    assert(
+        (isMemoized == false
+            || (isMemoized == true && localPRGIdOfMemoizedLocalNodePath == localPrg.id))
+        || assert_msg("Memoization bug: memoized a local node path for PRG with id"
+            << localPRGIdOfMemoizedLocalNodePath << " but PRG id " << localPrg.id
+            << " is also trying to use this memoized path"));
 
-    if (isMemoized == false || memoizedDirty == true) { //checks if we must do memoization
-        //yes
-        //not memoized, memoize
+    if (isMemoized == false
+        || memoizedDirty == true) { // checks if we must do memoization
+        // yes
+        // not memoized, memoize
         memoizedLocalNodePath = localPrg.nodes_along_path_core(*this);
 
-        //update the memoization control variables
+        // update the memoization control variables
         localPRGIdOfMemoizedLocalNodePath = localPrg.id;
         isMemoized = true;
         memoizedDirty = false;
 
-        //return the local node path
+        // return the local node path
         return memoizedLocalNodePath;
     } else if (memoizedDirty == false) {
-        //redudant call, return the memoized local node path
+        // redudant call, return the memoized local node path
         return memoizedLocalNodePath;
     } else {
         fatalError("Bug on prg::Path::nodes_along_path()");
     }
 }
 
-prg::Path prg::Path::subpath(const uint32_t start, const uint32_t len) const {
-    //function now returns the path starting at position start along the path, rather than at position start on
-    //linear PRG, and for length len
-    //cout << "find subpath of " << *this << " from " << start << " for length " << len << endl;
+prg::Path prg::Path::subpath(const uint32_t start, const uint32_t len) const
+{
+    // function now returns the path starting at position start along the path, rather
+    // than at position start on linear PRG, and for length len cout << "find subpath of
+    // " << *this << " from " << start << " for length " << len << endl;
     assert(start + len <= length());
     prg::Path p;
     std::deque<Interval> d;
     uint32_t covered_length = 0;
     uint32_t added_len = 0;
-    for (const auto &interval: path) {
-        if ((covered_length <= start and covered_length + interval.length > start and p.path.empty()) or
-            (covered_length == start and interval.length == 0 and p.path.empty())) {
+    for (const auto& interval : path) {
+        if ((covered_length <= start and covered_length + interval.length > start
+                and p.path.empty())
+            or (covered_length == start and interval.length == 0 and p.path.empty())) {
             assert(added_len == 0);
-            d = {Interval(interval.start + start - covered_length,
-                          std::min(interval.get_end(), interval.start + start - covered_length + len - added_len))};
+            d = { Interval(interval.start + start - covered_length,
+                std::min(interval.get_end(),
+                    interval.start + start - covered_length + len - added_len)) };
             p.initialize(d);
-            added_len += std::min(len - added_len, interval.length - start + covered_length);
-            ///cout << "added first interval " << p.path.back() << " and added length is now " << added_len << endl;
+            added_len
+                += std::min(len - added_len, interval.length - start + covered_length);
+            /// cout << "added first interval " << p.path.back() << " and added length
+            /// is now " << added_len << endl;
         } else if (covered_length >= start and added_len <= len) {
-            p.add_end_interval(
-                    Interval(interval.start, std::min(interval.get_end(), interval.start + len - added_len)));
+            p.add_end_interval(Interval(interval.start,
+                std::min(interval.get_end(), interval.start + len - added_len)));
             added_len += std::min(len - added_len, interval.length);
-            //cout << "added interval " << p.path.back() << " and added length is now " << added_len << endl;
+            // cout << "added interval " << p.path.back() << " and added length is now "
+            // << added_len << endl;
         }
         covered_length += interval.length;
-        //cout << "covered length is now " << covered_length << endl;
+        // cout << "covered length is now " << covered_length << endl;
         if (added_len >= len) {
             break;
         }
@@ -95,7 +106,8 @@ prg::Path prg::Path::subpath(const uint32_t start, const uint32_t len) const {
     return p;
 }
 
-bool prg::Path::is_branching(const prg::Path &y) const // returns true if the two paths branch together or coalesce apart
+bool prg::Path::is_branching(const prg::Path& y)
+    const // returns true if the two paths branch together or coalesce apart
 {
     // simple case, one ends before the other starts -> return false
     if (get_end() < y.get_start() or y.get_end() < get_start()) {
@@ -109,7 +121,7 @@ bool prg::Path::is_branching(const prg::Path &y) const // returns true if the tw
         if (overlap) {
             if (it->start != it2->start) {
                 // had paths which overlapped and now don't
-                //cout << "branch" << endl;
+                // cout << "branch" << endl;
                 return true; // represent branching paths at this point
             }
             ++it2;
@@ -119,21 +131,25 @@ bool prg::Path::is_branching(const prg::Path &y) const // returns true if the tw
             }
         } else {
             for (it2 = y.path.begin(); it2 != y.path.end(); ++it2) {
-                //cout << *it << " " << *it2 << endl;
-                if ((it->get_end() > it2->start and it->start < it2->get_end()) or (*it == *it2)) {
+                // cout << *it << " " << *it2 << endl;
+                if ((it->get_end() > it2->start and it->start < it2->get_end())
+                    or (*it == *it2)) {
                     // then the paths overlap
                     overlap = true;
-                    //cout << "overlap" << endl;
-                    // first query the previous intervals if they exist, to see if they overlap
-                    if (it != path.begin() && it2 != y.path.begin() && (--it)->get_end() != (--it2)->get_end()) {
-                        //cout << "coal" << endl;
+                    // cout << "overlap" << endl;
+                    // first query the previous intervals if they exist, to see if they
+                    // overlap
+                    if (it != path.begin() && it2 != y.path.begin()
+                        && (--it)->get_end() != (--it2)->get_end()) {
+                        // cout << "coal" << endl;
                         return true; // represent coalescent paths at this point
                     } else {
                         ++it2;
                         if (it2 == y.path.end()) {
                             return false;
                         }
-                        break; // we will step through intervals from here comparing to path
+                        break; // we will step through intervals from here comparing to
+                               // path
                     }
                 }
             }
@@ -143,19 +159,18 @@ bool prg::Path::is_branching(const prg::Path &y) const // returns true if the tw
     return false;
 }
 
-bool prg::Path::is_subpath(const prg::Path &big_path) const {
-    if (big_path.length() < length()
-        or big_path.get_start() > get_start()
-        or big_path.get_end() < get_end()
-        or is_branching(big_path)) {
-        //cout << "fell at first hurdle " << (big_path.length() < length());
-        //cout << (big_path.start > start) << (big_path.end < end);
-        //cout << (is_branching(big_path)) << endl;
+bool prg::Path::is_subpath(const prg::Path& big_path) const
+{
+    if (big_path.length() < length() or big_path.get_start() > get_start()
+        or big_path.get_end() < get_end() or is_branching(big_path)) {
+        // cout << "fell at first hurdle " << (big_path.length() < length());
+        // cout << (big_path.start > start) << (big_path.end < end);
+        // cout << (is_branching(big_path)) << endl;
         return false;
     }
 
     uint32_t offset = 0;
-    for (const auto &big_i : big_path.path) {
+    for (const auto& big_i : big_path.path) {
         if (big_i.get_end() >= get_start()) {
             offset += get_start() - big_i.start;
             if (offset + length() > big_path.length()) {
@@ -171,11 +186,13 @@ bool prg::Path::is_subpath(const prg::Path &big_path) const {
     return false;
 }
 
-bool prg::Path::operator<(const prg::Path &y) const {
+bool prg::Path::operator<(const prg::Path& y) const
+{
     auto it2 = y.path.begin();
     auto it = path.begin();
     while (it != path.end() and it2 != y.path.end()) {
-        if (!(*it == *it2)) //for the first interval which is not the same in both paths
+        if (!(*it
+                == *it2)) // for the first interval which is not the same in both paths
         {
             return (*it < *it2); // return interval comparison
         }
@@ -183,18 +200,24 @@ bool prg::Path::operator<(const prg::Path &y) const {
         it2++;
     }
     if (it == path.end() and it2 != y.path.end()) {
-        // if path is shorter than comparison path, but equal otherwise, return that it is smaller
+        // if path is shorter than comparison path, but equal otherwise, return that it
+        // is smaller
         return true;
     }
 
     return false; // shouldn't ever call this
 }
 
-bool prg::Path::operator==(const prg::Path &y) const {
-    if (path.size() != y.path.size()) { return false; }
+bool prg::Path::operator==(const prg::Path& y) const
+{
+    if (path.size() != y.path.size()) {
+        return false;
+    }
     auto it2 = y.path.begin();
     for (auto it = path.begin(); it != path.end();) {
-        if (!(*it == *it2)) { return false; }
+        if (!(*it == *it2)) {
+            return false;
+        }
         it++;
         it2++;
     }
@@ -203,7 +226,8 @@ bool prg::Path::operator==(const prg::Path &y) const {
 
 // tests if the paths are equal except for null nodes at the start or
 // ends of the paths
-bool equal_except_null_nodes(const prg::Path &x, const prg::Path &y) {
+bool equal_except_null_nodes(const prg::Path& x, const prg::Path& y)
+{
     auto it2 = y.begin();
     for (auto it = x.begin(); it != x.end();) {
         while (it != x.end() and it->length == 0) {
@@ -229,11 +253,10 @@ bool equal_except_null_nodes(const prg::Path &x, const prg::Path &y) {
     return true;
 }
 
-bool prg::Path::operator!=(const prg::Path &y) const {
-    return (!(path == y.path));
-}
+bool prg::Path::operator!=(const prg::Path& y) const { return (!(path == y.path)); }
 
-std::ostream &prg::operator<<(std::ostream &out, const prg::Path &p) {
+std::ostream& prg::operator<<(std::ostream& out, const prg::Path& p)
+{
     uint32_t num_intervals = p.path.size();
     out << num_intervals << "{";
     for (auto it = p.path.begin(); it != p.path.end(); ++it) {
@@ -243,7 +266,8 @@ std::ostream &prg::operator<<(std::ostream &out, const prg::Path &p) {
     return out;
 }
 
-std::istream &prg::operator>>(std::istream &in, prg::Path &p) {
+std::istream& prg::operator>>(std::istream& in, prg::Path& p)
+{
     uint32_t num_intervals;
     in >> num_intervals;
     std::deque<Interval> d(num_intervals, Interval());
@@ -256,12 +280,13 @@ std::istream &prg::operator>>(std::istream &in, prg::Path &p) {
     return in;
 }
 
-prg::Path prg::get_union(const prg::Path &x, const prg::Path &y) {
+prg::Path prg::get_union(const prg::Path& x, const prg::Path& y)
+{
     auto xit = x.path.begin();
     auto yit = y.path.begin();
 
     prg::Path p;
-    assert (x < y);
+    assert(x < y);
 
     if (x.get_end() < y.get_start() or x.is_branching(y)) {
         return p;
@@ -269,7 +294,8 @@ prg::Path prg::get_union(const prg::Path &x, const prg::Path &y) {
         return y;
     }
 
-    while (xit != x.path.end() and yit != y.path.end() and xit->get_end() < yit->start) {
+    while (
+        xit != x.path.end() and yit != y.path.end() and xit->get_end() < yit->start) {
         if (p.path.empty()) {
             p.initialize(*xit);
         } else {
@@ -280,9 +306,11 @@ prg::Path prg::get_union(const prg::Path &x, const prg::Path &y) {
     if (xit != x.path.end() and yit != y.path.end() and xit->start <= yit->get_end()) {
         // then we have overlap
         if (p.path.empty()) {
-            p.initialize(Interval(xit->start, std::max(yit->get_end(), xit->get_end())));
+            p.initialize(
+                Interval(xit->start, std::max(yit->get_end(), xit->get_end())));
         } else {
-            p.add_end_interval(Interval(xit->start, std::max(yit->get_end(), xit->get_end())));
+            p.add_end_interval(
+                Interval(xit->start, std::max(yit->get_end(), xit->get_end())));
         }
         while (yit != --y.path.end()) {
             yit++;

--- a/src/random_path_main.cpp
+++ b/src/random_path_main.cpp
@@ -1,17 +1,16 @@
-#include <cstring>
-#include <cassert>
-#include <vector>
-#include <iostream>
-#include <fstream>
+#include "fastaq.h"
+#include "fastaq_handler.h"
 #include "localPRG.h"
-#include "utils.h"
 #include "localgraph.h"
 #include "localnode.h"
-#include "fastaq_handler.h"
-#include "fastaq.h"
+#include "utils.h"
+#include <cassert>
+#include <cstring>
+#include <fstream>
+#include <iostream>
+#include <vector>
 
-
-int pandora_random_path(int argc, char *argv[]) // the "pandora walk" comand
+int pandora_random_path(int argc, char* argv[]) // the "pandora walk" comand
 {
     if (argc != 3 and argc != 2) {
         fprintf(stderr, "Usage: pandora random_path <in_prg.fa> [<num_paths>]\n");
@@ -30,7 +29,7 @@ int pandora_random_path(int argc, char *argv[]) // the "pandora walk" comand
         num_paths = strtoul(argv[2], nullptr, 10);
     }
 
-    for (const auto &prg_ptr: prgs) {
+    for (const auto& prg_ptr : prgs) {
         std::unordered_set<std::string> random_paths;
         auto skip = 0;
         while (random_paths.size() < num_paths and skip < 10) {
@@ -42,7 +41,7 @@ int pandora_random_path(int argc, char *argv[]) // the "pandora walk" comand
             }
         }
         uint32_t i = 0;
-        for (const auto &path : random_paths) {
+        for (const auto& path : random_paths) {
             fa.add_entry(prg_ptr->name + "_" + std::to_string(i), path);
             i++;
         }
@@ -52,4 +51,3 @@ int pandora_random_path(int argc, char *argv[]) // the "pandora walk" comand
 
     return 0;
 }
-

--- a/src/seq.cpp
+++ b/src/seq.cpp
@@ -1,6 +1,6 @@
+#include <cassert>
 #include <iostream>
 #include <vector>
-#include <cassert>
 #include <zconf.h>
 
 #include <boost/log/trivial.hpp>
@@ -10,21 +10,23 @@
 #include "seq.h"
 #include "utils.h"
 
-
 #define assert_msg(x) !(std::cerr << "Assertion failed: " << x << std::endl)
 
 using std::vector;
 
-
-Seq::Seq(uint32_t i, const std::string &n, const std::string &p, uint32_t w, uint32_t k) : id(i), name(n), seq(p) {
+Seq::Seq(uint32_t i, const std::string& n, const std::string& p, uint32_t w, uint32_t k)
+    : id(i)
+    , name(n)
+    , seq(p)
+{
     minimizer_sketch(w, k);
 }
 
-Seq::~Seq() {
-    sketch.clear();
-}
+Seq::~Seq() { sketch.clear(); }
 
-void Seq::initialize(uint32_t i, const std::string &n, const std::string &p, uint32_t w, uint32_t k) {
+void Seq::initialize(
+    uint32_t i, const std::string& n, const std::string& p, uint32_t w, uint32_t k)
+{
     id = i;
     name = n;
     seq = p;
@@ -32,31 +34,32 @@ void Seq::initialize(uint32_t i, const std::string &n, const std::string &p, uin
     minimizer_sketch(w, k);
 }
 
-bool Seq::add_letter_to_get_next_kmer(const char &letter,
-                                      const uint64_t &shift1,
-                                      const uint64_t &mask,
-                                      uint32_t &buff,
-                                      uint64_t (&kmer)[2],
-                                      uint64_t (&kh)[2]) {
-    uint32_t c = nt4((uint8_t) letter);
+bool Seq::add_letter_to_get_next_kmer(const char& letter, const uint64_t& shift1,
+    const uint64_t& mask, uint32_t& buff, uint64_t (&kmer)[2], uint64_t (&kh)[2])
+{
+    uint32_t c = nt4((uint8_t)letter);
     if (c < 4) { // not an ambiguous base
-        kmer[0] = (kmer[0] << 2 | c) & mask;           // forward k-mer
+        kmer[0] = (kmer[0] << 2 | c) & mask; // forward k-mer
         kmer[1] = (kmer[1] >> 2) | (3ULL ^ c) << shift1; // reverse k-mer
         kh[0] = hash64(kmer[0], mask);
         kh[1] = hash64(kmer[1], mask);
         buff++;
         return true;
     } else {
-        BOOST_LOG_TRIVIAL(debug) << now() << "bad letter - found a non AGCT base in read so skipping read " << name;
+        BOOST_LOG_TRIVIAL(debug)
+            << now() << "bad letter - found a non AGCT base in read so skipping read "
+            << name;
         sketch.clear();
         return false;
     }
 }
 
-uint64_t find_smallest_kmer_value(const vector<Minimizer> &window, uint &pos_of_smallest) {
+uint64_t find_smallest_kmer_value(
+    const vector<Minimizer>& window, uint& pos_of_smallest)
+{
     uint64_t smallest = std::numeric_limits<uint64_t>::max();
     uint i = 0;
-    for (const auto &minimizer : window) {
+    for (const auto& minimizer : window) {
         if (minimizer.canonical_kmer_hash <= smallest) {
             smallest = minimizer.canonical_kmer_hash;
             pos_of_smallest = i;
@@ -66,65 +69,80 @@ uint64_t find_smallest_kmer_value(const vector<Minimizer> &window, uint &pos_of_
     return smallest;
 }
 
-void Seq::add_minimizing_kmers_to_sketch(const vector<Minimizer> &window, const uint64_t &smallest) {
-    for (const auto &minimizer : window) {
+void Seq::add_minimizing_kmers_to_sketch(
+    const vector<Minimizer>& window, const uint64_t& smallest)
+{
+    for (const auto& minimizer : window) {
         if (minimizer.canonical_kmer_hash == smallest) {
             sketch.insert(minimizer);
-            //num_minis_found += 1;
+            // num_minis_found += 1;
         }
     }
 }
 
-//finds the minimizer in the window, add the minimizer to the sketch set and erase everything until the minimizer
-void Seq::minimize_window(vector<Minimizer> &window, uint64_t &smallest) {
+// finds the minimizer in the window, add the minimizer to the sketch set and erase
+// everything until the minimizer
+void Seq::minimize_window(vector<Minimizer>& window, uint64_t& smallest)
+{
     uint pos_of_smallest;
     smallest = find_smallest_kmer_value(window, pos_of_smallest);
     add_minimizing_kmers_to_sketch(window, smallest);
     window.erase(window.begin(), window.begin() + pos_of_smallest + 1);
 }
 
-//add the last element of the window (a Minimizer) to the sketch, update the smallest and clear the window
-void Seq::add_new_smallest_minimizer(vector<Minimizer> &window, uint64_t &smallest) {
+// add the last element of the window (a Minimizer) to the sketch, update the smallest
+// and clear the window
+void Seq::add_new_smallest_minimizer(vector<Minimizer>& window, uint64_t& smallest)
+{
     sketch.insert(window.back());
     smallest = window.back().canonical_kmer_hash;
     window.clear();
 }
 
-void Seq::minimizer_sketch(const uint32_t w, const uint32_t k) {
+void Seq::minimizer_sketch(const uint32_t w, const uint32_t k)
+{
     bool sequence_too_short_to_sketch = seq.length() + 1 < w + k;
     if (sequence_too_short_to_sketch)
         return;
 
     // initializations
     uint64_t shift1 = 2 * (k - 1), mask = (1ULL << 2 * k) - 1,
-            smallest = std::numeric_limits<uint64_t>::max(),
-            kmer[2] = {0, 0}, kh[2] = {0, 0};
+             smallest = std::numeric_limits<uint64_t>::max(), kmer[2] = { 0, 0 },
+             kh[2] = { 0, 0 };
     uint32_t buff = 0;
-    vector<Minimizer> window; //will store all k-mers as Minimizer in the window
+    vector<Minimizer> window; // will store all k-mers as Minimizer in the window
     window.reserve(w);
 
     for (const char letter : seq) {
-        bool added = add_letter_to_get_next_kmer(letter, shift1, mask, buff, kmer, kh); //add the next base and remove the first one to get the next kmer
+        bool added = add_letter_to_get_next_kmer(letter, shift1, mask, buff, kmer,
+            kh); // add the next base and remove the first one to get the next kmer
         if (not added)
             return;
 
         if (buff >= k) {
-            window.push_back(Minimizer(std::min(kh[0], kh[1]), buff - k, buff, (kh[0] <= kh[1])));
+            window.push_back(
+                Minimizer(std::min(kh[0], kh[1]), buff - k, buff, (kh[0] <= kh[1])));
         }
 
         if (window.size() == w) {
-            minimize_window(window, smallest); //finds the minimizer in the window, add the minimizer to the sketch set and erase everything until the minimizer
+            minimize_window(window,
+                smallest); // finds the minimizer in the window, add the minimizer to
+                           // the sketch set and erase everything until the minimizer
         } else if (buff >= w + k and window.back().canonical_kmer_hash <= smallest) {
-            add_new_smallest_minimizer(window, smallest); //add the last element of the window (a Minimizer) to the sketch, update the smallest and clear the window
+            add_new_smallest_minimizer(window,
+                smallest); // add the last element of the window (a Minimizer) to the
+                           // sketch, update the smallest and clear the window
         }
-        assert(window.size() < w ||
-               assert_msg("we can't have added a smallest kmer correctly as window still has size " << window.size()));
+        assert(window.size() < w
+            || assert_msg("we can't have added a smallest kmer correctly as window "
+                          "still has size "
+                << window.size()));
     }
-    //cout << now() << "Sketch size " << sketch.size() << " for read " << name << endl;
+    // cout << now() << "Sketch size " << sketch.size() << " for read " << name << endl;
 }
 
-std::ostream &operator<<(std::ostream &out, Seq const &data) {
+std::ostream& operator<<(std::ostream& out, Seq const& data)
+{
     out << data.name;
     return out;
 }
-

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -1,33 +1,32 @@
-#include <cstring>
-#include <sstream>
-#include <iomanip>
-#include <unordered_map>
-#include <vector>
-#include <iostream>
-#include <fstream>
-#include <cmath>
-#include <cassert>
-#include <cctype>
-#include <set>
-#include <memory>
-#include <ctime>
 #include <algorithm>
 #include <boost/filesystem.hpp>
+#include <cassert>
+#include <cctype>
+#include <cmath>
+#include <cstring>
+#include <ctime>
+#include <fstream>
+#include <iomanip>
+#include <iostream>
+#include <memory>
+#include <set>
+#include <sstream>
+#include <unordered_map>
+#include <vector>
 
-#include "utils.h"
-#include "seq.h"
+#include "fastaq_handler.h"
 #include "localPRG.h"
+#include "minihit.h"
+#include "noise_filtering.h"
 #include "pangenome/pangraph.h"
 #include "pangenome/panread.h"
-#include "noise_filtering.h"
-#include "minihit.h"
-#include "fastaq_handler.h"
-
+#include "seq.h"
+#include "utils.h"
 
 #define assert_msg(x) !(std::cerr << "Assertion failed: " << x << std::endl)
 
-
-std::string now() {
+std::string now()
+{
     time_t now;
     std::string dt;
 
@@ -36,13 +35,15 @@ std::string now() {
     return dt.substr(0, dt.length() - 1) + " ";
 }
 
-std::string int_to_string(const int number) {
+std::string int_to_string(const int number)
+{
     std::stringstream ss;
     ss << std::setw(2) << std::setfill('0') << number;
     return ss.str();
 }
 
-std::vector<std::string> split(const std::string &query, const std::string &d) {
+std::vector<std::string> split(const std::string& query, const std::string& d)
+{
     std::vector<std::string> v;
     std::string::size_type k = 0;
     std::string::size_type j = query.find(d, k);
@@ -59,34 +60,42 @@ std::vector<std::string> split(const std::string &query, const std::string &d) {
     return v;
 }
 
-char complement(char n) {
+char complement(char n)
+{
     switch (n) {
-        case 'A':
-        case 'a':
-            return 'T';
-        case 'T':
-        case 't':
-            return 'A';
-        case 'G':
-        case 'g':
-            return 'C';
-        case 'C':
-        case 'c':
-            return 'G';
+    case 'A':
+    case 'a':
+        return 'T';
+    case 'T':
+    case 't':
+        return 'A';
+    case 'G':
+    case 'g':
+        return 'C';
+    case 'C':
+    case 'c':
+        return 'G';
     }
-    //assert(false);
+    // assert(false);
     return 'N';
 }
 
-std::string rev_complement(std::string s) {
+std::string rev_complement(std::string s)
+{
     transform(begin(s), end(s), begin(s), complement);
     reverse(s.begin(), s.end());
     return s;
 }
 
-float lognchoosek2(uint32_t n, uint32_t k1, uint32_t k2) {
-    assert(n >= k1 + k2 || assert_msg(
-            "Currently the model assumes that the most a given kmer (defined by position) can occur is once per read, i.e. an error somewhere else in the read cannot result in this kmer. If you are getting this message, then you have evidence of violation of this assumption. Either try using a bigger k, or come up with a better model"));
+float lognchoosek2(uint32_t n, uint32_t k1, uint32_t k2)
+{
+    assert(n >= k1 + k2
+        || assert_msg(
+            "Currently the model assumes that the most a given kmer (defined by "
+            "position) can occur is once per read, i.e. an error somewhere else in the "
+            "read cannot result in this kmer. If you are getting this message, then "
+            "you have evidence of violation of this assumption. Either try using a "
+            "bigger k, or come up with a better model"));
     float total = 0;
 
     for (uint32_t m = n; m != n - k1 - k2; --m) {
@@ -104,8 +113,9 @@ float lognchoosek2(uint32_t n, uint32_t k1, uint32_t k2) {
     return total;
 }
 
-void read_prg_file(std::vector<std::shared_ptr<LocalPRG>> &prgs,
-                   const std::string &filepath, uint32_t id) {
+void read_prg_file(std::vector<std::shared_ptr<LocalPRG>>& prgs,
+    const std::string& filepath, uint32_t id)
+{
     BOOST_LOG_TRIVIAL(debug) << "Loading PRGs from file " << filepath;
 
     FastaqHandler fh(filepath);
@@ -113,7 +123,9 @@ void read_prg_file(std::vector<std::shared_ptr<LocalPRG>> &prgs,
         fh.get_next();
         if (fh.name.empty() or fh.read.empty())
             continue;
-        auto s = std::make_shared<LocalPRG>(LocalPRG(id, fh.name, fh.read)); //build a node in the graph, which will represent a LocalPRG (the graph is a list of nodes, each representing a LocalPRG)
+        auto s = std::make_shared<LocalPRG>(LocalPRG(id, fh.name,
+            fh.read)); // build a node in the graph, which will represent a LocalPRG
+                       // (the graph is a list of nodes, each representing a LocalPRG)
         if (s != nullptr) {
             prgs.push_back(s);
             id++;
@@ -125,8 +137,9 @@ void read_prg_file(std::vector<std::shared_ptr<LocalPRG>> &prgs,
     BOOST_LOG_TRIVIAL(debug) << "Number of LocalPRGs read: " << prgs.size();
 }
 
-void load_PRG_kmergraphs(std::vector<std::shared_ptr<LocalPRG>> &prgs, const uint32_t &w, const uint32_t &k,
-                         const std::string &prgfile) {
+void load_PRG_kmergraphs(std::vector<std::shared_ptr<LocalPRG>>& prgs,
+    const uint32_t& w, const uint32_t& k, const std::string& prgfile)
+{
     BOOST_LOG_TRIVIAL(debug) << "Loading kmer_prgs from files";
     std::string prefix = "";
     size_t pos = prgfile.find_last_of("/");
@@ -134,12 +147,12 @@ void load_PRG_kmergraphs(std::vector<std::shared_ptr<LocalPRG>> &prgs, const uin
         prefix += prgfile.substr(0, pos);
         prefix += "/";
     }
-    //cout << "prefix for kmerprgs dir is " << prefix << endl;
+    // cout << "prefix for kmerprgs dir is " << prefix << endl;
 
     auto dir_num = 0;
     std::string dir;
-    for (const auto &prg: prgs) {
-        //cout << "Load kmergraph for " << prg->name << endl;
+    for (const auto& prg : prgs) {
+        // cout << "Load kmergraph for " << prg->name << endl;
         if (prg->id % 4000 == 0) {
             dir = prefix + "kmer_prgs/" + int_to_string(dir_num + 1);
             dir_num++;
@@ -147,11 +160,13 @@ void load_PRG_kmergraphs(std::vector<std::shared_ptr<LocalPRG>> &prgs, const uin
             if (not boost::filesystem::exists(p))
                 dir = prefix + "kmer_prgs";
         }
-        prg->kmer_prg.load(dir + "/" + prg->name + ".k" + std::to_string(k) + ".w" + std::to_string(w) + ".gfa");
+        prg->kmer_prg.load(dir + "/" + prg->name + ".k" + std::to_string(k) + ".w"
+            + std::to_string(w) + ".gfa");
     }
 }
 
-void load_vcf_refs_file(const std::string &filepath, VCFRefs &vcf_refs) {
+void load_vcf_refs_file(const std::string& filepath, VCFRefs& vcf_refs)
+{
     BOOST_LOG_TRIVIAL(info) << "Loading VCF refs from file " << filepath;
 
     FastaqHandler fh(filepath);
@@ -163,325 +178,378 @@ void load_vcf_refs_file(const std::string &filepath, VCFRefs &vcf_refs) {
     }
 }
 
-void add_read_hits(const Seq &sequence,
-                   const std::shared_ptr<MinimizerHits> &minimizer_hits,
-                   const Index &index) {
-    //cout << now() << "Search for hits for read " << s->name << " which has sketch size " << s->sketch.size() << " against index of size " << idx->minhash.size() << endl;
-    //uint32_t hit_count = 0;
-    // creates Seq object for the read, then looks up minimizers in the Seq sketch and adds hits to a global MinimizerHits object
-    //Seq s(id, name, seq, w, k);
-    for (auto sequenceSketchIt = sequence.sketch.begin(); sequenceSketchIt != sequence.sketch.end(); ++sequenceSketchIt) {
+void add_read_hits(const Seq& sequence,
+    const std::shared_ptr<MinimizerHits>& minimizer_hits, const Index& index)
+{
+    // cout << now() << "Search for hits for read " << s->name << " which has sketch
+    // size " << s->sketch.size() << " against index of size " << idx->minhash.size() <<
+    // endl; uint32_t hit_count = 0;
+    // creates Seq object for the read, then looks up minimizers in the Seq sketch and
+    // adds hits to a global MinimizerHits object
+    // Seq s(id, name, seq, w, k);
+    for (auto sequenceSketchIt = sequence.sketch.begin();
+         sequenceSketchIt != sequence.sketch.end(); ++sequenceSketchIt) {
         auto minhashIt = index.minhash.find((*sequenceSketchIt).canonical_kmer_hash);
-        if (minhashIt != index.minhash.end()) { //checks if the kmer is in the index
-            //yes, add all hits of this minimizer hit to this kmer
-            for (const MiniRecord &miniRecord : *(minhashIt->second)) {
+        if (minhashIt != index.minhash.end()) { // checks if the kmer is in the index
+            // yes, add all hits of this minimizer hit to this kmer
+            for (const MiniRecord& miniRecord : *(minhashIt->second)) {
                 minimizer_hits->add_hit(sequence.id, *sequenceSketchIt, miniRecord);
                 //++hit_count;
             }
         }
     }
-    //hits->sort();
-    //cout << now() << "Found " << hit_count << " hits found for read " << s->name << " so size of MinimizerHits is now "
+    // hits->sort();
+    // cout << now() << "Found " << hit_count << " hits found for read " << s->name << "
+    // so size of MinimizerHits is now "
     //     << hits->hits.size() + hits->uhits.size() << endl;
 }
 
-void define_clusters(std::set<MinimizerHitCluster, clusterComp> &clusters_of_hits,
-                     const std::vector<std::shared_ptr<LocalPRG>> &prgs,
-                     std::shared_ptr<MinimizerHits> minimizer_hits,
-                     const int max_diff,
-                     const float &fraction_kmers_required_for_cluster,
-                     const uint32_t min_cluster_size, const uint32_t expected_number_kmers_in_short_read_sketch) {
-    BOOST_LOG_TRIVIAL(debug) << "Define clusters of hits from the " << minimizer_hits->hits.size() << " hits";
+void define_clusters(std::set<MinimizerHitCluster, clusterComp>& clusters_of_hits,
+    const std::vector<std::shared_ptr<LocalPRG>>& prgs,
+    std::shared_ptr<MinimizerHits> minimizer_hits, const int max_diff,
+    const float& fraction_kmers_required_for_cluster, const uint32_t min_cluster_size,
+    const uint32_t expected_number_kmers_in_short_read_sketch)
+{
+    BOOST_LOG_TRIVIAL(debug) << "Define clusters of hits from the "
+                             << minimizer_hits->hits.size() << " hits";
 
-    if (minimizer_hits->hits.empty()) { return; }
+    if (minimizer_hits->hits.empty()) {
+        return;
+    }
 
-    // A cluster of hits should match same localPRG, each hit not more than max_diff read bases from the last hit (this last bit is to handle repeat genes). 
+    // A cluster of hits should match same localPRG, each hit not more than max_diff
+    // read bases from the last hit (this last bit is to handle repeat genes).
     auto mh_previous = minimizer_hits->hits.begin();
     MinimizerHitCluster current_cluster;
     current_cluster.insert(*mh_previous);
     uint32_t length_based_threshold;
     for (auto mh_current = ++minimizer_hits->hits.begin();
          mh_current != minimizer_hits->hits.end(); ++mh_current) {
-        if ((*mh_current)->get_read_id() != (*mh_previous)->get_read_id() or
-            (*mh_current)->get_prg_id() != (*mh_previous)->get_prg_id() or
-            (*mh_current)->is_forward() != (*mh_previous)->is_forward() or
-            (abs((int) (*mh_current)->get_read_start_position() - (int) (*mh_previous)->get_read_start_position())) > max_diff) {
+        if ((*mh_current)->get_read_id() != (*mh_previous)->get_read_id()
+            or (*mh_current)->get_prg_id() != (*mh_previous)->get_prg_id()
+            or (*mh_current)->is_forward() != (*mh_previous)->is_forward()
+            or (abs((int)(*mh_current)->get_read_start_position()
+                   - (int)(*mh_previous)->get_read_start_position()))
+                > max_diff) {
             // keep clusters which cover at least 1/2 the expected number of minihits
-            length_based_threshold = std::min(prgs[(*mh_previous)->get_prg_id()]->kmer_prg.min_path_length(),
-                                              expected_number_kmers_in_short_read_sketch) *
-                                     fraction_kmers_required_for_cluster;
-            BOOST_LOG_TRIVIAL(debug) << "Length based cluster threshold min("
-                                     << prgs[(*mh_previous)->get_prg_id()]->kmer_prg.min_path_length() << ", "
-                                     << expected_number_kmers_in_short_read_sketch << ") * "
-                                     << fraction_kmers_required_for_cluster << " = " << length_based_threshold;
+            length_based_threshold
+                = std::min(
+                      prgs[(*mh_previous)->get_prg_id()]->kmer_prg.min_path_length(),
+                      expected_number_kmers_in_short_read_sketch)
+                * fraction_kmers_required_for_cluster;
+            BOOST_LOG_TRIVIAL(debug)
+                << "Length based cluster threshold min("
+                << prgs[(*mh_previous)->get_prg_id()]->kmer_prg.min_path_length()
+                << ", " << expected_number_kmers_in_short_read_sketch << ") * "
+                << fraction_kmers_required_for_cluster << " = "
+                << length_based_threshold;
 
-            if (current_cluster.size() >
-                std::max(length_based_threshold, min_cluster_size)) {
+            if (current_cluster.size()
+                > std::max(length_based_threshold, min_cluster_size)) {
                 clusters_of_hits.insert(current_cluster);
-                //cout << "Found cluster of size " << current_cluster.size() << endl;
-                } else {
-                BOOST_LOG_TRIVIAL(debug) << "Rejected cluster of size "
-                                         << current_cluster.size() << " < max("
-                                         << length_based_threshold << ", " << min_cluster_size << ")";
-                }
+                // cout << "Found cluster of size " << current_cluster.size() << endl;
+            } else {
+                BOOST_LOG_TRIVIAL(debug)
+                    << "Rejected cluster of size " << current_cluster.size()
+                    << " < max(" << length_based_threshold << ", " << min_cluster_size
+                    << ")";
+            }
             current_cluster.clear();
         }
         current_cluster.insert(*mh_current);
         mh_previous = mh_current;
     }
-    length_based_threshold = std::min(prgs[(*mh_previous)->get_prg_id()]->kmer_prg.min_path_length(),
-                                      expected_number_kmers_in_short_read_sketch) * fraction_kmers_required_for_cluster;
-    BOOST_LOG_TRIVIAL(debug) << "Length based cluster threshold min("
-                             << prgs[(*mh_previous)->get_prg_id()]->kmer_prg.min_path_length() << ", "
-                             << expected_number_kmers_in_short_read_sketch << ") * "
-                             << fraction_kmers_required_for_cluster << " = " << length_based_threshold;
-    if (current_cluster.size() >
-        std::max(length_based_threshold, min_cluster_size)) {
+    length_based_threshold
+        = std::min(prgs[(*mh_previous)->get_prg_id()]->kmer_prg.min_path_length(),
+              expected_number_kmers_in_short_read_sketch)
+        * fraction_kmers_required_for_cluster;
+    BOOST_LOG_TRIVIAL(debug)
+        << "Length based cluster threshold min("
+        << prgs[(*mh_previous)->get_prg_id()]->kmer_prg.min_path_length() << ", "
+        << expected_number_kmers_in_short_read_sketch << ") * "
+        << fraction_kmers_required_for_cluster << " = " << length_based_threshold;
+    if (current_cluster.size() > std::max(length_based_threshold, min_cluster_size)) {
         clusters_of_hits.insert(current_cluster);
-        } else {
-            BOOST_LOG_TRIVIAL(debug) << "Rejected cluster of size "
-                                     << current_cluster.size() << " < max("
-                                     << length_based_threshold << ", " << min_cluster_size << ")";
-        }
+    } else {
+        BOOST_LOG_TRIVIAL(debug)
+            << "Rejected cluster of size " << current_cluster.size() << " < max("
+            << length_based_threshold << ", " << min_cluster_size << ")";
+    }
 
-    BOOST_LOG_TRIVIAL(debug) << "Found " << clusters_of_hits.size() << " clusters of hits";
+    BOOST_LOG_TRIVIAL(debug) << "Found " << clusters_of_hits.size()
+                             << " clusters of hits";
 }
 
-void filter_clusters(std::set<MinimizerHitCluster, clusterComp> &clusters_of_hits) {
+void filter_clusters(std::set<MinimizerHitCluster, clusterComp>& clusters_of_hits)
+{
     // Next order clusters, choose between those that overlap by too much
-    BOOST_LOG_TRIVIAL(debug) << "Filter the " << clusters_of_hits.size() << " clusters of hits";
-    if (clusters_of_hits.empty()) { return; }
+    BOOST_LOG_TRIVIAL(debug) << "Filter the " << clusters_of_hits.size()
+                             << " clusters of hits";
+    if (clusters_of_hits.empty()) {
+        return;
+    }
     // to do this consider pairs of clusters in turn
     auto c_previous = clusters_of_hits.begin();
     /*cout << "first cluster" << endl;
-    for (set<MinimizerHit*, pComp>::iterator p=c_previous->begin(); p!=c_previous->end(); ++p)
+    for (set<MinimizerHit*, pComp>::iterator p=c_previous->begin();
+    p!=c_previous->end(); ++p)
     {
         cout << **p << endl;
     }*/
     for (auto c_current = ++clusters_of_hits.begin();
          c_current != clusters_of_hits.end(); ++c_current) {
         /*cout << "current cluster" << endl;
-        for (set<MinimizerHit*, pComp>::iterator p=c_current->begin(); p!=c_current->end(); ++p)
+        for (set<MinimizerHit*, pComp>::iterator p=c_current->begin();
+        p!=c_current->end(); ++p)
         {
             cout << **p << endl;
         }*/
-        if (((*(*c_current).begin())->get_read_id() == (*(*c_previous).begin())->get_read_id()) && // if on same read and either
-            ((((*(*c_current).begin())->get_prg_id() == (*(*c_previous).begin())->get_prg_id()) && // same prg, different strand
-              ((*(*c_current).begin())->is_forward() != (*(*c_previous).begin())->is_forward())) or // or cluster is contained
-             ((*--(*c_current).end())->get_read_start_position() <=
-              (*--(*c_previous).end())->get_read_start_position()))) // i.e. not least one hit outside overlap
-            // NB we expect noise in the k-1 kmers overlapping the boundary of two clusters, but could also impose no more than 2k hits in overlap
+        if (((*(*c_current).begin())->get_read_id()
+                == (*(*c_previous).begin())->get_read_id())
+            && // if on same read and either
+            ((((*(*c_current).begin())->get_prg_id()
+                  == (*(*c_previous).begin())->get_prg_id())
+                 && // same prg, different strand
+                 ((*(*c_current).begin())->is_forward()
+                     != (*(*c_previous).begin())->is_forward()))
+                or // or cluster is contained
+                ((*--(*c_current).end())->get_read_start_position()
+                    <= (*--(*c_previous).end())
+                           ->get_read_start_position()))) // i.e. not least one hit
+                                                          // outside overlap
+        // NB we expect noise in the k-1 kmers overlapping the boundary of two clusters,
+        // but could also impose no more than 2k hits in overlap
         {
             if (c_previous->size() >= c_current->size()) {
                 clusters_of_hits.erase(c_current);
-                //cout << "erase current" << endl;
+                // cout << "erase current" << endl;
                 c_current = c_previous;
             } else {
                 clusters_of_hits.erase(c_previous);
-                //cout << "erase previous" << endl;
+                // cout << "erase previous" << endl;
             }
         }
         c_previous = c_current;
     }
-    BOOST_LOG_TRIVIAL(debug) << "Now have " << clusters_of_hits.size() << " clusters of hits";
+    BOOST_LOG_TRIVIAL(debug) << "Now have " << clusters_of_hits.size()
+                             << " clusters of hits";
 }
 
-void filter_clusters2(std::set<MinimizerHitCluster, clusterComp> &clusters_of_hits,
-                      const uint32_t &genome_size) {
-    // Sort clusters by size, and filter out those small clusters which are entirely contained in bigger clusters on reads
-    BOOST_LOG_TRIVIAL(debug) << "Filter2 the " << clusters_of_hits.size() << " clusters of hits";
-    if (clusters_of_hits.empty()) { return; }
+void filter_clusters2(std::set<MinimizerHitCluster, clusterComp>& clusters_of_hits,
+    const uint32_t& genome_size)
+{
+    // Sort clusters by size, and filter out those small clusters which are entirely
+    // contained in bigger clusters on reads
+    BOOST_LOG_TRIVIAL(debug) << "Filter2 the " << clusters_of_hits.size()
+                             << " clusters of hits";
+    if (clusters_of_hits.empty()) {
+        return;
+    }
 
-    std::set<MinimizerHitCluster, clusterComp_size> clusters_by_size(clusters_of_hits.begin(),
-                                                                                  clusters_of_hits.end());
+    std::set<MinimizerHitCluster, clusterComp_size> clusters_by_size(
+        clusters_of_hits.begin(), clusters_of_hits.end());
 
     auto it = clusters_by_size.begin();
     std::vector<int> read_v(genome_size, 0);
-    //cout << "fill from " << (*(it->begin()))->read_start_position() << " to " << (*--(it->end()))->read_start_position() << endl;
-    fill(read_v.begin() + (*(it->begin()))->get_read_start_position(), read_v.begin() + (*--(it->end()))->get_read_start_position(),
-         1);
+    // cout << "fill from " << (*(it->begin()))->read_start_position() << " to " <<
+    // (*--(it->end()))->read_start_position() << endl;
+    fill(read_v.begin() + (*(it->begin()))->get_read_start_position(),
+        read_v.begin() + (*--(it->end()))->get_read_start_position(), 1);
     bool contained;
-    for (auto it_next = ++clusters_by_size.begin();
-         it_next != clusters_by_size.end(); ++it_next) {
-        //cout << "read id " << (*(it_next->begin()))->get_prg_id() << endl;
+    for (auto it_next = ++clusters_by_size.begin(); it_next != clusters_by_size.end();
+         ++it_next) {
+        // cout << "read id " << (*(it_next->begin()))->get_prg_id() << endl;
         if ((*(it_next->begin()))->get_read_id() == (*(it->begin()))->get_read_id()) {
-            //check if have any 0s in interval of read_v between first and last
+            // check if have any 0s in interval of read_v between first and last
             contained = true;
             for (uint32_t i = (*(it_next->begin()))->get_read_start_position();
                  i < (*--(it_next->end()))->get_read_start_position(); ++i) {
-                //cout << i << ":" << read_v[i] << "\t";
+                // cout << i << ":" << read_v[i] << "\t";
                 if (read_v[i] == 0) {
                     contained = false;
-                    //cout << "found unique element at read position " << i << endl;
-                    //cout << "fill from " << i << " to " << (*--(it_next->end()))->get_read_start_position() << endl;
-                    fill(read_v.begin() + i, read_v.begin() + (*--(it_next->end()))->get_read_start_position(), 1);
+                    // cout << "found unique element at read position " << i << endl;
+                    // cout << "fill from " << i << " to " <<
+                    // (*--(it_next->end()))->get_read_start_position() << endl;
+                    fill(read_v.begin() + i,
+                        read_v.begin()
+                            + (*--(it_next->end()))->get_read_start_position(),
+                        1);
                     break;
                 }
-
             }
-            //cout << endl;
+            // cout << endl;
             if (contained) {
-                //cout << "erase cluster so clusters_of_hits has size decrease from " << clusters_of_hits.size();
+                // cout << "erase cluster so clusters_of_hits has size decrease from "
+                // << clusters_of_hits.size();
                 clusters_of_hits.erase(*it_next);
-                //cout << " to " << clusters_of_hits.size() << endl;
+                // cout << " to " << clusters_of_hits.size() << endl;
             }
         } else {
-            //cout << "consider new read" << endl;
+            // cout << "consider new read" << endl;
             fill(read_v.begin(), read_v.end(), 0);
         }
         ++it;
     }
-    BOOST_LOG_TRIVIAL(debug) << "Now have " << clusters_of_hits.size() << " clusters of hits";
+    BOOST_LOG_TRIVIAL(debug) << "Now have " << clusters_of_hits.size()
+                             << " clusters of hits";
 }
 
-void
-add_clusters_to_pangraph(std::set<MinimizerHitCluster, clusterComp> &clusters_of_hits,
-                         std::shared_ptr<pangenome::Graph> pangraph,
-                         const std::vector<std::shared_ptr<LocalPRG>> &prgs) {
+void add_clusters_to_pangraph(
+    std::set<MinimizerHitCluster, clusterComp>& clusters_of_hits,
+    std::shared_ptr<pangenome::Graph> pangraph,
+    const std::vector<std::shared_ptr<LocalPRG>>& prgs)
+{
     BOOST_LOG_TRIVIAL(debug) << "Add inferred order to PanGraph";
-    if (clusters_of_hits.empty()) { return; }
+    if (clusters_of_hits.empty()) {
+        return;
+    }
 
     // to do this consider pairs of clusters in turn
-    for (auto cluster: clusters_of_hits) {
+    for (auto cluster : clusters_of_hits) {
 
-        pangraph->add_hits_between_PRG_and_read(
-               prgs[(*cluster.begin())->get_prg_id()],
-               (*cluster.begin())->get_read_id(),
-               cluster);
+        pangraph->add_hits_between_PRG_and_read(prgs[(*cluster.begin())->get_prg_id()],
+            (*cluster.begin())->get_read_id(), cluster);
     }
 }
 
-void infer_localPRG_order_for_reads(const std::vector<std::shared_ptr<LocalPRG>> &prgs,
-                                    std::shared_ptr<MinimizerHits> minimizer_hits,
-                                    std::shared_ptr<pangenome::Graph> pangraph,
-                                    const int max_diff, const uint32_t &genome_size,
-                                    const float &fraction_kmers_required_for_cluster,
-                                    const uint32_t min_cluster_size,
-                                    const uint32_t expected_number_kmers_in_short_read_sketch) {
+void infer_localPRG_order_for_reads(const std::vector<std::shared_ptr<LocalPRG>>& prgs,
+    std::shared_ptr<MinimizerHits> minimizer_hits,
+    std::shared_ptr<pangenome::Graph> pangraph, const int max_diff,
+    const uint32_t& genome_size, const float& fraction_kmers_required_for_cluster,
+    const uint32_t min_cluster_size,
+    const uint32_t expected_number_kmers_in_short_read_sketch)
+{
     // this step infers the gene order for a read and adds this to the pangraph
     // by defining clusters of hits, keeping those which are not noise and
     // then adding the inferred gene ordering
-    if (minimizer_hits->hits.empty()) { return; }
+    if (minimizer_hits->hits.empty()) {
+        return;
+    }
 
     std::set<MinimizerHitCluster, clusterComp> clusters_of_hits;
-    define_clusters(clusters_of_hits, prgs, minimizer_hits, max_diff, fraction_kmers_required_for_cluster,
-                    min_cluster_size, expected_number_kmers_in_short_read_sketch);
+    define_clusters(clusters_of_hits, prgs, minimizer_hits, max_diff,
+        fraction_kmers_required_for_cluster, min_cluster_size,
+        expected_number_kmers_in_short_read_sketch);
 
     filter_clusters(clusters_of_hits);
-    //filter_clusters2(clusters_of_hits, genome_size);
+    // filter_clusters2(clusters_of_hits, genome_size);
 
-    #pragma omp critical(pangraph)
+#pragma omp critical(pangraph)
     {
         add_clusters_to_pangraph(clusters_of_hits, pangraph, prgs);
     }
 }
 
-//TODO: this should be in a constructor of pangenome::Graph or in a factory class
-uint32_t pangraph_from_read_file(const std::string &filepath,
-                                 std::shared_ptr<pangenome::Graph> pangraph,
-                                 std::shared_ptr<Index> index,
-                                 const std::vector<std::shared_ptr<LocalPRG>> &prgs,
-                                 const uint32_t w,
-                                 const uint32_t k,
-                                 const int max_diff,
-                                 const float &e_rate,
-                                 const uint32_t min_cluster_size,
-                                 const uint32_t genome_size,
-                                 const bool illumina,
-                                 const bool clean,
-                                 const uint32_t max_covg,
-                                 uint32_t threads) {
-    //constant variables
+// TODO: this should be in a constructor of pangenome::Graph or in a factory class
+uint32_t pangraph_from_read_file(const std::string& filepath,
+    std::shared_ptr<pangenome::Graph> pangraph, std::shared_ptr<Index> index,
+    const std::vector<std::shared_ptr<LocalPRG>>& prgs, const uint32_t w,
+    const uint32_t k, const int max_diff, const float& e_rate,
+    const uint32_t min_cluster_size, const uint32_t genome_size, const bool illumina,
+    const bool clean, const uint32_t max_covg, uint32_t threads)
+{
+    // constant variables
     const double fraction_kmers_required_for_cluster = 0.5 / exp(e_rate * k);
-    const uint32_t nb_reads_to_map_in_a_batch = 1000; //nb of reads to map in a batch
+    const uint32_t nb_reads_to_map_in_a_batch = 1000; // nb of reads to map in a batch
 
+    // shared variable - controlled by critical(covg)
+    uint64_t covg { 0 };
 
-    //shared variable - controlled by critical(covg)
-    uint64_t covg{0};
-
-    //shared variables - controlled by critical(ReadFileMutex)
+    // shared variables - controlled by critical(ReadFileMutex)
     FastaqHandler fh(filepath);
-    uint32_t id{0};
+    uint32_t id { 0 };
 
-    //parallel region
-    #pragma omp parallel num_threads(threads)
+// parallel region
+#pragma omp parallel num_threads(threads)
     {
-        //will hold the reads batch
-        std::vector<Seq> sequencesBuffer(nb_reads_to_map_in_a_batch, Seq(0, "null", "", w, k));
+        // will hold the reads batch
+        std::vector<Seq> sequencesBuffer(
+            nb_reads_to_map_in_a_batch, Seq(0, "null", "", w, k));
         while (true) {
-            //read the next batch of reads
-            uint32_t nbOfReads=0;
+            // read the next batch of reads
+            uint32_t nbOfReads = 0;
 
-            //read the reads in batch
-            #pragma omp critical(ReadFileMutex)
+// read the reads in batch
+#pragma omp critical(ReadFileMutex)
             {
-                for (auto &sequence : sequencesBuffer) {
-                    //did we reach the end already?
-                    if (!fh.eof()) { //no
-                        //print some logging
+                for (auto& sequence : sequencesBuffer) {
+                    // did we reach the end already?
+                    if (!fh.eof()) { // no
+                        // print some logging
                         if (id && id % 100000 == 0)
                             BOOST_LOG_TRIVIAL(info) << id << " reads processed...";
 
-                        //read the read
+                        // read the read
                         fh.get_next();
                         sequence.initialize(id, fh.name, fh.read, w, k);
                         ++nbOfReads;
                         ++id;
-                    } else{ //yes
-                        break; //we read everything already, exit this loop
+                    } else { // yes
+                        break; // we read everything already, exit this loop
                     }
                 }
             }
 
+            if (nbOfReads == 0)
+                break; // we reached the end of the file, nothing else to map
 
-            if (nbOfReads==0) break; //we reached the end of the file, nothing else to map
-
-            //quasimap the batch of reads
-            bool coverageExceeded=false;
-            for (uint32_t i=0; i<nbOfReads; i++) {
+            // quasimap the batch of reads
+            bool coverageExceeded = false;
+            for (uint32_t i = 0; i < nbOfReads; i++) {
                 const auto& sequence = sequencesBuffer[i];
 
-                //checks if we are still good regarding coverage
+                // checks if we are still good regarding coverage
                 if (!sequence.sketch.empty()) {
-                    #pragma omp critical(covg)
+#pragma omp critical(covg)
                     {
-                        //check if the max_covg was already exceeded
+                        // check if the max_covg was already exceeded
                         if (covg / genome_size > max_covg) {
-                            //if reached here, it means that another thread realised that we went past the max_covg, so we just exit
+                            // if reached here, it means that another thread realised
+                            // that we went past the max_covg, so we just exit
                             coverageExceeded = true;
                         } else {
-                            //no other thread still signalized exceeding max coverage
+                            // no other thread still signalized exceeding max coverage
                             covg += sequence.seq.length();
                             if (covg / genome_size > max_covg) {
-                                //oops, we are the first one to see max_covg being exceeded, print and exit!
-                                BOOST_LOG_TRIVIAL(warning) << "Stop processing reads as have reached max coverage";
+                                // oops, we are the first one to see max_covg being
+                                // exceeded, print and exit!
+                                BOOST_LOG_TRIVIAL(warning)
+                                    << "Stop processing reads as have reached max "
+                                       "coverage";
                                 coverageExceeded = true;
                             }
                         }
                     }
 
-                    if (coverageExceeded) break; //max covg exceeded, get out
+                    if (coverageExceeded)
+                        break; // max covg exceeded, get out
                 } else {
                     continue;
                 }
 
-                uint32_t expected_number_kmers_in_short_read_sketch{std::numeric_limits<uint32_t>::max()};
-                if (illumina and expected_number_kmers_in_short_read_sketch == std::numeric_limits<uint32_t>::max()) {
+                uint32_t expected_number_kmers_in_short_read_sketch {
+                    std::numeric_limits<uint32_t>::max()
+                };
+                if (illumina
+                    and expected_number_kmers_in_short_read_sketch
+                        == std::numeric_limits<uint32_t>::max()) {
                     assert(w != 0);
-                    expected_number_kmers_in_short_read_sketch = sequence.seq.length() * 2 / w;
+                    expected_number_kmers_in_short_read_sketch
+                        = sequence.seq.length() * 2 / w;
                 }
 
-                //get the minizer hits
+                // get the minizer hits
                 auto minimizer_hits = std::make_shared<MinimizerHits>(MinimizerHits());
                 add_read_hits(sequence, minimizer_hits, *index);
 
-                //infer
-                infer_localPRG_order_for_reads(prgs, minimizer_hits, pangraph, max_diff, genome_size,
-                                               fraction_kmers_required_for_cluster, min_cluster_size,
-                                               expected_number_kmers_in_short_read_sketch);
+                // infer
+                infer_localPRG_order_for_reads(prgs, minimizer_hits, pangraph, max_diff,
+                    genome_size, fraction_kmers_required_for_cluster, min_cluster_size,
+                    expected_number_kmers_in_short_read_sketch);
             }
 
-            if (coverageExceeded) break; //max_covg exceeded, get out
+            if (coverageExceeded)
+                break; // max_covg exceeded, get out
         }
     }
     BOOST_LOG_TRIVIAL(info) << "Processed " << id << " reads";
@@ -491,21 +559,21 @@ uint32_t pangraph_from_read_file(const std::string &filepath,
     covg = covg / genome_size;
     BOOST_LOG_TRIVIAL(debug) << "Estimated coverage: " << covg;
 
-
     if (illumina and clean) {
         clean_pangraph_with_debruijn_graph(pangraph, 2, 1, illumina);
-        BOOST_LOG_TRIVIAL(debug) << "After cleaning, pangraph has " << pangraph->nodes.size() << " nodes";
+        BOOST_LOG_TRIVIAL(debug)
+            << "After cleaning, pangraph has " << pangraph->nodes.size() << " nodes";
     } else if (clean) {
         clean_pangraph_with_debruijn_graph(pangraph, 3, 1, illumina);
-        BOOST_LOG_TRIVIAL(debug) << "After cleaning, pangraph has " << pangraph->nodes.size() << " nodes";
+        BOOST_LOG_TRIVIAL(debug)
+            << "After cleaning, pangraph has " << pangraph->nodes.size() << " nodes";
     }
 
     return covg;
 }
 
-
-
-void fatalError (const string &message) {
+void fatalError(const string& message)
+{
     cerr << endl << endl << "[FATAL ERROR] " << message << endl << endl;
     cerr.flush();
     exit(1);

--- a/src/vcf.cpp
+++ b/src/vcf.cpp
@@ -1,54 +1,59 @@
-#include <iostream>
-#include <fstream>
-#include <sstream>
+#include <algorithm>
 #include <cassert>
 #include <ctime>
+#include <fstream>
+#include <iostream>
 #include <numeric>
+#include <sstream>
 #include <vector>
-#include <algorithm>
 
 #include <boost/log/trivial.hpp>
 
-#include "vcfrecord.h"
-#include "vcf.h"
-#include "utils.h"
 #include "localnode.h"
-
+#include "utils.h"
+#include "vcf.h"
+#include "vcfrecord.h"
 
 #define assert_msg(x) !(std::cerr << "Assertion failed: " << x << std::endl)
 
-
-void VCF::add_record_core(const VCFRecord &vr) {
+void VCF::add_record_core(const VCFRecord& vr)
+{
     records.push_back(std::make_shared<VCFRecord>(vr));
-    chrom2recordIntervalTree[vr.chrom].add(vr.pos, vr.pos + vr.ref.length() + 1, records.back().get());
+    chrom2recordIntervalTree[vr.chrom].add(
+        vr.pos, vr.pos + vr.ref.length() + 1, records.back().get());
 }
 
-void VCF::add_record(std::string c, uint32_t p, std::string r, std::string a, std::string i, std::string g) {
+void VCF::add_record(std::string c, uint32_t p, std::string r, std::string a,
+    std::string i, std::string g)
+{
     std::unordered_map<std::string, std::vector<uint16_t>> empty_map;
     VCFRecord vr(c, p, r, a, i, g);
-    if (find_record_in_records(vr) == records.end()) { //TODO: improve this search to log(n) using a map or sth
+    if (find_record_in_records(vr)
+        == records.end()) { // TODO: improve this search to log(n) using a map or sth
         add_record_core(vr);
-        records.back()->samples.insert(records.back()->samples.end(), samples.size(), empty_map);
+        records.back()->samples.insert(
+            records.back()->samples.end(), samples.size(), empty_map);
     }
-    //cout << "added record: " << vr << endl;
+    // cout << "added record: " << vr << endl;
 }
 
-
-
-VCFRecord &VCF::add_record(VCFRecord &vr, const std::vector<std::string> &sample_names) {
+VCFRecord& VCF::add_record(VCFRecord& vr, const std::vector<std::string>& sample_names)
+{
     assert(vr.samples.size() == sample_names.size() or sample_names.size() == 0);
 
     std::unordered_map<std::string, std::vector<uint16_t>> empty_map;
-    auto record_it = find_record_in_records(vr); //TODO: improve this search to log(n) using a map or sth
+    auto record_it = find_record_in_records(
+        vr); // TODO: improve this search to log(n) using a map or sth
     if (record_it == records.end()) {
         add_record_core(vr);
         records.back()->samples.clear();
-        records.back()->samples.insert(records.back()->samples.end(), samples.size(), empty_map);
+        records.back()->samples.insert(
+            records.back()->samples.end(), samples.size(), empty_map);
         record_it = --records.end();
     }
 
-    for (uint32_t i=0; i < sample_names.size(); ++i){
-        auto &name = sample_names[i];
+    for (uint32_t i = 0; i < sample_names.size(); ++i) {
+        auto& name = sample_names[i];
         ptrdiff_t sample_index = get_sample_index(name);
         (*record_it)->samples[sample_index] = vr.samples[i];
     }
@@ -56,26 +61,29 @@ VCFRecord &VCF::add_record(VCFRecord &vr, const std::vector<std::string> &sample
     return **record_it;
 }
 
-void VCF::add_samples(const std::vector<std::string> sample_names) {
-    for (uint32_t i=0; i < sample_names.size(); ++i){
-        auto &name = sample_names[i];
+void VCF::add_samples(const std::vector<std::string> sample_names)
+{
+    for (uint32_t i = 0; i < sample_names.size(); ++i) {
+        auto& name = sample_names[i];
         ptrdiff_t sample_index = get_sample_index(name);
     }
 }
 
-void VCF::add_formats(const std::vector<std::string> &v) {
-    for (auto &record : records) {
+void VCF::add_formats(const std::vector<std::string>& v)
+{
+    for (auto& record : records) {
         record->add_formats(v);
     }
 }
 
-ptrdiff_t VCF::get_sample_index(const std::string &name) {
+ptrdiff_t VCF::get_sample_index(const std::string& name)
+{
     std::unordered_map<std::string, std::vector<uint16_t>> empty_map;
 
     // if this sample has not been added before, add a column for it
     auto sample_it = find(samples.begin(), samples.end(), name);
     if (sample_it == samples.end()) {
-        //cout << "this is the first time this sample has been added" << endl;
+        // cout << "this is the first time this sample has been added" << endl;
         samples.push_back(name);
         for (uint32_t i = 0; i != records.size(); ++i) {
             records[i]->samples.push_back(empty_map);
@@ -87,40 +95,46 @@ ptrdiff_t VCF::get_sample_index(const std::string &name) {
     }
 }
 
-void VCF::add_sample_gt(const std::string &name, const std::string &c, const uint32_t p, const std::string &r,
-                        const std::string &a) {
-    //cout << "adding gt " << c << " " << p << " " << r << " vs " << name << " " << a << endl;
+void VCF::add_sample_gt(const std::string& name, const std::string& c, const uint32_t p,
+    const std::string& r, const std::string& a)
+{
+    // cout << "adding gt " << c << " " << p << " " << r << " vs " << name << " " << a
+    // << endl;
     if (r == "" and a == "") {
         return;
     }
 
-    //cout << "adding gt " << r << " vs " << a << endl;
+    // cout << "adding gt " << r << " vs " << a << endl;
 
     ptrdiff_t sample_index = get_sample_index(name);
 
     VCFRecord vr(c, p, r, a);
-    VCFRecord *vrp;
+    VCFRecord* vrp;
     bool added = false;
-    auto it = find_record_in_records(vr); //TODO: improve this search to log(n) using a map or sth
+    auto it = find_record_in_records(
+        vr); // TODO: improve this search to log(n) using a map or sth
     if (it != records.end()) {
-        //cout << "found record with this ref and alt" << endl;
-        (*it)->samples[sample_index]["GT"] = {1};
+        // cout << "found record with this ref and alt" << endl;
+        (*it)->samples[sample_index]["GT"] = { 1 };
         vrp = it->get();
     } else {
-        //cout << "didn't find a record for pos " << p << " ref " << r << " and alt " << a << endl;
-        // either we have the ref allele, an alternative allele for a too nested site, or a mistake
+        // cout << "didn't find a record for pos " << p << " ref " << r << " and alt "
+        // << a << endl;
+        // either we have the ref allele, an alternative allele for a too nested site,
+        // or a mistake
         for (uint32_t i = 0; i != records.size(); ++i) {
-            if (records[i]->chrom == c and records[i]->pos == p and r == a and records[i]->ref == r) {
-                //cout << "have ref allele" << endl;
-                records[i]->samples[sample_index]["GT"] = {0};
+            if (records[i]->chrom == c and records[i]->pos == p and r == a
+                and records[i]->ref == r) {
+                // cout << "have ref allele" << endl;
+                records[i]->samples[sample_index]["GT"] = { 0 };
                 vrp = records[i].get();
                 added = true;
             }
         }
         if (!added and r != a) {
-            //cout << "have new allele not in graph" << endl;
+            // cout << "have new allele not in graph" << endl;
             add_record(c, p, r, a, "SVTYPE=COMPLEX", "GRAPHTYPE=TOO_MANY_ALTS");
-            records.back()->samples[sample_index]["GT"] = {1};
+            records.back()->samples[sample_index]["GT"] = { 1 };
             vrp = records.back().get();
             added = true;
         }
@@ -130,41 +144,45 @@ void VCF::add_sample_gt(const std::string &name, const std::string &c, const uin
 
     // update other samples at this site if they have ref allele at this pos
     for (uint32_t i = 0; i != records.size(); ++i) {
-        if (records[i]->chrom == c and records[i]->pos <= p and records[i]->pos + records[i]->ref.length() > p) {
+        if (records[i]->chrom == c and records[i]->pos <= p
+            and records[i]->pos + records[i]->ref.length() > p) {
             for (uint32_t j = 0; j != records[i]->samples.size(); ++j) {
                 if (records[i]->samples[j].find("GT") != records[i]->samples[j].end()
                     and !records[i]->samples[j]["GT"].empty()
                     and records[i]->samples[j]["GT"][0] == 0) {
-                    //cout << "update my record to have ref allele also for sample " << j << endl;
-                    //cout << records[i] << endl;
-                    vrp->samples[j]["GT"] = {0};
+                    // cout << "update my record to have ref allele also for sample " <<
+                    // j << endl; cout << records[i] << endl;
+                    vrp->samples[j]["GT"] = { 0 };
                 }
             }
         }
     }
 }
 
-void VCF::add_sample_ref_alleles(const std::string &sample_name, const std::string &chrom, const uint32_t &pos,
-                                 const uint32_t &pos_to) {
+void VCF::add_sample_ref_alleles(const std::string& sample_name,
+    const std::string& chrom, const uint32_t& pos, const uint32_t& pos_to)
+{
 
     ptrdiff_t sample_index = get_sample_index(sample_name);
 
     for (uint32_t i = 0; i != records.size(); ++i) {
-        if (records[i]->chrom == chrom and pos <= records[i]->pos and
-            records[i]->pos + records[i]->ref.length() <= pos_to) {
-            records[i]->samples[sample_index]["GT"] = {0};
-            //cout << "update record " << records[i] << endl;
+        if (records[i]->chrom == chrom and pos <= records[i]->pos
+            and records[i]->pos + records[i]->ref.length() <= pos_to) {
+            records[i]->samples[sample_index]["GT"] = { 0 };
+            // cout << "update record " << records[i] << endl;
         }
     }
 }
 
-void VCF::append_vcf(const VCF &other_vcf) {
+void VCF::append_vcf(const VCF& other_vcf)
+{
     auto original_size = records.size();
     auto num_samples_added = 0;
 
-    BOOST_LOG_TRIVIAL(debug) << "find which samples are new of the " << other_vcf.samples.size() << " samples";
+    BOOST_LOG_TRIVIAL(debug) << "find which samples are new of the "
+                             << other_vcf.samples.size() << " samples";
     std::vector<uint_least16_t> other_sample_positions;
-    for (const auto &sample : other_vcf.samples) {
+    for (const auto& sample : other_vcf.samples) {
         auto sample_it = find(samples.begin(), samples.end(), sample);
         if (sample_it == samples.end()) {
             samples.push_back(sample);
@@ -175,62 +193,73 @@ void VCF::append_vcf(const VCF &other_vcf) {
         }
     }
 
-    BOOST_LOG_TRIVIAL(debug) << "for all existing " << original_size << " records, add null entries for the "
+    BOOST_LOG_TRIVIAL(debug) << "for all existing " << original_size
+                             << " records, add null entries for the "
                              << num_samples_added << " new samples";
     std::unordered_map<std::string, std::vector<uint16_t>> empty_u_map;
-    assert(original_size < std::numeric_limits<uint_least64_t>::max() ||
-           assert_msg("VCF size has got too big to use the append feature"));
+    assert(original_size < std::numeric_limits<uint_least64_t>::max()
+        || assert_msg("VCF size has got too big to use the append feature"));
     for (uint_least64_t i = 0; i < original_size; ++i) {
-        records[i]->samples.insert(records[i]->samples.end(), num_samples_added, empty_u_map);
+        records[i]->samples.insert(
+            records[i]->samples.end(), num_samples_added, empty_u_map);
     }
 
     BOOST_LOG_TRIVIAL(debug) << "add the " << other_vcf.records.size() << " records";
-    for (auto &recordPointer : other_vcf.records) {
-        auto &record = *recordPointer;
-        VCFRecord &vr = add_record(record, other_vcf.samples);
+    for (auto& recordPointer : other_vcf.records) {
+        auto& record = *recordPointer;
+        VCFRecord& vr = add_record(record, other_vcf.samples);
         for (uint_least16_t j = 0; j < other_vcf.samples.size(); ++j) {
             vr.samples[other_sample_positions[j]] = record.samples[j];
-            //NB this overwrites old data without checking
+            // NB this overwrites old data without checking
         }
     }
 }
 
-void VCF::sort_records() {
-    sort(records.begin(), records.end(), [](const std::shared_ptr<VCFRecord>& lhs, const std::shared_ptr<VCFRecord>& rhs) {
-        return (*lhs) < (*rhs);
-    });
+void VCF::sort_records()
+{
+    sort(records.begin(), records.end(),
+        [](const std::shared_ptr<VCFRecord>& lhs,
+            const std::shared_ptr<VCFRecord>& rhs) { return (*lhs) < (*rhs); });
 }
 
-bool VCF::pos_in_range(const uint32_t from, const uint32_t to, const std::string &chrom) const {
+bool VCF::pos_in_range(
+    const uint32_t from, const uint32_t to, const std::string& chrom) const
+{
     // is there a record contained in the range from,to?
-    for (const auto &recordPointer : records) {
-        const auto &record = *recordPointer;
-        if (chrom == record.chrom and from < record.pos and record.pos + record.ref.length() <= to) {
+    for (const auto& recordPointer : records) {
+        const auto& record = *recordPointer;
+        if (chrom == record.chrom and from < record.pos
+            and record.pos + record.ref.length() <= to) {
             return true;
         }
     }
     return false;
 }
 
-void VCF::genotype(const std::vector<uint32_t> &expected_depth_covg, const float &error_rate,
-                   const uint16_t confidence_threshold,
-                   const uint32_t &min_allele_covg, const float &min_fraction_allele_covg,
-                   const uint32_t &min_site_total_covg, const uint32_t &min_site_diff_covg, bool snps_only) {
+void VCF::genotype(const std::vector<uint32_t>& expected_depth_covg,
+    const float& error_rate, const uint16_t confidence_threshold,
+    const uint32_t& min_allele_covg, const float& min_fraction_allele_covg,
+    const uint32_t& min_site_total_covg, const uint32_t& min_site_diff_covg,
+    bool snps_only)
+{
     BOOST_LOG_TRIVIAL(info) << now() << "Genotype VCF";
-    for (auto &vrPointer : records) {
-        auto &vr = *vrPointer;
-        if (not snps_only or (vr.ref.length() == 1 and !vr.alt.empty() and vr.alt[0].length() == 1)) {
-            vr.likelihood(expected_depth_covg, error_rate, min_allele_covg, min_fraction_allele_covg);
+    for (auto& vrPointer : records) {
+        auto& vr = *vrPointer;
+        if (not snps_only
+            or (vr.ref.length() == 1 and !vr.alt.empty() and vr.alt[0].length() == 1)) {
+            vr.likelihood(expected_depth_covg, error_rate, min_allele_covg,
+                min_fraction_allele_covg);
             vr.confidence(min_site_total_covg, min_site_diff_covg);
             vr.genotype(confidence_threshold);
         }
     }
-    add_formats({"GT_CONF", "LIKELIHOOD"});
+    add_formats({ "GT_CONF", "LIKELIHOOD" });
     BOOST_LOG_TRIVIAL(info) << now() << "Make all genotypes compatible";
     make_gt_compatible();
 }
 
-void VCF::clean() {
+void VCF::clean()
+{
     VCFRecord dummy;
     for (auto record_it = records.begin(); record_it != records.end();) {
         if (**record_it == dummy)
@@ -240,16 +269,19 @@ void VCF::clean() {
     }
 }
 
-void merge_sample_key(std::unordered_map<std::string, std::vector<uint16_t>> &first,
-                      const std::unordered_map<std::string, std::vector<uint16_t>> &second,
-                      const std::string &key) {
-    if (first.empty() or second.empty() or first.find(key) == first.end() or first[key].empty()) {
+void merge_sample_key(std::unordered_map<std::string, std::vector<uint16_t>>& first,
+    const std::unordered_map<std::string, std::vector<uint16_t>>& second,
+    const std::string& key)
+{
+    if (first.empty() or second.empty() or first.find(key) == first.end()
+        or first[key].empty()) {
         return;
-    } else if (first.find(key) != first.end() and (second.find(key) == second.end() or second.at(key).empty())) {
+    } else if (first.find(key) != first.end()
+        and (second.find(key) == second.end() or second.at(key).empty())) {
         first.erase(key);
     } else if (first[key][0] == second.at(key).at(0)) {
         bool ref = true;
-        for (const auto &val : second.at(key)) {
+        for (const auto& val : second.at(key)) {
             if (!ref)
                 first[key].push_back(val);
             ref = false;
@@ -258,16 +290,19 @@ void merge_sample_key(std::unordered_map<std::string, std::vector<uint16_t>> &fi
         first.erase(key);
 }
 
-void merge_regt_sample_key(std::unordered_map<std::string, std::vector<float>> &first,
-                           const std::unordered_map<std::string, std::vector<float>> &second,
-                           const std::string &key) {
-    if (first.empty() or second.empty() or first.find(key) == first.end() or first[key].empty()) {
+void merge_regt_sample_key(std::unordered_map<std::string, std::vector<float>>& first,
+    const std::unordered_map<std::string, std::vector<float>>& second,
+    const std::string& key)
+{
+    if (first.empty() or second.empty() or first.find(key) == first.end()
+        or first[key].empty()) {
         return;
-    } else if (first.find(key) != first.end() and (second.find(key) == second.end() or second.at(key).empty())) {
+    } else if (first.find(key) != first.end()
+        and (second.find(key) == second.end() or second.at(key).empty())) {
         first.erase(key);
     } else if (first[key][0] == second.at(key).at(0)) {
         bool ref = true;
-        for (const auto &val : second.at(key)) {
+        for (const auto& val : second.at(key)) {
             if (!ref)
                 first[key].push_back(val);
             ref = false;
@@ -276,24 +311,27 @@ void merge_regt_sample_key(std::unordered_map<std::string, std::vector<float>> &
         first.erase(key);
 }
 
-void merge_gt(VCFRecord &first, const VCFRecord &second, const uint16_t i, const uint16_t prev_alt_size) {
+void merge_gt(VCFRecord& first, const VCFRecord& second, const uint16_t i,
+    const uint16_t prev_alt_size)
+{
     if (first.samples.size() < i or second.samples.size() < i) {
         return;
     } else if (second.samples[i].find("GT") == second.samples[i].end()
-               or second.samples[i].at("GT").empty()) {
+        or second.samples[i].at("GT").empty()) {
         return;
     } else if (first.samples[i].find("GT") == first.samples[i].end()
-               or first.samples[i]["GT"].empty()) {
+        or first.samples[i]["GT"].empty()) {
         if (second.samples[i].at("GT")[0] == 0) {
-            first.samples[i]["GT"] = {0};
+            first.samples[i]["GT"] = { 0 };
         } else {
             uint16_t new_allele = second.samples[i].at("GT")[0] + prev_alt_size;
-            first.samples[i]["GT"] = {new_allele};
+            first.samples[i]["GT"] = { new_allele };
         }
     } else if (first.samples[i]["GT"][0] != 0 or second.samples[i].at("GT")[0] != 0) {
-        //conflict, try to resolve with likelihoods
+        // conflict, try to resolve with likelihoods
         if (first.regt_samples.size() > i
-            and first.regt_samples[i].find("LIKELIHOOD") != first.regt_samples[i].end()) {
+            and first.regt_samples[i].find("LIKELIHOOD")
+                != first.regt_samples[i].end()) {
             first.confidence();
             first.genotype(5);
         } else {
@@ -302,8 +340,8 @@ void merge_gt(VCFRecord &first, const VCFRecord &second, const uint16_t i, const
     }
 }
 
-
-void VCF::merge_multi_allelic(uint32_t max_allele_length) {
+void VCF::merge_multi_allelic(uint32_t max_allele_length)
+{
     if (records.size() < 2)
         return;
 
@@ -313,22 +351,20 @@ void VCF::merge_multi_allelic(uint32_t max_allele_length) {
     auto reserve_size = vcf_size * 1.05;
     records.reserve(reserve_size);
     for (uint32_t current_pos = 1; current_pos < vcf_size; ++current_pos) {
-        const auto &record = *(records.at(current_pos));
-        //cout << "comparing record " << current_pos << "/" << vcf_size << " to record " << prev_pos << endl;
+        const auto& record = *(records.at(current_pos));
+        // cout << "comparing record " << current_pos << "/" << vcf_size << " to record
+        // " << prev_pos << endl;
 
-        if (record != prev_vr
-            and prev_vr.chrom == record.chrom
-            and prev_vr.pos == record.pos
-            and prev_vr.ref == record.ref
-            and prev_vr.ref != "."
-            and prev_vr.ref != ""
+        if (record != prev_vr and prev_vr.chrom == record.chrom
+            and prev_vr.pos == record.pos and prev_vr.ref == record.ref
+            and prev_vr.ref != "." and prev_vr.ref != ""
             and prev_vr.ref.length() <= max_allele_length
             and prev_vr.alt[0].length() <= max_allele_length) {
 
             // merge alts
             uint16_t prev_alt_size = prev_vr.alt.size();
             bool short_enough = true;
-            for (const auto &a : record.alt) {
+            for (const auto& a : record.alt) {
                 if (a.length() > max_allele_length)
                     short_enough = false;
                 prev_vr.alt.push_back(a);
@@ -348,19 +384,19 @@ void VCF::merge_multi_allelic(uint32_t max_allele_length) {
                 prev_vr = *(records.at(prev_pos));
             }
             for (uint i = 0; i < record.samples.size(); ++i) {
-                auto keys = {"MEAN_FWD_COVG", "MEAN_REV_COVG",
-                             "MED_FWD_COVG", "MED_REV_COVG",
-                             "SUM_FWD_COVG", "SUM_REV_COVG"};
-                for (const auto &key: keys) {
+                auto keys = { "MEAN_FWD_COVG", "MEAN_REV_COVG", "MED_FWD_COVG",
+                    "MED_REV_COVG", "SUM_FWD_COVG", "SUM_REV_COVG" };
+                for (const auto& key : keys) {
                     merge_sample_key(prev_vr.samples[i], record.samples[i], key);
                 }
-                keys = {"LIKELIHOOD", "GT_CONF", "GAPS"};
+                keys = { "LIKELIHOOD", "GT_CONF", "GAPS" };
                 if (!prev_vr.regt_samples.empty() and !record.regt_samples.empty()) {
-                    for (const auto &key: keys)
-                        merge_regt_sample_key(prev_vr.regt_samples[i], record.regt_samples[i], key);
+                    for (const auto& key : keys)
+                        merge_regt_sample_key(
+                            prev_vr.regt_samples[i], record.regt_samples[i], key);
                 }
 
-                //merge GT
+                // merge GT
                 merge_gt(prev_vr, record, i, prev_alt_size);
                 records.at(current_pos)->clear_sample(i);
                 records.at(prev_pos)->clear_sample(i);
@@ -378,17 +414,20 @@ void VCF::merge_multi_allelic(uint32_t max_allele_length) {
     sort_records();
 }
 
-void VCF::correct_dot_alleles(const std::string &vcf_ref, const std::string &chrom) {
-    //NB need to merge multiallelic before
-    //NB cannot add covgs after
+void VCF::correct_dot_alleles(const std::string& vcf_ref, const std::string& chrom)
+{
+    // NB need to merge multiallelic before
+    // NB cannot add covgs after
     auto vcf_size = records.size();
-    for (auto &recordPointer : records) {
-        auto &record = *recordPointer;
+    for (auto& recordPointer : records) {
+        auto& record = *recordPointer;
         if (record.chrom != chrom)
             continue;
-        assert(vcf_ref.length() >= record.pos || assert_msg("vcf_ref.length() = " << vcf_ref.length() << "!>= record.pos "
-                                                                                 << record.pos << "\n" << record << "\n"
-                                                                                 << vcf_ref));
+        assert(vcf_ref.length() >= record.pos
+            || assert_msg("vcf_ref.length() = " << vcf_ref.length() << "!>= record.pos "
+                                                << record.pos << "\n"
+                                                << record << "\n"
+                                                << vcf_ref));
         bool add_prev_letter = record.contains_dot_allele();
 
         if (add_prev_letter and record.pos > 0) {
@@ -399,24 +438,24 @@ void VCF::correct_dot_alleles(const std::string &vcf_ref, const std::string &chr
                 record.ref = prev_letter;
             else
                 record.ref = prev_letter + record.ref;
-                record.pos -= 1;
-            for (auto &a : record.alt){
-                if(a == "" or a == ".")
+            record.pos -= 1;
+            for (auto& a : record.alt) {
+                if (a == "" or a == ".")
                     a = prev_letter;
                 else
                     a = prev_letter + a;
             }
 
-
-        } else if (add_prev_letter and record.pos + record.ref.length() + 1 < vcf_ref.length()) {
+        } else if (add_prev_letter
+            and record.pos + record.ref.length() + 1 < vcf_ref.length()) {
             auto next_letter = vcf_ref[record.pos + record.ref.length()];
             if (record.ref == "" or record.ref == ".") {
                 next_letter = vcf_ref[record.pos];
                 record.ref = next_letter;
             } else
                 record.ref = record.ref + next_letter;
-            for (auto &a : record.alt)
-                if(a == "" or a == ".")
+            for (auto& a : record.alt)
+                if (a == "" or a == ".")
                     a = next_letter;
                 else
                     a = a + next_letter;
@@ -429,57 +468,69 @@ void VCF::correct_dot_alleles(const std::string &vcf_ref, const std::string &chr
     sort_records();
 }
 
-void VCF::make_gt_compatible() {
-    //TODO: this can be a source of inneficiency, fix this?
-    //TODO: interval tree does not to be indexed everytime this function is called, only if the interval tree changed
-    for (auto &pair : chrom2recordIntervalTree)
+void VCF::make_gt_compatible()
+{
+    // TODO: this can be a source of inneficiency, fix this?
+    // TODO: interval tree does not to be indexed everytime this function is called,
+    // only if the interval tree changed
+    for (auto& pair : chrom2recordIntervalTree)
         pair.second.index();
 
-    uint record_count=0;
-    for (auto &recordPointer : records) { //goes through all records
-        auto &record = *recordPointer;
+    uint record_count = 0;
+    for (auto& recordPointer : records) { // goes through all records
+        auto& record = *recordPointer;
         record_count++;
-        for (uint i = 0; i < record.samples.size(); ++i) { //goes through all samples of this record
+        for (uint i = 0; i < record.samples.size();
+             ++i) { // goes through all samples of this record
 
-            //retrieve all VCF records overlapping this record
+            // retrieve all VCF records overlapping this record
             std::vector<VCFRecord*> overlappingVCFRecords;
 
             std::vector<size_t> overlaps;
-            chrom2recordIntervalTree[record.chrom].overlap(record.pos, record.pos + record.ref.length() + 1, overlaps);
+            chrom2recordIntervalTree[record.chrom].overlap(
+                record.pos, record.pos + record.ref.length() + 1, overlaps);
             for (size_t i = 0; i < overlaps.size(); ++i)
-                overlappingVCFRecords.push_back(chrom2recordIntervalTree[record.chrom].data(overlaps[i]));
+                overlappingVCFRecords.push_back(
+                    chrom2recordIntervalTree[record.chrom].data(overlaps[i]));
 
-            //TODO: not sure if we need to sort, but doing it just in case... Check this later
-            std::sort(overlappingVCFRecords.begin(), overlappingVCFRecords.end(), [](VCFRecord* lhs, VCFRecord* rhs) {
-                return *lhs < *rhs;
-            });
+            // TODO: not sure if we need to sort, but doing it just in case... Check
+            // this later
+            std::sort(overlappingVCFRecords.begin(), overlappingVCFRecords.end(),
+                [](VCFRecord* lhs, VCFRecord* rhs) { return *lhs < *rhs; });
 
             for (VCFRecord* other_record_pointer : overlappingVCFRecords) {
-                VCFRecord &other_record = *other_record_pointer;
-                if (record == other_record) //no need to process this
+                VCFRecord& other_record = *other_record_pointer;
+                if (record == other_record) // no need to process this
                     continue;
-                if (   record.pos <= other_record.pos
+                if (record.pos <= other_record.pos
                     && other_record.pos <= record.pos + record.ref.length()
                     && record.samples[i].find("GT") != record.samples[i].end()
-                    && other_record.samples[i].find("GT") != other_record.samples[i].end()
+                    && other_record.samples[i].find("GT")
+                        != other_record.samples[i].end()
                     && record.samples[i]["GT"].size() > 0
                     && other_record.samples[i]["GT"].size() > 0) {
 
-                    if (record.samples[i]["GT"][0] == 0 and other_record.samples[i]["GT"][0] == 0)
+                    if (record.samples[i]["GT"][0] == 0
+                        and other_record.samples[i]["GT"][0] == 0)
                         continue;
-                    else if (not record.regt_samples.empty() and not other_record.regt_samples.empty()
-                             and record.regt_samples[i].find("LIKELIHOOD") != record.regt_samples[i].end()
-                             and
-                             other_record.regt_samples[i].find("LIKELIHOOD") != other_record.regt_samples[i].end()) {
-                        if (record.regt_samples[i]["LIKELIHOOD"][record.samples[i]["GT"][0]] >
-                            other_record.regt_samples[i]["LIKELIHOOD"][other_record.samples[i]["GT"][0]]) {
+                    else if (not record.regt_samples.empty()
+                        and not other_record.regt_samples.empty()
+                        and record.regt_samples[i].find("LIKELIHOOD")
+                            != record.regt_samples[i].end()
+                        and other_record.regt_samples[i].find("LIKELIHOOD")
+                            != other_record.regt_samples[i].end()) {
+                        if (record.regt_samples[i]["LIKELIHOOD"]
+                                               [record.samples[i]["GT"][0]]
+                            > other_record
+                                  .regt_samples[i]["LIKELIHOOD"]
+                                               [other_record.samples[i]["GT"][0]]) {
                             if (record.samples[i]["GT"][0] == 0)
-                                other_record.samples[i]["GT"] = {0};
+                                other_record.samples[i]["GT"] = { 0 };
                             else
                                 other_record.samples[i]["GT"] = {};
                         } else {
                             if (other_record.samples[i]["GT"][0] == 0)
-                                record.samples[i]["GT"] = {0};
+                                record.samples[i]["GT"] = { 0 };
                             else
                                 record.samples[i]["GT"] = {};
                         }
@@ -493,7 +544,8 @@ void VCF::make_gt_compatible() {
     }
 }
 
-std::string VCF::header() {
+std::string VCF::header()
+{
     // find date
     time_t t = time(0);
     char mbstr[10];
@@ -511,23 +563,37 @@ std::string VCF::header() {
     header += "\n##ALT=<ID=SNP,Description=\"SNP\">\n";
     header += "##ALT=<ID=PH_SNPs,Description=\"Phased SNPs\">\n";
     header += "##ALT=<ID=INDEL,Description=\"Insertion-deletion\">\n";
-    header += "##ALT=<ID=COMPLEX,Description=\"Complex variant, collection of SNPs and indels\">\n";
-    header += "##INFO=<ID=SVTYPE,Number=1,Type=String,Description=\"Type of variant\">\n";
+    header += "##ALT=<ID=COMPLEX,Description=\"Complex variant, collection of SNPs and "
+              "indels\">\n";
+    header
+        += "##INFO=<ID=SVTYPE,Number=1,Type=String,Description=\"Type of variant\">\n";
     header += "##ALT=<ID=SIMPLE,Description=\"Graph bubble is simple\">\n";
-    header += "##ALT=<ID=NESTED,Description=\"Variation site was a nested feature in the graph\">\n";
-    header += "##ALT=<ID=TOO_MANY_ALTS,Description=\"Variation site was a multinested feature with too many alts to include all in the VCF\">\n";
-    header += "##INFO=<ID=GRAPHTYPE,Number=1,Type=String,Description=\"Type of graph feature\">\n";
+    header += "##ALT=<ID=NESTED,Description=\"Variation site was a nested feature in "
+              "the graph\">\n";
+    header += "##ALT=<ID=TOO_MANY_ALTS,Description=\"Variation site was a multinested "
+              "feature with too many alts to include all in the VCF\">\n";
+    header += "##INFO=<ID=GRAPHTYPE,Number=1,Type=String,Description=\"Type of graph "
+              "feature\">\n";
     header += "##FORMAT=<ID=GT,Number=1,Type=String,Description=\"Genotype\">\n";
-    header += "##FORMAT=<ID=MEAN_FWD_COVG,Number=A,Type=Integer,Description=\"Mean forward coverage\">\n";
-    header += "##FORMAT=<ID=MEAN_REV_COVG,Number=A,Type=Integer,Description=\"Mean reverse coverage\">\n";
-    header += "##FORMAT=<ID=MED_FWD_COVG,Number=A,Type=Integer,Description=\"Med forward coverage\">\n";
-    header += "##FORMAT=<ID=MED_REV_COVG,Number=A,Type=Integer,Description=\"Med reverse coverage\">\n";
-    header += "##FORMAT=<ID=SUM_FWD_COVG,Number=A,Type=Integer,Description=\"Sum forward coverage\">\n";
-    header += "##FORMAT=<ID=SUM_REV_COVG,Number=A,Type=Integer,Description=\"Sum reverse coverage\">\n";
-    header += "##FORMAT=<ID=GAPS,Number=A,Type=Float,Description=\"Number of gap bases\">\n";
-    header += "##FORMAT=<ID=LIKELIHOOD,Number=A,Type=Float,Description=\"Likelihood\">\n";
-    header += "##FORMAT=<ID=GT_CONF,Number=1,Type=Float,Description=\"Genotype confidence\">\n";
-    for (const auto chrom : chroms){
+    header += "##FORMAT=<ID=MEAN_FWD_COVG,Number=A,Type=Integer,Description=\"Mean "
+              "forward coverage\">\n";
+    header += "##FORMAT=<ID=MEAN_REV_COVG,Number=A,Type=Integer,Description=\"Mean "
+              "reverse coverage\">\n";
+    header += "##FORMAT=<ID=MED_FWD_COVG,Number=A,Type=Integer,Description=\"Med "
+              "forward coverage\">\n";
+    header += "##FORMAT=<ID=MED_REV_COVG,Number=A,Type=Integer,Description=\"Med "
+              "reverse coverage\">\n";
+    header += "##FORMAT=<ID=SUM_FWD_COVG,Number=A,Type=Integer,Description=\"Sum "
+              "forward coverage\">\n";
+    header += "##FORMAT=<ID=SUM_REV_COVG,Number=A,Type=Integer,Description=\"Sum "
+              "reverse coverage\">\n";
+    header += "##FORMAT=<ID=GAPS,Number=A,Type=Float,Description=\"Number of gap "
+              "bases\">\n";
+    header
+        += "##FORMAT=<ID=LIKELIHOOD,Number=A,Type=Float,Description=\"Likelihood\">\n";
+    header += "##FORMAT=<ID=GT_CONF,Number=1,Type=Float,Description=\"Genotype "
+              "confidence\">\n";
+    for (const auto chrom : chroms) {
         header += "##contig=<ID=" + chrom + ">\n";
     }
     header += "#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\tFORMAT";
@@ -539,14 +605,16 @@ std::string VCF::header() {
     return header;
 }
 
-// NB in the absence of filter flags being set to true, all results are saved. If one or more filter flags for SVTYPE are set, 
-// then only those matching the filter are saved. Similarly for GRAPHTYPE.
-void VCF::save(const std::string &filepath, bool simple, bool complexgraph, bool toomanyalts, bool snp, bool indel,
-               bool phsnps, bool complexvar) {
+// NB in the absence of filter flags being set to true, all results are saved. If one or
+// more filter flags for SVTYPE are set, then only those matching the filter are saved.
+// Similarly for GRAPHTYPE.
+void VCF::save(const std::string& filepath, bool simple, bool complexgraph,
+    bool toomanyalts, bool snp, bool indel, bool phsnps, bool complexvar)
+{
     /*if (samples.empty())
     {
-	    cout << now() << "Did not save VCF for sample" << endl;
-	    return;
+            cout << now() << "Did not save VCF for sample" << endl;
+            return;
     }*/
     BOOST_LOG_TRIVIAL(debug) << "Saving VCF to " << filepath;
 
@@ -562,23 +630,33 @@ void VCF::save(const std::string &filepath, bool simple, bool complexgraph, bool
         if (records[i]->contains_dot_allele())
             continue;
 
-        if (((!simple and !complexgraph) or
-             (simple and records[i]->info.find("GRAPHTYPE=SIMPLE") != std::string::npos) or
-             (complexgraph and records[i]->info.find("GRAPHTYPE=NESTED") != std::string::npos) or
-             (toomanyalts and records[i]->info.find("GRAPHTYPE=TOO_MANY_ALTS") != std::string::npos)) and
-            ((!snp and !indel and !phsnps and !complexvar) or
-             (snp and records[i]->info.find("SVTYPE=SNP") != std::string::npos) or
-             (indel and records[i]->info.find("SVTYPE=INDEL") != std::string::npos) or
-             (phsnps and records[i]->info.find("SVTYPE=PH_SNPs") != std::string::npos) or
-             (complexvar and records[i]->info.find("SVTYPE=COMPLEX") != std::string::npos))) {
+        if (((!simple and !complexgraph)
+                or (simple
+                    and records[i]->info.find("GRAPHTYPE=SIMPLE") != std::string::npos)
+                or (complexgraph
+                    and records[i]->info.find("GRAPHTYPE=NESTED") != std::string::npos)
+                or (toomanyalts
+                    and records[i]->info.find("GRAPHTYPE=TOO_MANY_ALTS")
+                        != std::string::npos))
+            and ((!snp and !indel and !phsnps and !complexvar)
+                or (snp and records[i]->info.find("SVTYPE=SNP") != std::string::npos)
+                or (indel
+                    and records[i]->info.find("SVTYPE=INDEL") != std::string::npos)
+                or (phsnps
+                    and records[i]->info.find("SVTYPE=PH_SNPs") != std::string::npos)
+                or (complexvar
+                    and records[i]->info.find("SVTYPE=COMPLEX")
+                        != std::string::npos))) {
             handle << *(records[i]);
         }
     }
     handle.close();
-    BOOST_LOG_TRIVIAL(debug) << "Finished saving " << records.size() << " entries to file";
+    BOOST_LOG_TRIVIAL(debug) << "Finished saving " << records.size()
+                             << " entries to file";
 }
 
-void VCF::load(const std::string &filepath) {
+void VCF::load(const std::string& filepath)
+{
     BOOST_LOG_TRIVIAL(debug) << "Loading VCF from " << filepath;
     VCFRecord vr;
     std::string line;
@@ -596,8 +674,8 @@ void VCF::load(const std::string &filepath) {
                 ss.clear();
                 add_record(vr, sample_names);
                 added += 1;
-            } else if (line[1] != '#'){
-                auto sample_string = line.replace(0,45, "");
+            } else if (line[1] != '#') {
+                auto sample_string = line.replace(0, 45, "");
                 sample_names = split(sample_string, "\t");
             }
         }
@@ -605,12 +683,16 @@ void VCF::load(const std::string &filepath) {
         std::cerr << "Unable to open VCF file " << filepath << std::endl;
         std::exit(1);
     }
-    BOOST_LOG_TRIVIAL(debug) << "Finished loading " << added << " entries to VCF, which now has size "
+    BOOST_LOG_TRIVIAL(debug) << "Finished loading " << added
+                             << " entries to VCF, which now has size "
                              << records.size();
 }
 
-bool VCF::operator==(const VCF &y) const {
-    if (records.size() != y.records.size()) { return false; }
+bool VCF::operator==(const VCF& y) const
+{
+    if (records.size() != y.records.size()) {
+        return false;
+    }
     for (uint32_t i = 0; i != y.records.size(); ++i) {
         if (find_record_in_records(*(y.records[i])) == records.end()) {
             return false;
@@ -619,19 +701,18 @@ bool VCF::operator==(const VCF &y) const {
     return true;
 }
 
-bool VCF::operator!=(const VCF &y) const {
-    return !(*this == y);
-}
+bool VCF::operator!=(const VCF& y) const { return !(*this == y); }
 
-
-void VCF::concatenateVCFs(const std::vector<std::string> &VCFPathsToBeConcatenated, const std::string &sink) {
+void VCF::concatenateVCFs(
+    const std::vector<std::string>& VCFPathsToBeConcatenated, const std::string& sink)
+{
     std::ofstream outFile(sink);
     bool headerIsOutput = false;
-    for (const auto &VCFPath : VCFPathsToBeConcatenated) {
+    for (const auto& VCFPath : VCFPathsToBeConcatenated) {
         std::ifstream inFile(VCFPath);
         std::string line;
         while (std::getline(inFile, line)) {
-            if ((line[0]!='#') || (line[0]=='#' && headerIsOutput==false))
+            if ((line[0] != '#') || (line[0] == '#' && headerIsOutput == false))
                 outFile << line << std::endl;
         }
         headerIsOutput = true;
@@ -640,8 +721,9 @@ void VCF::concatenateVCFs(const std::vector<std::string> &VCFPathsToBeConcatenat
     outFile.close();
 }
 
-std::ostream &operator<<(std::ostream &out, VCF const &m) {
-    for (const auto &record : m.records) {
+std::ostream& operator<<(std::ostream& out, VCF const& m)
+{
+    for (const auto& record : m.records) {
         out << (*record);
     }
     return out;

--- a/src/vcfrecord.cpp
+++ b/src/vcfrecord.cpp
@@ -1,47 +1,58 @@
+#include <algorithm>
 #include <cassert>
 #include <cmath>
 #include <iostream>
-#include <vector>
-#include <algorithm>
 #include <numeric>
+#include <vector>
 
 #include <boost/log/trivial.hpp>
 
-#include "vcfrecord.h"
 #include "utils.h"
-
+#include "vcfrecord.h"
 
 #define assert_msg(x) !(std::cerr << "Assertion failed: " << x << std::endl)
 
-
-VCFRecord::VCFRecord(std::string c, uint32_t p, std::string r, std::string a, std::string i, std::string g) : chrom(c),
-                                                                                                              pos(p),
-                                                                                                              id("."),
-                                                                                                              ref(r),
-                                                                                                              qual("."),
-                                                                                                              filter("."),
-                                                                                                              info(i),
-                                                                                                              format({"GT"}) {
+VCFRecord::VCFRecord(std::string c, uint32_t p, std::string r, std::string a,
+    std::string i, std::string g)
+    : chrom(c)
+    , pos(p)
+    , id(".")
+    , ref(r)
+    , qual(".")
+    , filter(".")
+    , info(i)
+    , format({ "GT" })
+{
     if (a == "")
         alt.push_back(".");
     else
         alt.push_back(a);
 
     // fix so no empty strings
-    if (ref == "") { ref = "."; }
+    if (ref == "") {
+        ref = ".";
+    }
 
     // classify variants as SNPs, INDELs PH_SNPs or COMPLEX
-    // need to think about how to handle cases where there are more than 2 options, not all of one type
+    // need to think about how to handle cases where there are more than 2 options, not
+    // all of one type
     if (info == ".") {
-        if (ref == "." and (alt.empty() or alt[0] == ".")) {}
-        else if (ref == "." or alt.empty() or alt[0] == ".") { info = "SVTYPE=INDEL"; }
-        else if (ref.length() == 1 and !alt.empty() and alt[0].length() == 1) { info = "SVTYPE=SNP"; }
-        else if (!alt.empty() and alt[0].length() == ref.length()) { info = "SVTYPE=PH_SNPs"; }
-        else if (!alt.empty() and ref.length() < alt[0].length() and
-                 ref.compare(0, ref.length(), alt[0], 0, ref.length()) == 0) { info = "SVTYPE=INDEL"; }
-        else if (!alt.empty() and alt[0].length() < ref.length() and
-                 alt[0].compare(0, alt[0].length(), ref, 0, alt[0].length()) == 0) { info = "SVTYPE=INDEL"; }
-        else { info = "SVTYPE=COMPLEX"; }
+        if (ref == "." and (alt.empty() or alt[0] == ".")) {
+        } else if (ref == "." or alt.empty() or alt[0] == ".") {
+            info = "SVTYPE=INDEL";
+        } else if (ref.length() == 1 and !alt.empty() and alt[0].length() == 1) {
+            info = "SVTYPE=SNP";
+        } else if (!alt.empty() and alt[0].length() == ref.length()) {
+            info = "SVTYPE=PH_SNPs";
+        } else if (!alt.empty() and ref.length() < alt[0].length()
+            and ref.compare(0, ref.length(), alt[0], 0, ref.length()) == 0) {
+            info = "SVTYPE=INDEL";
+        } else if (!alt.empty() and alt[0].length() < ref.length()
+            and alt[0].compare(0, alt[0].length(), ref, 0, alt[0].length()) == 0) {
+            info = "SVTYPE=INDEL";
+        } else {
+            info = "SVTYPE=COMPLEX";
+        }
     }
 
     // add graph type info
@@ -51,9 +62,17 @@ VCFRecord::VCFRecord(std::string c, uint32_t p, std::string r, std::string a, st
     }
 };
 
-VCFRecord::VCFRecord() : chrom("."), pos(0), id("."), ref("."), qual("."), filter("."), info(".") {};
+VCFRecord::VCFRecord()
+    : chrom(".")
+    , pos(0)
+    , id(".")
+    , ref(".")
+    , qual(".")
+    , filter(".")
+    , info(".") {};
 
-VCFRecord::VCFRecord(const VCFRecord &other) {
+VCFRecord::VCFRecord(const VCFRecord& other)
+{
     chrom = other.chrom;
     pos = other.pos;
     id = other.id;
@@ -67,7 +86,8 @@ VCFRecord::VCFRecord(const VCFRecord &other) {
     regt_samples = other.regt_samples;
 }
 
-VCFRecord &VCFRecord::operator=(const VCFRecord &other) {
+VCFRecord& VCFRecord::operator=(const VCFRecord& other)
+{
     // check for self-assignment
     if (this == &other)
         return *this;
@@ -89,7 +109,8 @@ VCFRecord &VCFRecord::operator=(const VCFRecord &other) {
 
 VCFRecord::~VCFRecord() {};
 
-void VCFRecord::clear() {
+void VCFRecord::clear()
+{
     chrom = ".";
     pos = 0;
     id = ".";
@@ -107,7 +128,8 @@ void VCFRecord::clear() {
     regt_samples.clear();
 }
 
-void VCFRecord::clear_sample(uint32_t i) {
+void VCFRecord::clear_sample(uint32_t i)
+{
     if (samples.size() > i) {
         samples.at(i).clear();
     }
@@ -116,7 +138,7 @@ void VCFRecord::clear_sample(uint32_t i) {
         regt_samples.at(i).clear();
     }
     bool all_cleared(true);
-    for (const auto &s : samples) {
+    for (const auto& s : samples) {
         if (!s.empty()) {
             all_cleared = false;
             break;
@@ -127,40 +149,50 @@ void VCFRecord::clear_sample(uint32_t i) {
     }
 }
 
-void VCFRecord::add_formats(const std::vector<std::string> &formats) {
-    for (const auto &s : formats) {
+void VCFRecord::add_formats(const std::vector<std::string>& formats)
+{
+    for (const auto& s : formats) {
         if (find(format.begin(), format.end(), s) == format.end())
             format.push_back(s);
     }
 }
 
-void VCFRecord::set_format(const uint32_t& sample_id, const std::string& format, const std::vector<uint16_t>& val){
+void VCFRecord::set_format(const uint32_t& sample_id, const std::string& format,
+    const std::vector<uint16_t>& val)
+{
     assert(samples.size() > sample_id);
     samples[sample_id][format] = val;
-    add_formats({format});
+    add_formats({ format });
 }
 
-void VCFRecord::set_format(const uint32_t& sample_id, const std::string& format, const std::vector<float>& val){
+void VCFRecord::set_format(
+    const uint32_t& sample_id, const std::string& format, const std::vector<float>& val)
+{
     std::unordered_map<std::string, std::vector<float>> m;
     m.reserve(3);
-    for (uint i=regt_samples.size(); i<samples.size(); ++i) {
+    for (uint i = regt_samples.size(); i < samples.size(); ++i) {
         regt_samples.push_back(m);
     }
     assert(regt_samples.size() > sample_id);
     regt_samples[sample_id][format] = val;
-    add_formats({format});
+    add_formats({ format });
 }
 
-void VCFRecord::set_format(const uint32_t& sample_id, const std::string& format, const uint16_t& val){
+void VCFRecord::set_format(
+    const uint32_t& sample_id, const std::string& format, const uint16_t& val)
+{
     std::vector<uint16_t> v = {};
     v.emplace_back(val);
     set_format(sample_id, format, v);
 }
 
-void VCFRecord::set_format(const uint32_t& sample_id, const std::string& format, const uint32_t& val){
-    if (val >= std::numeric_limits<uint16_t>::max()){
-        BOOST_LOG_TRIVIAL(debug) << now() << "Value too large for sample id " << sample_id << " format " << format
-                                 << " value " << val;
+void VCFRecord::set_format(
+    const uint32_t& sample_id, const std::string& format, const uint32_t& val)
+{
+    if (val >= std::numeric_limits<uint16_t>::max()) {
+        BOOST_LOG_TRIVIAL(debug)
+            << now() << "Value too large for sample id " << sample_id << " format "
+            << format << " value " << val;
         uint16_t v = std::numeric_limits<uint16_t>::max() - 1;
         set_format(sample_id, format, v);
     } else {
@@ -169,25 +201,32 @@ void VCFRecord::set_format(const uint32_t& sample_id, const std::string& format,
     }
 }
 
-void VCFRecord::set_format(const uint32_t& sample_id, const std::string& format, const float& val){
+void VCFRecord::set_format(
+    const uint32_t& sample_id, const std::string& format, const float& val)
+{
     std::vector<float> v = {};
     v.emplace_back(val);
     set_format(sample_id, format, v);
 }
 
-void VCFRecord::append_format(const uint32_t& sample_id, const std::string& format, const uint16_t& val){
+void VCFRecord::append_format(
+    const uint32_t& sample_id, const std::string& format, const uint16_t& val)
+{
     assert(samples.size() > sample_id);
-    if (samples[sample_id].find(format)!=samples[sample_id].end()){
+    if (samples[sample_id].find(format) != samples[sample_id].end()) {
         samples[sample_id][format].push_back(val);
     } else {
         set_format(sample_id, format, val);
     }
 }
 
-void VCFRecord::append_format(const uint32_t& sample_id, const std::string& format, const uint32_t& val){
-    if (val >= std::numeric_limits<uint16_t>::max()){
-        BOOST_LOG_TRIVIAL(debug) << now() << "Value too large for sample id " << sample_id << " format " << format
-                                 << " value " << val;
+void VCFRecord::append_format(
+    const uint32_t& sample_id, const std::string& format, const uint32_t& val)
+{
+    if (val >= std::numeric_limits<uint16_t>::max()) {
+        BOOST_LOG_TRIVIAL(debug)
+            << now() << "Value too large for sample id " << sample_id << " format "
+            << format << " value " << val;
         uint16_t v = std::numeric_limits<uint16_t>::max() - 1;
         append_format(sample_id, format, v);
     } else {
@@ -196,45 +235,54 @@ void VCFRecord::append_format(const uint32_t& sample_id, const std::string& form
     }
 }
 
-void VCFRecord::append_format(const uint32_t& sample_id, const std::string& format, const float& val){
+void VCFRecord::append_format(
+    const uint32_t& sample_id, const std::string& format, const float& val)
+{
     std::unordered_map<std::string, std::vector<float>> m;
     m.reserve(3);
     if (regt_samples.empty()) {
-        for (const auto &sample : samples) {
+        for (const auto& sample : samples) {
             regt_samples.push_back(m);
         }
     }
     assert(regt_samples.size() > sample_id);
-    if (regt_samples[sample_id].find(format)!=regt_samples[sample_id].end()){
+    if (regt_samples[sample_id].find(format) != regt_samples[sample_id].end()) {
         regt_samples[sample_id][format].push_back(val);
     } else {
         set_format(sample_id, format, val);
     }
 }
 
-std::vector<uint16_t> VCFRecord::get_format_u(const uint32_t& sample_id, const std::string& format){
+std::vector<uint16_t> VCFRecord::get_format_u(
+    const uint32_t& sample_id, const std::string& format)
+{
     std::vector<uint16_t> empty_return;
     bool sample_exists = samples.size() > sample_id;
     if (!sample_exists)
         return empty_return;
-    bool found_key_in_sample = samples[sample_id].find(format)!=samples[sample_id].end();
+    bool found_key_in_sample
+        = samples[sample_id].find(format) != samples[sample_id].end();
     if (!found_key_in_sample)
         return empty_return;
     return samples[sample_id][format];
 }
 
-std::vector<float> VCFRecord::get_format_f(const uint32_t& sample_id, const std::string& format){
+std::vector<float> VCFRecord::get_format_f(
+    const uint32_t& sample_id, const std::string& format)
+{
     std::vector<float> empty_return;
     bool sample_exists = regt_samples.size() > sample_id;
     if (!sample_exists)
         return empty_return;
-    bool found_key_in_sample = regt_samples[sample_id].find(format)!=regt_samples[sample_id].end();
+    bool found_key_in_sample
+        = regt_samples[sample_id].find(format) != regt_samples[sample_id].end();
     if (!found_key_in_sample)
         return empty_return;
     return regt_samples[sample_id][format];
 }
 
-float logfactorial(uint32_t n) {
+float logfactorial(uint32_t n)
+{
     float ret = 0;
     for (uint32_t i = 1; i <= n; ++i) {
         ret += log(i);
@@ -242,16 +290,20 @@ float logfactorial(uint32_t n) {
     return ret;
 }
 
-void VCFRecord::likelihood(const std::vector<uint32_t> &expected_depth_covg_v, const float &error_rate,
-                           const uint32_t &min_allele_covg, const float &min_fraction_allele_covg) {
+void VCFRecord::likelihood(const std::vector<uint32_t>& expected_depth_covg_v,
+    const float& error_rate, const uint32_t& min_allele_covg,
+    const float& min_fraction_allele_covg)
+{
     for (uint_least16_t i = 0; i < samples.size(); ++i) {
         assert(i < expected_depth_covg_v.size());
-        const auto &expected_depth_covg = expected_depth_covg_v[i];
-        const uint32_t min_covg = std::max(min_allele_covg, uint(min_fraction_allele_covg*expected_depth_covg));
-        const auto &fwd_covgs = get_format_u(i,"MEAN_FWD_COVG");
-        const auto &rev_covgs = get_format_u(i,"MEAN_REV_COVG");
-        const auto &gaps = get_format_f(i,"GAPS");
-        if (!fwd_covgs.empty() and fwd_covgs.size() == rev_covgs.size() and fwd_covgs.size() == gaps.size()){
+        const auto& expected_depth_covg = expected_depth_covg_v[i];
+        const uint32_t min_covg = std::max(
+            min_allele_covg, uint(min_fraction_allele_covg * expected_depth_covg));
+        const auto& fwd_covgs = get_format_u(i, "MEAN_FWD_COVG");
+        const auto& rev_covgs = get_format_u(i, "MEAN_REV_COVG");
+        const auto& gaps = get_format_f(i, "GAPS");
+        if (!fwd_covgs.empty() and fwd_covgs.size() == rev_covgs.size()
+            and fwd_covgs.size() == gaps.size()) {
 
             std::vector<uint16_t> covgs = {};
             for (uint j = 0; j < fwd_covgs.size(); ++j) {
@@ -266,34 +318,44 @@ void VCFRecord::likelihood(const std::vector<uint32_t> &expected_depth_covg_v, c
             for (uint j = 0; j < covgs.size(); ++j) {
                 auto other_covg = accumulate(covgs.begin(), covgs.end(), 0) - covgs[j];
                 if (covgs[j] > 0) {
-                    likelihood = covgs[j] * log(expected_depth_covg) - expected_depth_covg
-                                 - logfactorial(covgs[j]) + other_covg * log(error_rate);
-                    //std::cout << "likelihood before gaps " << likelihood << " gaps = " << gaps[j] << std::endl;
-                    likelihood += (1 - gaps[j]) * log(1 - exp(-(float)expected_depth_covg)) - expected_depth_covg * gaps[j];
-                    //std::cout << "likelihood after gaps " << likelihood << std::endl;
+                    likelihood = covgs[j] * log(expected_depth_covg)
+                        - expected_depth_covg - logfactorial(covgs[j])
+                        + other_covg * log(error_rate);
+                    // std::cout << "likelihood before gaps " << likelihood << " gaps =
+                    // " << gaps[j] << std::endl;
+                    likelihood
+                        += (1 - gaps[j]) * log(1 - exp(-(float)expected_depth_covg))
+                        - expected_depth_covg * gaps[j];
+                    // std::cout << "likelihood after gaps " << likelihood << std::endl;
                 } else {
                     likelihood = other_covg * log(error_rate) - expected_depth_covg;
-                    //std::cout << "likelihood before gaps " << likelihood << " gaps = " << gaps[j] << std::endl;
-                    likelihood += (1 - gaps[j]) * log(1 - exp(-(float)expected_depth_covg)) - expected_depth_covg * gaps[j];
-                    //std::cout << "likelihood after gaps " << likelihood << std::endl;
+                    // std::cout << "likelihood before gaps " << likelihood << " gaps =
+                    // " << gaps[j] << std::endl;
+                    likelihood
+                        += (1 - gaps[j]) * log(1 - exp(-(float)expected_depth_covg))
+                        - expected_depth_covg * gaps[j];
+                    // std::cout << "likelihood after gaps " << likelihood << std::endl;
                 }
-                append_format(i,"LIKELIHOOD",likelihood);
+                append_format(i, "LIKELIHOOD", likelihood);
             }
         }
     }
 
-    assert(regt_samples.size() == samples.size() or assert_msg(regt_samples.size() << "!=" << samples.size()));
+    assert(regt_samples.size() == samples.size()
+        or assert_msg(regt_samples.size() << "!=" << samples.size()));
 }
 
-void VCFRecord::confidence(const uint32_t &min_total_covg, const uint32_t &min_diff_covg) {
-    for (uint i=0; i < regt_samples.size(); ++i) {
+void VCFRecord::confidence(
+    const uint32_t& min_total_covg, const uint32_t& min_diff_covg)
+{
+    for (uint i = 0; i < regt_samples.size(); ++i) {
         auto& sample = regt_samples[i];
         if (sample.find("LIKELIHOOD") != sample.end()) {
             assert(sample["LIKELIHOOD"].size() > 1);
             float max_lik = 0, max_lik2 = 0;
             uint32_t max_coord = 0, max_coord2 = 0;
-            for (uint j=0; j < sample["LIKELIHOOD"].size(); ++j ){
-                const auto & likelihood = sample["LIKELIHOOD"][j];
+            for (uint j = 0; j < sample["LIKELIHOOD"].size(); ++j) {
+                const auto& likelihood = sample["LIKELIHOOD"][j];
                 if (max_lik == 0 or likelihood > max_lik) {
                     max_coord2 = max_coord;
                     max_coord = j;
@@ -306,31 +368,35 @@ void VCFRecord::confidence(const uint32_t &min_total_covg, const uint32_t &min_d
             }
 
             assert(samples.size() > i);
-            assert(samples[i].find("MEAN_FWD_COVG")!=samples[i].end());
+            assert(samples[i].find("MEAN_FWD_COVG") != samples[i].end());
             assert(samples[i]["MEAN_FWD_COVG"].size() > max_coord);
 
-            const auto & max_covg = samples[i]["MEAN_FWD_COVG"][max_coord]+samples[i]["MEAN_REV_COVG"][max_coord];
-            const auto & next_covg = samples[i]["MEAN_FWD_COVG"][max_coord2]+samples[i]["MEAN_REV_COVG"][max_coord2];
+            const auto& max_covg = samples[i]["MEAN_FWD_COVG"][max_coord]
+                + samples[i]["MEAN_REV_COVG"][max_coord];
+            const auto& next_covg = samples[i]["MEAN_FWD_COVG"][max_coord2]
+                + samples[i]["MEAN_REV_COVG"][max_coord2];
             bool enough_total_covg = (max_covg + next_covg >= min_total_covg);
-            bool enough_difference_in_covg = (std::abs(max_covg-next_covg) >= min_diff_covg);
+            bool enough_difference_in_covg
+                = (std::abs(max_covg - next_covg) >= min_diff_covg);
             if (enough_total_covg and enough_difference_in_covg)
-                sample["GT_CONF"] = {std::abs(max_lik - max_lik2)};
+                sample["GT_CONF"] = { std::abs(max_lik - max_lik2) };
             else
-                sample["GT_CONF"] = {0};
+                sample["GT_CONF"] = { 0 };
         }
     }
-    add_formats({"GT_CONF"});
+    add_formats({ "GT_CONF" });
 }
 
-void VCFRecord::genotype(const uint16_t confidence_threshold) {
+void VCFRecord::genotype(const uint16_t confidence_threshold)
+{
     for (uint_least16_t i = 0; i < samples.size(); ++i) {
         if (regt_samples[i].find("GT_CONF") != regt_samples[i].end()) {
             if (regt_samples[i]["GT_CONF"][0] > confidence_threshold) {
                 uint16_t allele = 0;
                 float max_likelihood = 0;
-                for (const auto &likelihood : regt_samples[i]["LIKELIHOOD"]) {
+                for (const auto& likelihood : regt_samples[i]["LIKELIHOOD"]) {
                     if (max_likelihood == 0 or likelihood > max_likelihood) {
-                        samples[i]["GT"] = {allele};
+                        samples[i]["GT"] = { allele };
                         max_likelihood = likelihood;
                     }
                     allele++;
@@ -344,64 +410,90 @@ void VCFRecord::genotype(const uint16_t confidence_threshold) {
     }
 }
 
-bool VCFRecord::contains_dot_allele() const {
+bool VCFRecord::contains_dot_allele() const
+{
     if (ref == "." or ref == "")
         return true;
-    for (const auto &a : alt){
+    for (const auto& a : alt) {
         if (a == "." or a == "")
             return true;
     }
     return false;
 }
 
-bool VCFRecord::operator==(const VCFRecord &y) const {
-    if (chrom != y.chrom) { return false; }
-    if (pos != y.pos) { return false; }
-    if (ref != y.ref) { return false; }
-    if (alt.size() != y.alt.size()) { return false; }
-    for (const auto &a : alt) {
-        if (find(y.alt.begin(), y.alt.end(), a) == y.alt.end()) { return false; }
+bool VCFRecord::operator==(const VCFRecord& y) const
+{
+    if (chrom != y.chrom) {
+        return false;
+    }
+    if (pos != y.pos) {
+        return false;
+    }
+    if (ref != y.ref) {
+        return false;
+    }
+    if (alt.size() != y.alt.size()) {
+        return false;
+    }
+    for (const auto& a : alt) {
+        if (find(y.alt.begin(), y.alt.end(), a) == y.alt.end()) {
+            return false;
+        }
     }
     return true;
 }
 
-bool VCFRecord::operator!=(const VCFRecord &y) const {
-    return !(*this == y);
-}
+bool VCFRecord::operator!=(const VCFRecord& y) const { return !(*this == y); }
 
-bool VCFRecord::operator<(const VCFRecord &y) const {
-    if (chrom < y.chrom) { return true; }
-    if (chrom > y.chrom) { return false; }
-    if (pos < y.pos) { return true; }
-    if (pos > y.pos) { return false; }
-    if (ref < y.ref) { return true; }
-    if (ref > y.ref) { return false; }
-    if (alt < y.alt) { return true; }
-    if (alt > y.alt) { return false; }
+bool VCFRecord::operator<(const VCFRecord& y) const
+{
+    if (chrom < y.chrom) {
+        return true;
+    }
+    if (chrom > y.chrom) {
+        return false;
+    }
+    if (pos < y.pos) {
+        return true;
+    }
+    if (pos > y.pos) {
+        return false;
+    }
+    if (ref < y.ref) {
+        return true;
+    }
+    if (ref > y.ref) {
+        return false;
+    }
+    if (alt < y.alt) {
+        return true;
+    }
+    if (alt > y.alt) {
+        return false;
+    }
     return false;
 }
 
-
-std::ostream &operator<<(std::ostream &out, VCFRecord const &m) {
+std::ostream& operator<<(std::ostream& out, VCFRecord const& m)
+{
     out << m.chrom << "\t" << m.pos + 1 << "\t" << m.id << "\t" << m.ref << "\t";
 
     if (m.alt.empty()) {
         out << ".";
     } else {
         std::string buffer = "";
-        for (const auto &a : m.alt) {
+        for (const auto& a : m.alt) {
             out << buffer << a;
             buffer = ",";
         }
     }
-    out << "\t" << m.qual << "\t"
-        << m.filter << "\t" << m.info << "\t";
+    out << "\t" << m.qual << "\t" << m.filter << "\t" << m.info << "\t";
 
     std::string last_format;
     if (!m.format.empty())
         last_format = m.format[m.format.size() - 1];
 
-    for (const auto &s : m.format) {
+    for (const auto& s : m.format) {
         out << s;
         if (s != last_format)
             out << ":";
@@ -409,18 +501,19 @@ std::ostream &operator<<(std::ostream &out, VCFRecord const &m) {
 
     for (uint_least16_t i = 0; i < m.samples.size(); ++i) {
         out << "\t";
-        for (const auto &f : m.format) {
+        for (const auto& f : m.format) {
             std::string buffer = "";
-            if (m.samples[i].find(f) != m.samples[i].end() and not m.samples[i].at(f).empty()) {
-                for (const auto &a : m.samples.at(i).at(f)) {
+            if (m.samples[i].find(f) != m.samples[i].end()
+                and not m.samples[i].at(f).empty()) {
+                for (const auto& a : m.samples.at(i).at(f)) {
                     out << buffer << +a;
                     buffer = ",";
                 }
 
             } else if (m.regt_samples.size() > i
-                       and m.regt_samples[i].find(f) != m.regt_samples[i].end()
-                       and not m.regt_samples[i].at(f).empty()) {
-                for (const auto &a : m.regt_samples.at(i).at(f)) {
+                and m.regt_samples[i].find(f) != m.regt_samples[i].end()
+                and not m.regt_samples[i].at(f).empty()) {
+                for (const auto& a : m.regt_samples.at(i).at(f)) {
                     out << buffer << +a;
                     buffer = ",";
                 }
@@ -437,10 +530,11 @@ std::ostream &operator<<(std::ostream &out, VCFRecord const &m) {
     return out;
 }
 
-std::istream &operator>>(std::istream &in, VCFRecord &m) {
+std::istream& operator>>(std::istream& in, VCFRecord& m)
+{
     std::string token, alt_s;
     std::vector<std::string> sample_strings, sample_substrings;
-    std::vector<std::string> float_strings = {"LIKELIHOOD", "GT_CONF", "GAPS"};
+    std::vector<std::string> float_strings = { "LIKELIHOOD", "GT_CONF", "GAPS" };
     std::unordered_map<std::string, std::vector<uint16_t>> sample_data;
     std::unordered_map<std::string, std::vector<float>> regt_sample_data;
     m.alt.clear();
@@ -473,24 +567,25 @@ std::istream &operator>>(std::istream &in, VCFRecord &m) {
     sample_data.reserve(m.format.size());
     while (in >> token) {
         sample_strings = split(token, ":");
-        assert(sample_strings.size() == m.format.size() or assert_msg("sample data does not fit format"));
+        assert(sample_strings.size() == m.format.size()
+            or assert_msg("sample data does not fit format"));
         m.samples.push_back(sample_data);
         m.regt_samples.push_back(regt_sample_data);
         for (uint32_t i = 0; i < m.format.size(); ++i) {
             if (sample_strings[i] != "."
-                and find(float_strings.begin(), float_strings.end(), m.format[i]) == float_strings.end()) {
+                and find(float_strings.begin(), float_strings.end(), m.format[i])
+                    == float_strings.end()) {
                 sample_substrings = split(sample_strings[i], ",");
-                for (const auto &s : sample_substrings)
+                for (const auto& s : sample_substrings)
                     m.samples.back()[m.format[i]].push_back(stoi(s));
             } else if (sample_strings[i] != "."
-                       and find(float_strings.begin(), float_strings.end(), m.format[i]) != float_strings.end()) {
+                and find(float_strings.begin(), float_strings.end(), m.format[i])
+                    != float_strings.end()) {
                 sample_substrings = split(sample_strings[i], ",");
-                for (const auto &s : sample_substrings)
+                for (const auto& s : sample_substrings)
                     m.regt_samples.back()[m.format[i]].push_back(stof(s));
             }
         }
     }
     return in;
 }
-
-

--- a/src/walk_main.cpp
+++ b/src/walk_main.cpp
@@ -1,19 +1,19 @@
-#include <cstring>
-#include <cassert>
-#include <vector>
-#include <iostream>
-#include <fstream>
+#include "fastaq_handler.h"
 #include "localPRG.h"
-#include "utils.h"
 #include "localgraph.h"
 #include "localnode.h"
-#include "fastaq_handler.h"
+#include "utils.h"
+#include <cassert>
+#include <cstring>
+#include <fstream>
+#include <iostream>
+#include <vector>
 
-
-int pandora_walk(int argc, char *argv[]) // the "pandora walk" comand
+int pandora_walk(int argc, char* argv[]) // the "pandora walk" comand
 {
     if (argc != 3) {
-        fprintf(stderr, "Usage: pandora walk <in_prg.fa> [<seq.fa> | --top | --bottom]\n");
+        fprintf(
+            stderr, "Usage: pandora walk <in_prg.fa> [<seq.fa> | --top | --bottom]\n");
         return 1;
     }
 
@@ -24,7 +24,7 @@ int pandora_walk(int argc, char *argv[]) // the "pandora walk" comand
     std::vector<LocalNodePtr> npath;
 
     if (strcmp(argv[2], "--top") == 0) {
-        for (const auto &prg_ptr : prgs) {
+        for (const auto& prg_ptr : prgs) {
             npath = prg_ptr->prg.top_path();
             std::cout << prg_ptr->name << "\t";
             for (uint32_t j = 0; j != npath.size(); ++j) {
@@ -34,7 +34,7 @@ int pandora_walk(int argc, char *argv[]) // the "pandora walk" comand
         }
         return 0;
     } else if (strcmp(argv[2], "--bottom") == 0) {
-        for (const auto &prg_ptr: prgs) {
+        for (const auto& prg_ptr : prgs) {
             npath = prg_ptr->prg.bottom_path();
             std::cout << prg_ptr->name << "\t";
             for (uint32_t j = 0; j != npath.size(); ++j) {
@@ -50,8 +50,9 @@ int pandora_walk(int argc, char *argv[]) // the "pandora walk" comand
     FastaqHandler readfile(argv[2]);
     while (not readfile.eof()) {
         readfile.get_next();
-        //cout << "Try to find gene " << readfile.num_reads_parsed << " " << readfile.name << endl << readfile.read << endl;
-        for (const auto &prg_ptr: prgs) {
+        // cout << "Try to find gene " << readfile.num_reads_parsed << " " <<
+        // readfile.name << endl << readfile.read << endl;
+        for (const auto& prg_ptr : prgs) {
             npath = prg_ptr->prg.nodes_along_string(readfile.read);
             if (not npath.empty()) {
                 std::cout << readfile.name << "\t" << prg_ptr->name << "\t";
@@ -65,4 +66,3 @@ int pandora_walk(int argc, char *argv[]) // the "pandora walk" comand
 
     return 0;
 }
-

--- a/test/de_bruijn_graph_class.h
+++ b/test/de_bruijn_graph_class.h
@@ -1,10 +1,10 @@
 #include "de_bruijn/graph.h"
 #include "de_bruijn/ns.cpp"
 
-
 class GraphTester : public debruijn::Graph {
 public:
-    GraphTester(uint8_t i) : Graph(i) {};
+    GraphTester(uint8_t i)
+        : Graph(i) {};
 
     friend class DeBruijnGraphCreate_Initialize_SetsSizeAndNextId_Test;
 

--- a/test/de_bruijn_graph_test.cpp
+++ b/test/de_bruijn_graph_test.cpp
@@ -1,25 +1,26 @@
-#include <iostream>
 #include <deque>
-#include <unordered_set>
+#include <iostream>
 #include <unordered_map>
+#include <unordered_set>
 
-#include "gtest/gtest.h"
-#include "test_macro.cpp"
 #include "de_bruijn_graph_class.h"
-
+#include "test_macro.cpp"
+#include "gtest/gtest.h"
 
 using namespace debruijn;
 
-TEST(DeBruijnGraphCreate, Initialize_SetsSizeAndNextId) {
+TEST(DeBruijnGraphCreate, Initialize_SetsSizeAndNextId)
+{
     GraphTester g(5);
-    EXPECT_EQ(g.size, (uint) 5);
-    EXPECT_EQ(g.next_id, (uint) 0);
+    EXPECT_EQ(g.size, (uint)5);
+    EXPECT_EQ(g.next_id, (uint)0);
 }
 
-TEST(DeBruijnGraphAddNode, AddNode_NodeHashInIndex) {
+TEST(DeBruijnGraphAddNode, AddNode_NodeHashInIndex)
+{
     GraphTester g(3);
 
-    std::deque<uint_least32_t> v = {4, 6, 8};
+    std::deque<uint_least32_t> v = { 4, 6, 8 };
     uint32_t read_id = 0;
     g.add_node(v, read_id);
 
@@ -27,10 +28,11 @@ TEST(DeBruijnGraphAddNode, AddNode_NodeHashInIndex) {
     EXPECT_TRUE(found);
 }
 
-TEST(DeBruijnGraphAddNode, AddNode_NodeIdInIndex) {
+TEST(DeBruijnGraphAddNode, AddNode_NodeIdInIndex)
+{
     GraphTester g(3);
 
-    std::deque<uint_least32_t> v = {4, 6, 8};
+    std::deque<uint_least32_t> v = { 4, 6, 8 };
     uint32_t read_id = 0;
     g.add_node(v, read_id);
 
@@ -38,12 +40,13 @@ TEST(DeBruijnGraphAddNode, AddNode_NodeIdInIndex) {
     EXPECT_TRUE(found);
 }
 
-TEST(DeBruijnGraphAddNode, AddNode_NodePropertiesCorrect) {
+TEST(DeBruijnGraphAddNode, AddNode_NodePropertiesCorrect)
+{
     GraphTester g(3);
 
-    std::deque<uint_least32_t> v = {4, 6, 8};
+    std::deque<uint_least32_t> v = { 4, 6, 8 };
     uint32_t read_id = 0;
-    std::unordered_multiset<uint32_t> w = {read_id};
+    std::unordered_multiset<uint32_t> w = { read_id };
     g.add_node(v, read_id);
 
     EXPECT_EQ(*g.nodes[0], Node(0, v, 0));
@@ -51,12 +54,13 @@ TEST(DeBruijnGraphAddNode, AddNode_NodePropertiesCorrect) {
     EXPECT_ITERABLE_EQ(std::unordered_multiset<uint32_t>, g.nodes[0]->read_ids, w);
 }
 
-TEST(DeBruijnGraphAddNode, AddNodeTwiceForSameRead_NodeReadsMultisetContainsReadTwice) {
+TEST(DeBruijnGraphAddNode, AddNodeTwiceForSameRead_NodeReadsMultisetContainsReadTwice)
+{
     GraphTester g(3);
 
-    std::deque<uint_least32_t> v = {4, 6, 8};
+    std::deque<uint_least32_t> v = { 4, 6, 8 };
     uint32_t read_id = 0;
-    std::unordered_multiset<uint32_t> w = {read_id, read_id};
+    std::unordered_multiset<uint32_t> w = { read_id, read_id };
     g.add_node(v, read_id);
     g.add_node(v, read_id);
 
@@ -65,13 +69,14 @@ TEST(DeBruijnGraphAddNode, AddNodeTwiceForSameRead_NodeReadsMultisetContainsRead
     EXPECT_ITERABLE_EQ(std::unordered_multiset<uint32_t>, g.nodes[0]->read_ids, w);
 }
 
-TEST(DeBruijnGraphAddNode, AddNodeTwiceForDifferentRead_NodeReadsMultisetContainsReads) {
+TEST(DeBruijnGraphAddNode, AddNodeTwiceForDifferentRead_NodeReadsMultisetContainsReads)
+{
     GraphTester g(3);
 
-    std::deque<uint_least32_t> v = {4, 6, 8};
+    std::deque<uint_least32_t> v = { 4, 6, 8 };
     uint32_t read_id = 0;
     g.add_node(v, read_id);
-    std::unordered_multiset<uint32_t> w = {read_id};
+    std::unordered_multiset<uint32_t> w = { read_id };
     read_id = 7;
     g.add_node(v, read_id);
     w.insert(read_id);
@@ -81,14 +86,15 @@ TEST(DeBruijnGraphAddNode, AddNodeTwiceForDifferentRead_NodeReadsMultisetContain
     EXPECT_ITERABLE_EQ(std::unordered_multiset<uint32_t>, g.nodes[0]->read_ids, w);
 }
 
-TEST(DeBruijnGraphAddNode, AddTwoNodes_SecondNodeInIndex) {
+TEST(DeBruijnGraphAddNode, AddTwoNodes_SecondNodeInIndex)
+{
     GraphTester g(3);
 
-    std::deque<uint_least32_t> v = {4, 6, 8};
+    std::deque<uint_least32_t> v = { 4, 6, 8 };
     uint32_t read_id = 0;
     g.add_node(v, read_id);
 
-    v = {6, 9, 3};
+    v = { 6, 9, 3 };
     read_id = 7;
     g.add_node(v, read_id);
 
@@ -96,170 +102,195 @@ TEST(DeBruijnGraphAddNode, AddTwoNodes_SecondNodeInIndex) {
     EXPECT_TRUE(found);
 }
 
-TEST(DeBruijnGraphAddNode, AddTwoNodes_SecondNodePropertiesCorrect) {
+TEST(DeBruijnGraphAddNode, AddTwoNodes_SecondNodePropertiesCorrect)
+{
     GraphTester g(3);
 
-    std::deque<uint_least32_t> v = {4, 6, 8};
+    std::deque<uint_least32_t> v = { 4, 6, 8 };
     uint32_t read_id = 0;
     g.add_node(v, read_id);
 
-    v = {6, 9, 3};
+    v = { 6, 9, 3 };
     read_id = 7;
     g.add_node(v, read_id);
-    std::unordered_multiset<uint32_t> w = {read_id};
+    std::unordered_multiset<uint32_t> w = { read_id };
 
     EXPECT_EQ(*g.nodes[1], Node(1, v, 7));
     EXPECT_ITERABLE_EQ(std::deque<uint_least32_t>, g.nodes[1]->hashed_node_ids, v);
     EXPECT_ITERABLE_EQ(std::unordered_multiset<uint32_t>, g.nodes[1]->read_ids, w);
 }
 
-TEST(DeBruijnGraphAddEdge, AddEdgeNodesOverlapForwards_EdgeAdded) {
+TEST(DeBruijnGraphAddEdge, AddEdgeNodesOverlapForwards_EdgeAdded)
+{
     GraphTester g(3);
 
-    std::deque<uint_least32_t> v1 = {4, 6, 8};
-    std::deque<uint_least32_t> v2 = {6, 8, 9};
+    std::deque<uint_least32_t> v1 = { 4, 6, 8 };
+    std::deque<uint_least32_t> v2 = { 6, 8, 9 };
     OrientedNodePtr n1 = g.add_node(v1, 0);
     OrientedNodePtr n2 = g.add_node(v2, 0);
     g.add_edge(n1, n2);
 
-    bool found_outnode_n1 = n1.first->out_nodes.find(n2.first->id) != n1.first->out_nodes.end();
-    bool found_innode_n2 = n2.first->in_nodes.find(n1.first->id) != n2.first->in_nodes.end();
-    bool found_innode_n1 = n1.first->in_nodes.find(n2.first->id) != n1.first->in_nodes.end();
-    bool found_outnode_n2 = n2.first->out_nodes.find(n1.first->id) != n2.first->out_nodes.end();
+    bool found_outnode_n1
+        = n1.first->out_nodes.find(n2.first->id) != n1.first->out_nodes.end();
+    bool found_innode_n2
+        = n2.first->in_nodes.find(n1.first->id) != n2.first->in_nodes.end();
+    bool found_innode_n1
+        = n1.first->in_nodes.find(n2.first->id) != n1.first->in_nodes.end();
+    bool found_outnode_n2
+        = n2.first->out_nodes.find(n1.first->id) != n2.first->out_nodes.end();
     EXPECT_TRUE(found_outnode_n1);
     EXPECT_TRUE(found_innode_n2);
     EXPECT_FALSE(found_innode_n1);
     EXPECT_FALSE(found_outnode_n2);
 }
 
-TEST(DeBruijnGraphAddEdge, AddEdgeFirstForwardSecondRC_EdgeAdded) {
+TEST(DeBruijnGraphAddEdge, AddEdgeFirstForwardSecondRC_EdgeAdded)
+{
     GraphTester g(3);
 
-    std::deque<uint_least32_t> v1 = {4, 6, 8};
-    std::deque<uint_least32_t> v3 = {6, 8, 9};
-    std::deque<uint_least32_t> v2 = {8, 9, 7};
+    std::deque<uint_least32_t> v1 = { 4, 6, 8 };
+    std::deque<uint_least32_t> v3 = { 6, 8, 9 };
+    std::deque<uint_least32_t> v2 = { 8, 9, 7 };
     OrientedNodePtr n1 = g.add_node(v1, 0);
     OrientedNodePtr n2 = g.add_node(v2, 0);
     OrientedNodePtr n3 = g.add_node(v3, 0);
     g.add_edge(n1, n3);
 
-    bool found_outnode_n1 = n1.first->out_nodes.find(n3.first->id) != n1.first->out_nodes.end();
-    bool found_innode_n3 = n3.first->in_nodes.find(n1.first->id) != n3.first->in_nodes.end();
-    bool found_innode_n1 = n1.first->in_nodes.find(n3.first->id) != n1.first->in_nodes.end();
-    bool found_outnode_n3 = n3.first->out_nodes.find(n1.first->id) != n3.first->out_nodes.end();
+    bool found_outnode_n1
+        = n1.first->out_nodes.find(n3.first->id) != n1.first->out_nodes.end();
+    bool found_innode_n3
+        = n3.first->in_nodes.find(n1.first->id) != n3.first->in_nodes.end();
+    bool found_innode_n1
+        = n1.first->in_nodes.find(n3.first->id) != n1.first->in_nodes.end();
+    bool found_outnode_n3
+        = n3.first->out_nodes.find(n1.first->id) != n3.first->out_nodes.end();
     EXPECT_TRUE(found_outnode_n1);
     EXPECT_FALSE(found_innode_n3);
     EXPECT_FALSE(found_innode_n1);
     EXPECT_TRUE(found_outnode_n3);
 }
 
-TEST(DeBruijnGraphAddEdge, AddEdgeFirstRCSecondForward_EdgeAdded) {
+TEST(DeBruijnGraphAddEdge, AddEdgeFirstRCSecondForward_EdgeAdded)
+{
     GraphTester g(3);
 
-    std::deque<uint_least32_t> v1 = {9, 7, 5};
-    std::deque<uint_least32_t> v2 = {4, 6, 8};
-    std::deque<uint_least32_t> v3 = {6, 8, 9};
+    std::deque<uint_least32_t> v1 = { 9, 7, 5 };
+    std::deque<uint_least32_t> v2 = { 4, 6, 8 };
+    std::deque<uint_least32_t> v3 = { 6, 8, 9 };
     OrientedNodePtr n1 = g.add_node(v1, 0);
     OrientedNodePtr n2 = g.add_node(v2, 0);
     OrientedNodePtr n3 = g.add_node(v3, 0);
     g.add_edge(n2, n3);
 
-    bool found_outnode_n2 = n2.first->out_nodes.find(n3.first->id) != n2.first->out_nodes.end();
-    bool found_innode_n3 = n3.first->in_nodes.find(n2.first->id) != n3.first->in_nodes.end();
-    bool found_innode_n2 = n2.first->in_nodes.find(n3.first->id) != n2.first->in_nodes.end();
-    bool found_outnode_n3 = n3.first->out_nodes.find(n2.first->id) != n3.first->out_nodes.end();
+    bool found_outnode_n2
+        = n2.first->out_nodes.find(n3.first->id) != n2.first->out_nodes.end();
+    bool found_innode_n3
+        = n3.first->in_nodes.find(n2.first->id) != n3.first->in_nodes.end();
+    bool found_innode_n2
+        = n2.first->in_nodes.find(n3.first->id) != n2.first->in_nodes.end();
+    bool found_outnode_n3
+        = n3.first->out_nodes.find(n2.first->id) != n3.first->out_nodes.end();
     EXPECT_FALSE(found_outnode_n2);
     EXPECT_TRUE(found_innode_n3);
     EXPECT_TRUE(found_innode_n2);
     EXPECT_FALSE(found_outnode_n3);
 }
 
-TEST(DeBruijnGraphAddEdge, AddEdgeNodesBothRC_EdgeAdded) {
+TEST(DeBruijnGraphAddEdge, AddEdgeNodesBothRC_EdgeAdded)
+{
     GraphTester g(3);
 
-    std::deque<uint_least32_t> v1 = {4, 6, 8};
-    std::deque<uint_least32_t> v2 = {6, 8, 9};
-    std::deque<uint_least32_t> v1_ = {9, 7, 5};
-    std::deque<uint_least32_t> v2_ = {8, 9, 7};
+    std::deque<uint_least32_t> v1 = { 4, 6, 8 };
+    std::deque<uint_least32_t> v2 = { 6, 8, 9 };
+    std::deque<uint_least32_t> v1_ = { 9, 7, 5 };
+    std::deque<uint_least32_t> v2_ = { 8, 9, 7 };
     OrientedNodePtr n1 = g.add_node(v1, 0);
     OrientedNodePtr n2 = g.add_node(v2, 0);
     n1 = g.add_node(v1_, 0);
     n2 = g.add_node(v2_, 0);
     g.add_edge(n2, n1);
 
-    bool found_outnode_n1 = n1.first->out_nodes.find(n2.first->id) != n1.first->out_nodes.end();
-    bool found_innode_n2 = n2.first->in_nodes.find(n1.first->id) != n2.first->in_nodes.end();
-    bool found_innode_n1 = n1.first->in_nodes.find(n2.first->id) != n1.first->in_nodes.end();
-    bool found_outnode_n2 = n2.first->out_nodes.find(n1.first->id) != n2.first->out_nodes.end();
+    bool found_outnode_n1
+        = n1.first->out_nodes.find(n2.first->id) != n1.first->out_nodes.end();
+    bool found_innode_n2
+        = n2.first->in_nodes.find(n1.first->id) != n2.first->in_nodes.end();
+    bool found_innode_n1
+        = n1.first->in_nodes.find(n2.first->id) != n1.first->in_nodes.end();
+    bool found_outnode_n2
+        = n2.first->out_nodes.find(n1.first->id) != n2.first->out_nodes.end();
     EXPECT_TRUE(found_outnode_n1);
     EXPECT_TRUE(found_innode_n2);
     EXPECT_FALSE(found_innode_n1);
     EXPECT_FALSE(found_outnode_n2);
 }
 
-TEST(DeBruijnGraphAddEdge, AddEdgeNoOverlap_Death) {
+TEST(DeBruijnGraphAddEdge, AddEdgeNoOverlap_Death)
+{
     GraphTester g(3);
 
-    std::deque<uint_least32_t> v1 = {4, 6, 8};
-    std::deque<uint_least32_t> v2 = {6, 0, 9};
+    std::deque<uint_least32_t> v1 = { 4, 6, 8 };
+    std::deque<uint_least32_t> v2 = { 6, 0, 9 };
     OrientedNodePtr n1 = g.add_node(v1, 0);
     OrientedNodePtr n2 = g.add_node(v2, 0);
     EXPECT_DEATH(g.add_edge(n1, n2), "");
 }
 
-TEST(DeBruijnGraphTest, remove_node) {
+TEST(DeBruijnGraphTest, remove_node)
+{
     GraphTester g(3);
-    std::deque<uint_least32_t> v1 = {4, 6, 8};
-    std::deque<uint_least32_t> v2 = {6, 8, 3};
+    std::deque<uint_least32_t> v1 = { 4, 6, 8 };
+    std::deque<uint_least32_t> v2 = { 6, 8, 3 };
 
     g.add_node(v1, 0);
     OrientedNodePtr n1 = g.add_node(v1, 7);
     OrientedNodePtr n2 = g.add_node(v2, 7);
     g.add_edge(n1, n2);
 
-    EXPECT_EQ(g.nodes.size(), (uint) 2);
+    EXPECT_EQ(g.nodes.size(), (uint)2);
     EXPECT_EQ(*g.nodes[0], Node(0, v1, 7));
     EXPECT_EQ(*g.nodes[1], Node(1, v2, 7));
     EXPECT_ITERABLE_EQ(std::deque<uint_least32_t>, g.nodes[0]->hashed_node_ids, v1);
     EXPECT_ITERABLE_EQ(std::deque<uint_least32_t>, g.nodes[1]->hashed_node_ids, v2);
-    std::unordered_multiset<uint32_t> w1 = {0, 7};
-    std::unordered_multiset<uint32_t> w2 = {7};
+    std::unordered_multiset<uint32_t> w1 = { 0, 7 };
+    std::unordered_multiset<uint32_t> w2 = { 7 };
     EXPECT_ITERABLE_EQ(std::unordered_multiset<uint32_t>, g.nodes[0]->read_ids, w1);
     EXPECT_ITERABLE_EQ(std::unordered_multiset<uint32_t>, g.nodes[1]->read_ids, w2);
-    std::unordered_set<uint32_t> s = {1};
-    std::unordered_set<uint32_t> t = {0};
+    std::unordered_set<uint32_t> s = { 1 };
+    std::unordered_set<uint32_t> t = { 0 };
     EXPECT_ITERABLE_EQ(std::unordered_set<uint32_t>, g.nodes[0]->out_nodes, s);
     EXPECT_ITERABLE_EQ(std::unordered_set<uint32_t>, g.nodes[1]->in_nodes, t);
 
     // remove a node
     g.remove_node(1);
-    EXPECT_EQ(g.nodes.size(), (uint) 1);
+    EXPECT_EQ(g.nodes.size(), (uint)1);
     EXPECT_EQ(*g.nodes[0], Node(0, v1, 7));
     EXPECT_ITERABLE_EQ(std::deque<uint_least32_t>, g.nodes[0]->hashed_node_ids, v1);
     EXPECT_ITERABLE_EQ(std::unordered_multiset<uint32_t>, g.nodes[0]->read_ids, w1);
-    EXPECT_EQ(g.nodes[0]->out_nodes.size(), (uint) 0);
+    EXPECT_EQ(g.nodes[0]->out_nodes.size(), (uint)0);
 }
 
-TEST(DeBruijnGraphAddEdge, AddEdgeTwice_EdgeAddedOnce) {
+TEST(DeBruijnGraphAddEdge, AddEdgeTwice_EdgeAddedOnce)
+{
     GraphTester g(3);
 
-    std::deque<uint_least32_t> v1 = {4, 6, 8};
-    std::deque<uint_least32_t> v2 = {6, 8, 9};
+    std::deque<uint_least32_t> v1 = { 4, 6, 8 };
+    std::deque<uint_least32_t> v2 = { 6, 8, 9 };
     OrientedNodePtr n1 = g.add_node(v1, 0);
     OrientedNodePtr n2 = g.add_node(v2, 0);
     g.add_edge(n1, n2);
 
-    EXPECT_EQ(n1.first->out_nodes.size(), (uint) 1);
-    EXPECT_EQ(n2.first->out_nodes.size(), (uint) 0);
-    EXPECT_EQ(n1.first->in_nodes.size(), (uint) 0);
-    EXPECT_EQ(n2.first->in_nodes.size(), (uint) 1);
+    EXPECT_EQ(n1.first->out_nodes.size(), (uint)1);
+    EXPECT_EQ(n2.first->out_nodes.size(), (uint)0);
+    EXPECT_EQ(n1.first->in_nodes.size(), (uint)0);
+    EXPECT_EQ(n2.first->in_nodes.size(), (uint)1);
 }
 
-TEST(DeBruijnGraphTest, remove_read_from_node) {
+TEST(DeBruijnGraphTest, remove_read_from_node)
+{
     GraphTester g(3);
-    std::deque<uint_least32_t> v1 = {4, 6, 8};
-    std::deque<uint_least32_t> v2 = {6, 8, 3};
-    std::deque<uint_least32_t> v3 = {1, 2, 3};
+    std::deque<uint_least32_t> v1 = { 4, 6, 8 };
+    std::deque<uint_least32_t> v2 = { 6, 8, 3 };
+    std::deque<uint_least32_t> v3 = { 1, 2, 3 };
 
     g.add_node(v1, 0);
     g.add_node(v2, 4);
@@ -268,21 +299,21 @@ TEST(DeBruijnGraphTest, remove_read_from_node) {
     OrientedNodePtr n2 = g.add_node(v2, 7);
     g.add_edge(n1, n2);
 
-    EXPECT_EQ(g.nodes.size(), (uint) 3);
+    EXPECT_EQ(g.nodes.size(), (uint)3);
     EXPECT_EQ(*g.nodes[0], Node(0, v1, 7));
     EXPECT_EQ(*g.nodes[1], Node(1, v2, 7));
     EXPECT_EQ(*g.nodes[2], Node(3, v3, 5));
     EXPECT_ITERABLE_EQ(std::deque<uint_least32_t>, g.nodes[0]->hashed_node_ids, v1);
     EXPECT_ITERABLE_EQ(std::deque<uint_least32_t>, g.nodes[1]->hashed_node_ids, v2);
     EXPECT_ITERABLE_EQ(std::deque<uint_least32_t>, g.nodes[2]->hashed_node_ids, v3);
-    std::unordered_multiset<uint32_t> w1 = {0, 7};
-    std::unordered_multiset<uint32_t> w2 = {4, 7};
-    std::unordered_multiset<uint32_t> w3 = {5};
+    std::unordered_multiset<uint32_t> w1 = { 0, 7 };
+    std::unordered_multiset<uint32_t> w2 = { 4, 7 };
+    std::unordered_multiset<uint32_t> w3 = { 5 };
     EXPECT_ITERABLE_EQ(std::unordered_multiset<uint32_t>, g.nodes[0]->read_ids, w1);
     EXPECT_ITERABLE_EQ(std::unordered_multiset<uint32_t>, g.nodes[1]->read_ids, w2);
     EXPECT_ITERABLE_EQ(std::unordered_multiset<uint32_t>, g.nodes[2]->read_ids, w3);
-    std::unordered_set<uint32_t> s = {1};
-    std::unordered_set<uint32_t> t = {0};
+    std::unordered_set<uint32_t> s = { 1 };
+    std::unordered_set<uint32_t> t = { 0 };
     std::unordered_set<uint32_t> u;
     EXPECT_ITERABLE_EQ(std::unordered_set<uint32_t>, g.nodes[0]->out_nodes, s);
     EXPECT_ITERABLE_EQ(std::unordered_set<uint32_t>, g.nodes[0]->in_nodes, u);
@@ -291,10 +322,9 @@ TEST(DeBruijnGraphTest, remove_read_from_node) {
     EXPECT_ITERABLE_EQ(std::unordered_set<uint32_t>, g.nodes[2]->out_nodes, u);
     EXPECT_ITERABLE_EQ(std::unordered_set<uint32_t>, g.nodes[2]->in_nodes, u);
 
-
     // remove a read which doesn't exist - nothing should happen
     g.remove_read_from_node(1, 0);
-    EXPECT_EQ(g.nodes.size(), (uint) 3);
+    EXPECT_EQ(g.nodes.size(), (uint)3);
     EXPECT_EQ(*g.nodes[0], Node(0, v1, 7));
     EXPECT_EQ(*g.nodes[1], Node(1, v2, 7));
     EXPECT_EQ(*g.nodes[2], Node(3, v3, 5));
@@ -313,7 +343,7 @@ TEST(DeBruijnGraphTest, remove_read_from_node) {
 
     // remove a read from a node which doesn't exist - nothing should happen
     g.remove_read_from_node(0, 3);
-    EXPECT_EQ(g.nodes.size(), (uint) 3);
+    EXPECT_EQ(g.nodes.size(), (uint)3);
     EXPECT_EQ(*g.nodes[0], Node(0, v1, 7));
     EXPECT_EQ(*g.nodes[1], Node(1, v2, 7));
     EXPECT_EQ(*g.nodes[2], Node(3, v3, 5));
@@ -332,14 +362,14 @@ TEST(DeBruijnGraphTest, remove_read_from_node) {
 
     // remove read from a node where should just change the read id list for node
     g.remove_read_from_node(7, 1);
-    EXPECT_EQ(g.nodes.size(), (uint) 3);
+    EXPECT_EQ(g.nodes.size(), (uint)3);
     EXPECT_EQ(*g.nodes[0], Node(0, v1, 7));
     EXPECT_EQ(*g.nodes[1], Node(1, v2, 7));
     EXPECT_EQ(*g.nodes[2], Node(3, v3, 5));
     EXPECT_ITERABLE_EQ(std::deque<uint_least32_t>, g.nodes[0]->hashed_node_ids, v1);
     EXPECT_ITERABLE_EQ(std::deque<uint_least32_t>, g.nodes[1]->hashed_node_ids, v2);
     EXPECT_ITERABLE_EQ(std::deque<uint_least32_t>, g.nodes[2]->hashed_node_ids, v3);
-    w2 = {4};
+    w2 = { 4 };
     EXPECT_ITERABLE_EQ(std::unordered_multiset<uint32_t>, g.nodes[0]->read_ids, w1);
     EXPECT_ITERABLE_EQ(std::unordered_multiset<uint32_t>, g.nodes[1]->read_ids, w2);
     EXPECT_ITERABLE_EQ(std::unordered_multiset<uint32_t>, g.nodes[2]->read_ids, w3);
@@ -352,7 +382,7 @@ TEST(DeBruijnGraphTest, remove_read_from_node) {
 
     // remove read from a node where should result in node being removed
     g.remove_read_from_node(5, 2);
-    EXPECT_EQ(g.nodes.size(), (uint) 2);
+    EXPECT_EQ(g.nodes.size(), (uint)2);
     EXPECT_EQ(*g.nodes[0], Node(0, v1, 7));
     EXPECT_EQ(*g.nodes[1], Node(1, v2, 7));
     EXPECT_ITERABLE_EQ(std::deque<uint_least32_t>, g.nodes[0]->hashed_node_ids, v1);
@@ -366,12 +396,12 @@ TEST(DeBruijnGraphTest, remove_read_from_node) {
 
     // continue removing reads until graph empty
     g.remove_read_from_node(0, 0);
-    EXPECT_EQ(g.nodes.size(), (uint) 2);
+    EXPECT_EQ(g.nodes.size(), (uint)2);
     EXPECT_EQ(*g.nodes[0], Node(0, v1, 7));
     EXPECT_EQ(*g.nodes[1], Node(1, v2, 7));
     EXPECT_ITERABLE_EQ(std::deque<uint_least32_t>, g.nodes[0]->hashed_node_ids, v1);
     EXPECT_ITERABLE_EQ(std::deque<uint_least32_t>, g.nodes[1]->hashed_node_ids, v2);
-    w1 = {7};
+    w1 = { 7 };
     EXPECT_ITERABLE_EQ(std::unordered_multiset<uint32_t>, g.nodes[0]->read_ids, w1);
     EXPECT_ITERABLE_EQ(std::unordered_multiset<uint32_t>, g.nodes[1]->read_ids, w2);
     EXPECT_ITERABLE_EQ(std::unordered_set<uint32_t>, g.nodes[0]->out_nodes, u);
@@ -380,7 +410,7 @@ TEST(DeBruijnGraphTest, remove_read_from_node) {
     EXPECT_ITERABLE_EQ(std::unordered_set<uint32_t>, g.nodes[1]->in_nodes, u);
 
     g.remove_read_from_node(4, 1);
-    EXPECT_EQ(g.nodes.size(), (uint) 1);
+    EXPECT_EQ(g.nodes.size(), (uint)1);
     EXPECT_EQ(*g.nodes[0], Node(0, v1, 7));
     EXPECT_ITERABLE_EQ(std::deque<uint_least32_t>, g.nodes[0]->hashed_node_ids, v1);
     EXPECT_ITERABLE_EQ(std::unordered_multiset<uint32_t>, g.nodes[0]->read_ids, w1);
@@ -388,18 +418,18 @@ TEST(DeBruijnGraphTest, remove_read_from_node) {
     EXPECT_ITERABLE_EQ(std::unordered_set<uint32_t>, g.nodes[0]->in_nodes, u);
 
     g.remove_read_from_node(7, 0);
-    EXPECT_EQ(g.nodes.size(), (uint) 0);
+    EXPECT_EQ(g.nodes.size(), (uint)0);
 }
 
-
-TEST(DeBruijnGraphTest, get_leaves) {
+TEST(DeBruijnGraphTest, get_leaves)
+{
     GraphTester g(3);
 
-    std::deque<uint_least32_t> v1 = {4, 1, 8};
-    std::deque<uint_least32_t> v2 = {1, 8, 9};
-    std::deque<uint_least32_t> v3 = {1, 8, 2};
-    std::deque<uint_least32_t> v4 = {8, 2, 4};
-    std::deque<uint_least32_t> v5 = {2, 4, 3};
+    std::deque<uint_least32_t> v1 = { 4, 1, 8 };
+    std::deque<uint_least32_t> v2 = { 1, 8, 9 };
+    std::deque<uint_least32_t> v3 = { 1, 8, 2 };
+    std::deque<uint_least32_t> v4 = { 8, 2, 4 };
+    std::deque<uint_least32_t> v5 = { 2, 4, 3 };
 
     OrientedNodePtr n1 = g.add_node(v1, 0);
     OrientedNodePtr n2 = g.add_node(v2, 0);
@@ -411,83 +441,85 @@ TEST(DeBruijnGraphTest, get_leaves) {
     OrientedNodePtr n5 = g.add_node(v5, 5);
 
     std::unordered_set<uint32_t> l = g.get_leaves();
-    std::unordered_set<uint32_t> l_exp = {1, 3, 4};
-    for (const auto &i : l_exp) {
+    std::unordered_set<uint32_t> l_exp = { 1, 3, 4 };
+    for (const auto& i : l_exp) {
         EXPECT_EQ(l.find(i) != l.end(), true);
     }
-    //EXPECT_ITERABLE_EQ(std::unordered_set<uint_least32_t>, l, l_exp);
+    // EXPECT_ITERABLE_EQ(std::unordered_set<uint_least32_t>, l, l_exp);
 }
 
-TEST(DeBruijnGraphTest, get_leaves2) {
+TEST(DeBruijnGraphTest, get_leaves2)
+{
     Graph dbg_exp(3);
-    std::deque<uint_least32_t> d = {0, 2, 4}; //0
+    std::deque<uint_least32_t> d = { 0, 2, 4 }; // 0
     OrientedNodePtr n1 = dbg_exp.add_node(d, 0);
-    d = {2, 4, 6};//1
+    d = { 2, 4, 6 }; // 1
     OrientedNodePtr n2 = dbg_exp.add_node(d, 0);
     dbg_exp.add_edge(n1, n2);
-    d = {4, 6, 8};//2
+    d = { 4, 6, 8 }; // 2
     n1 = dbg_exp.add_node(d, 0);
     dbg_exp.add_edge(n2, n1);
-    d = {6, 8, 10};//3
+    d = { 6, 8, 10 }; // 3
     n2 = dbg_exp.add_node(d, 0);
     dbg_exp.add_edge(n1, n2);
 
-    d = {6, 8, 10};//3
+    d = { 6, 8, 10 }; // 3
     n2 = dbg_exp.add_node(d, 1);
-    d = {8, 10, 0};//4
+    d = { 8, 10, 0 }; // 4
     n1 = dbg_exp.add_node(d, 1);
     dbg_exp.add_edge(n2, n1);
-    d = {10, 0, 2};//5
+    d = { 10, 0, 2 }; // 5
     n2 = dbg_exp.add_node(d, 1);
     dbg_exp.add_edge(n1, n2);
-    d = {0, 2, 4};//0
+    d = { 0, 2, 4 }; // 0
     n1 = dbg_exp.add_node(d, 1);
     dbg_exp.add_edge(n2, n1);
 
-    d = {2, 4, 6};//1
+    d = { 2, 4, 6 }; // 1
     n1 = dbg_exp.add_node(d, 2);
-    d = {4, 6, 14};//6
+    d = { 4, 6, 14 }; // 6
     n2 = dbg_exp.add_node(d, 2);
     dbg_exp.add_edge(n1, n2);
 
-    d = {0, 12, 6};//7
+    d = { 0, 12, 6 }; // 7
     n1 = dbg_exp.add_node(d, 3);
-    d = {12, 6, 8};//8
+    d = { 12, 6, 8 }; // 8
     n2 = dbg_exp.add_node(d, 3);
     dbg_exp.add_edge(n1, n2);
 
-    d = {0, 2, 4};//0
+    d = { 0, 2, 4 }; // 0
     n1 = dbg_exp.add_node(d, 4);
-    d = {2, 4, 12};//9
+    d = { 2, 4, 12 }; // 9
     n2 = dbg_exp.add_node(d, 4);
     dbg_exp.add_edge(n1, n2);
-    d = {4, 12, 6};//10
+    d = { 4, 12, 6 }; // 10
     n1 = dbg_exp.add_node(d, 4);
     dbg_exp.add_edge(n2, n1);
-    d = {12, 6, 8};//8
+    d = { 12, 6, 8 }; // 8
     n2 = dbg_exp.add_node(d, 4);
     dbg_exp.add_edge(n1, n2);
-    d = {6, 8, 10};//3
+    d = { 6, 8, 10 }; // 3
     n1 = dbg_exp.add_node(d, 4);
     dbg_exp.add_edge(n2, n1);
 
-    d = {12, 2, 4};//11
+    d = { 12, 2, 4 }; // 11
     n1 = dbg_exp.add_node(d, 5);
-    d = {2, 4, 12};//9
+    d = { 2, 4, 12 }; // 9
     n2 = dbg_exp.add_node(d, 5);
     dbg_exp.add_edge(n1, n2);
-    d = {4, 12, 6};//10
+    d = { 4, 12, 6 }; // 10
     n1 = dbg_exp.add_node(d, 5);
     dbg_exp.add_edge(n2, n1);
 
     std::unordered_set<uint32_t> l = dbg_exp.get_leaves();
-    std::unordered_set<uint32_t> l_exp = {6, 7, 11};
-    for (const auto &i : l_exp) {
+    std::unordered_set<uint32_t> l_exp = { 6, 7, 11 };
+    for (const auto& i : l_exp) {
         EXPECT_EQ(l.find(i) != l.end(), true);
     }
 }
 
-TEST(DeBruijnGraphGetUnitigs, OneBubble_ThreeTigs) {
+TEST(DeBruijnGraphGetUnitigs, OneBubble_ThreeTigs)
+{
     // 0 -> 1 -> 2 ------> 3 -> 4 -> 5 -> 0
     //             \> 6 -/
 
@@ -496,11 +528,11 @@ TEST(DeBruijnGraphGetUnitigs, OneBubble_ThreeTigs) {
 
     GraphTester g(3);
 
-    std::deque<uint_least32_t> v1 = {0, 2, 4};
-    std::deque<uint_least32_t> v2 = {2, 4, 6};
-    std::deque<uint_least32_t> v3 = {4, 6, 8};
-    std::deque<uint_least32_t> v4 = {6, 8, 10};
-    std::deque<uint_least32_t> v5 = {8, 10, 0};
+    std::deque<uint_least32_t> v1 = { 0, 2, 4 };
+    std::deque<uint_least32_t> v2 = { 2, 4, 6 };
+    std::deque<uint_least32_t> v3 = { 4, 6, 8 };
+    std::deque<uint_least32_t> v4 = { 6, 8, 10 };
+    std::deque<uint_least32_t> v5 = { 8, 10, 0 };
 
     OrientedNodePtr n0 = g.add_node(v1, 0);
     OrientedNodePtr n1 = g.add_node(v2, 0);
@@ -512,9 +544,9 @@ TEST(DeBruijnGraphGetUnitigs, OneBubble_ThreeTigs) {
     OrientedNodePtr n4 = g.add_node(v5, 0);
     g.add_edge(n3, n4);
 
-    std::deque<uint_least32_t> v6 = {2, 4, 12};
-    std::deque<uint_least32_t> v7 = {4, 12, 6};
-    std::deque<uint_least32_t> v8 = {12, 6, 8};
+    std::deque<uint_least32_t> v6 = { 2, 4, 12 };
+    std::deque<uint_least32_t> v7 = { 4, 12, 6 };
+    std::deque<uint_least32_t> v8 = { 12, 6, 8 };
 
     n0 = g.add_node(v1, 1);
     n1 = g.add_node(v6, 1);
@@ -527,31 +559,32 @@ TEST(DeBruijnGraphGetUnitigs, OneBubble_ThreeTigs) {
     g.add_edge(n3, n4);
 
     std::set<std::deque<uint32_t>> s = g.get_unitigs();
-    EXPECT_EQ(s.size(), (uint) 3);
+    EXPECT_EQ(s.size(), (uint)3);
 
     std::set<std::deque<uint32_t>> s_exp;
-    std::deque<uint32_t> d = {0, 1, 2, 3};
+    std::deque<uint32_t> d = { 0, 1, 2, 3 };
     s_exp.insert(d);
-    d = {0, 5, 6, 7, 3};
+    d = { 0, 5, 6, 7, 3 };
     s_exp.insert(d);
-    d = {3, 4};
+    d = { 3, 4 };
     s_exp.insert(d);
 
     EXPECT_ITERABLE_EQ(std::set<std::deque<uint32_t>>, s, s_exp);
 }
 
-TEST(DeBruijnGraphTest, get_unitigs) {
+TEST(DeBruijnGraphTest, get_unitigs)
+{
     // 0 -> 1
     //   \> 2 -> 3
     // 4
 
     GraphTester g(3);
 
-    std::deque<uint_least32_t> v1 = {4, 6, 8};
-    std::deque<uint_least32_t> v2 = {6, 8, 9};
-    std::deque<uint_least32_t> v3 = {6, 8, 2};
-    std::deque<uint_least32_t> v4 = {8, 2, 3};
-    std::deque<uint_least32_t> v5 = {5, 9, 3};
+    std::deque<uint_least32_t> v1 = { 4, 6, 8 };
+    std::deque<uint_least32_t> v2 = { 6, 8, 9 };
+    std::deque<uint_least32_t> v3 = { 6, 8, 2 };
+    std::deque<uint_least32_t> v4 = { 8, 2, 3 };
+    std::deque<uint_least32_t> v5 = { 5, 9, 3 };
 
     OrientedNodePtr n0 = g.add_node(v1, 0);
     OrientedNodePtr n1 = g.add_node(v2, 0);
@@ -562,41 +595,41 @@ TEST(DeBruijnGraphTest, get_unitigs) {
     g.add_edge(n2, n3);
     OrientedNodePtr n4 = g.add_node(v5, 5);
 
-    EXPECT_EQ(g.nodes.size(), (uint) 5);
-    EXPECT_EQ(g.nodes[0]->out_nodes.size(), (uint) 2);
-    EXPECT_EQ(g.nodes[0]->in_nodes.size(), (uint) 0);
-    EXPECT_EQ(g.nodes[1]->out_nodes.size(), (uint) 0);
-    EXPECT_EQ(g.nodes[1]->in_nodes.size(), (uint) 1);
-    EXPECT_EQ(g.nodes[2]->out_nodes.size(), (uint) 1);
-    EXPECT_EQ(g.nodes[2]->in_nodes.size(), (uint) 1);
-    EXPECT_EQ(g.nodes[3]->out_nodes.size(), (uint) 0);
-    EXPECT_EQ(g.nodes[3]->in_nodes.size(), (uint) 1);
-    EXPECT_EQ(g.nodes[4]->out_nodes.size(), (uint) 0);
-    EXPECT_EQ(g.nodes[4]->in_nodes.size(), (uint) 0);
-
+    EXPECT_EQ(g.nodes.size(), (uint)5);
+    EXPECT_EQ(g.nodes[0]->out_nodes.size(), (uint)2);
+    EXPECT_EQ(g.nodes[0]->in_nodes.size(), (uint)0);
+    EXPECT_EQ(g.nodes[1]->out_nodes.size(), (uint)0);
+    EXPECT_EQ(g.nodes[1]->in_nodes.size(), (uint)1);
+    EXPECT_EQ(g.nodes[2]->out_nodes.size(), (uint)1);
+    EXPECT_EQ(g.nodes[2]->in_nodes.size(), (uint)1);
+    EXPECT_EQ(g.nodes[3]->out_nodes.size(), (uint)0);
+    EXPECT_EQ(g.nodes[3]->in_nodes.size(), (uint)1);
+    EXPECT_EQ(g.nodes[4]->out_nodes.size(), (uint)0);
+    EXPECT_EQ(g.nodes[4]->in_nodes.size(), (uint)0);
 
     std::set<std::deque<uint32_t>> s = g.get_unitigs();
-    std::deque<uint32_t> d1 = {0, 2, 3};
-    std::deque<uint32_t> d2 = {0, 1};
-    std::set<std::deque<uint32_t>> s_exp = {d1, d2};
-    d1 = {4};
+    std::deque<uint32_t> d1 = { 0, 2, 3 };
+    std::deque<uint32_t> d2 = { 0, 1 };
+    std::set<std::deque<uint32_t>> s_exp = { d1, d2 };
+    d1 = { 4 };
     s_exp.insert(d1);
     EXPECT_EQ(s.size(), s_exp.size());
     EXPECT_ITERABLE_EQ(std::set<std::deque<uint32_t>>, s, s_exp);
 }
 
-TEST(DeBruijnGraphTest, extend_unitig) {
+TEST(DeBruijnGraphTest, extend_unitig)
+{
     // 0 -> 1
     //   \> 2 -> 3
     // 4
 
     GraphTester g(3);
 
-    std::deque<uint_least32_t> v1 = {4, 6, 8};
-    std::deque<uint_least32_t> v2 = {6, 8, 9};
-    std::deque<uint_least32_t> v3 = {6, 8, 2};
-    std::deque<uint_least32_t> v4 = {8, 2, 3};
-    std::deque<uint_least32_t> v5 = {5, 9, 3};
+    std::deque<uint_least32_t> v1 = { 4, 6, 8 };
+    std::deque<uint_least32_t> v2 = { 6, 8, 9 };
+    std::deque<uint_least32_t> v3 = { 6, 8, 2 };
+    std::deque<uint_least32_t> v4 = { 8, 2, 3 };
+    std::deque<uint_least32_t> v5 = { 5, 9, 3 };
 
     OrientedNodePtr n1 = g.add_node(v1, 0);
     OrientedNodePtr n2 = g.add_node(v2, 0);
@@ -607,51 +640,51 @@ TEST(DeBruijnGraphTest, extend_unitig) {
     g.add_edge(n3, n4);
     OrientedNodePtr n5 = g.add_node(v5, 5);
 
-    EXPECT_EQ(g.nodes.size(), (uint) 5);
-    EXPECT_EQ(g.nodes[0]->out_nodes.size(), (uint) 2);
-    EXPECT_EQ(g.nodes[0]->in_nodes.size(), (uint) 0);
-    EXPECT_EQ(g.nodes[1]->out_nodes.size(), (uint) 0);
-    EXPECT_EQ(g.nodes[1]->in_nodes.size(), (uint) 1);
-    EXPECT_EQ(g.nodes[2]->out_nodes.size(), (uint) 1);
-    EXPECT_EQ(g.nodes[2]->in_nodes.size(), (uint) 1);
-    EXPECT_EQ(g.nodes[3]->out_nodes.size(), (uint) 0);
-    EXPECT_EQ(g.nodes[3]->in_nodes.size(), (uint) 1);
-    EXPECT_EQ(g.nodes[4]->out_nodes.size(), (uint) 0);
-    EXPECT_EQ(g.nodes[4]->in_nodes.size(), (uint) 0);
+    EXPECT_EQ(g.nodes.size(), (uint)5);
+    EXPECT_EQ(g.nodes[0]->out_nodes.size(), (uint)2);
+    EXPECT_EQ(g.nodes[0]->in_nodes.size(), (uint)0);
+    EXPECT_EQ(g.nodes[1]->out_nodes.size(), (uint)0);
+    EXPECT_EQ(g.nodes[1]->in_nodes.size(), (uint)1);
+    EXPECT_EQ(g.nodes[2]->out_nodes.size(), (uint)1);
+    EXPECT_EQ(g.nodes[2]->in_nodes.size(), (uint)1);
+    EXPECT_EQ(g.nodes[3]->out_nodes.size(), (uint)0);
+    EXPECT_EQ(g.nodes[3]->in_nodes.size(), (uint)1);
+    EXPECT_EQ(g.nodes[4]->out_nodes.size(), (uint)0);
+    EXPECT_EQ(g.nodes[4]->in_nodes.size(), (uint)0);
 
-    std::deque<uint32_t> d = {0};
+    std::deque<uint32_t> d = { 0 };
     g.extend_unitig(d);
-    std::deque<uint32_t> d_exp = {0};
+    std::deque<uint32_t> d_exp = { 0 };
     EXPECT_ITERABLE_EQ(std::deque<uint32_t>, d, d_exp);
 
-    d = {1};
+    d = { 1 };
     g.extend_unitig(d);
-    d_exp = {0, 1};
+    d_exp = { 0, 1 };
     EXPECT_ITERABLE_EQ(std::deque<uint32_t>, d, d_exp);
 
-    d = {2};
-    d_exp = {0, 2, 3};
-    g.extend_unitig(d);
-    EXPECT_ITERABLE_EQ(std::deque<uint32_t>, d, d_exp);
-
-    d = {3};
+    d = { 2 };
+    d_exp = { 0, 2, 3 };
     g.extend_unitig(d);
     EXPECT_ITERABLE_EQ(std::deque<uint32_t>, d, d_exp);
 
-    d = {4};
+    d = { 3 };
     g.extend_unitig(d);
-    d_exp = {4};
+    EXPECT_ITERABLE_EQ(std::deque<uint32_t>, d, d_exp);
+
+    d = { 4 };
+    g.extend_unitig(d);
+    d_exp = { 4 };
     EXPECT_ITERABLE_EQ(std::deque<uint32_t>, d, d_exp);
 
     // and check doesn't break if there is a cycle
     g.nodes.clear();
     g.next_id = 0;
-    v1 = {0, 1, 2};
-    v2 = {1, 2, 3};
-    v3 = {2, 3, 4};
-    v4 = {3, 4, 5};
-    v5 = {4, 5, 0};
-    std::deque<uint_least32_t> v6 = {5, 0, 1};
+    v1 = { 0, 1, 2 };
+    v2 = { 1, 2, 3 };
+    v3 = { 2, 3, 4 };
+    v4 = { 3, 4, 5 };
+    v5 = { 4, 5, 0 };
+    std::deque<uint_least32_t> v6 = { 5, 0, 1 };
 
     n1 = g.add_node(v1, 0);
     n2 = g.add_node(v2, 0);
@@ -666,35 +699,35 @@ TEST(DeBruijnGraphTest, extend_unitig) {
     g.add_edge(n5, n6);
     g.add_edge(n6, n1);
 
-    EXPECT_EQ(g.nodes.size(), (uint) 6);
-    EXPECT_EQ(g.nodes[0]->out_nodes.size(), (uint) 1);
-    EXPECT_EQ(g.nodes[0]->in_nodes.size(), (uint) 1);
-    EXPECT_EQ(g.nodes[1]->out_nodes.size(), (uint) 1);
-    EXPECT_EQ(g.nodes[1]->in_nodes.size(), (uint) 1);
-    EXPECT_EQ(g.nodes[2]->out_nodes.size(), (uint) 1);
-    EXPECT_EQ(g.nodes[2]->in_nodes.size(), (uint) 1);
-    EXPECT_EQ(g.nodes[3]->out_nodes.size(), (uint) 1);
-    EXPECT_EQ(g.nodes[3]->in_nodes.size(), (uint) 1);
-    EXPECT_EQ(g.nodes[4]->out_nodes.size(), (uint) 1);
-    EXPECT_EQ(g.nodes[4]->in_nodes.size(), (uint) 1);
-    EXPECT_EQ(g.nodes[5]->out_nodes.size(), (uint) 1);
-    EXPECT_EQ(g.nodes[5]->in_nodes.size(), (uint) 1);
+    EXPECT_EQ(g.nodes.size(), (uint)6);
+    EXPECT_EQ(g.nodes[0]->out_nodes.size(), (uint)1);
+    EXPECT_EQ(g.nodes[0]->in_nodes.size(), (uint)1);
+    EXPECT_EQ(g.nodes[1]->out_nodes.size(), (uint)1);
+    EXPECT_EQ(g.nodes[1]->in_nodes.size(), (uint)1);
+    EXPECT_EQ(g.nodes[2]->out_nodes.size(), (uint)1);
+    EXPECT_EQ(g.nodes[2]->in_nodes.size(), (uint)1);
+    EXPECT_EQ(g.nodes[3]->out_nodes.size(), (uint)1);
+    EXPECT_EQ(g.nodes[3]->in_nodes.size(), (uint)1);
+    EXPECT_EQ(g.nodes[4]->out_nodes.size(), (uint)1);
+    EXPECT_EQ(g.nodes[4]->in_nodes.size(), (uint)1);
+    EXPECT_EQ(g.nodes[5]->out_nodes.size(), (uint)1);
+    EXPECT_EQ(g.nodes[5]->in_nodes.size(), (uint)1);
 
-    d = {1};
+    d = { 1 };
     g.extend_unitig(d);
-    d_exp = {1, 2, 3, 4, 5, 0};
+    d_exp = { 1, 2, 3, 4, 5, 0 };
     EXPECT_ITERABLE_EQ(std::deque<uint32_t>, d, d_exp);
 }
 
-
-TEST(DeBruijnGraphTest, equals) {
+TEST(DeBruijnGraphTest, equals)
+{
     GraphTester g1(3);
 
-    std::deque<uint_least32_t> v1 = {4, 6, 8};
-    std::deque<uint_least32_t> v2 = {6, 8, 9};
-    std::deque<uint_least32_t> v3 = {6, 8, 2};
-    std::deque<uint_least32_t> v4 = {8, 2, 3};
-    std::deque<uint_least32_t> v5 = {5, 6, 8};
+    std::deque<uint_least32_t> v1 = { 4, 6, 8 };
+    std::deque<uint_least32_t> v2 = { 6, 8, 9 };
+    std::deque<uint_least32_t> v3 = { 6, 8, 2 };
+    std::deque<uint_least32_t> v4 = { 8, 2, 3 };
+    std::deque<uint_least32_t> v5 = { 5, 6, 8 };
 
     OrientedNodePtr n1 = g1.add_node(v1, 0);
     OrientedNodePtr n2 = g1.add_node(v2, 0);
@@ -728,7 +761,7 @@ TEST(DeBruijnGraphTest, equals) {
     EXPECT_EQ(g2, g1);
 
     // an extra node does matter
-    std::deque<uint_least32_t> v6 = {0, 0, 3};
+    std::deque<uint_least32_t> v6 = { 0, 0, 3 };
     OrientedNodePtr m6 = g2.add_node(v6, 0);
 
     EXPECT_NE(g1, g2);

--- a/test/de_bruijn_node_test.cpp
+++ b/test/de_bruijn_node_test.cpp
@@ -1,33 +1,33 @@
-#include "gtest/gtest.h"
-#include "test_macro.cpp"
 #include "de_bruijn/node.h"
-#include <iostream>
+#include "test_macro.cpp"
+#include "gtest/gtest.h"
 #include <deque>
+#include <iostream>
 #include <unordered_set>
-
 
 using namespace debruijn;
 
-TEST(DeBruijnNodeTest, create) {
-    std::deque<uint_least32_t> v({4, 6, 8});
-    std::unordered_multiset<uint32_t> w({0});
+TEST(DeBruijnNodeTest, create)
+{
+    std::deque<uint_least32_t> v({ 4, 6, 8 });
+    std::unordered_multiset<uint32_t> w({ 0 });
     Node n(2, v, 0);
-    EXPECT_EQ(n.id, (uint) 2);
+    EXPECT_EQ(n.id, (uint)2);
     EXPECT_ITERABLE_EQ(std::deque<uint_least32_t>, n.hashed_node_ids, v);
     EXPECT_ITERABLE_EQ(std::unordered_multiset<uint32_t>, n.read_ids, w);
 }
 
-TEST(DeBruijnNodeTest, equals) {
-    std::deque<uint_least32_t> v({4, 7, 8});
-    std::deque<uint_least32_t> w({4, 6, 8});
-    std::deque<uint_least32_t> y({9, 6, 5});
+TEST(DeBruijnNodeTest, equals)
+{
+    std::deque<uint_least32_t> v({ 4, 7, 8 });
+    std::deque<uint_least32_t> w({ 4, 6, 8 });
+    std::deque<uint_least32_t> y({ 9, 6, 5 });
 
     Node n1(2, v, 0);
     Node n2(2, v, 5);
     Node n3(3, v, 0);
     Node n4(2, w, 0);
     Node n5(2, y, 0);
-
 
     EXPECT_EQ(n1, n1);
     EXPECT_EQ(n2, n2);
@@ -48,7 +48,6 @@ TEST(DeBruijnNodeTest, equals) {
     EXPECT_EQ(n5, n2);
     EXPECT_EQ(n5, n3);
 
-
     EXPECT_NE(n1, n4);
     EXPECT_NE(n4, n1);
     EXPECT_NE(n2, n4);
@@ -58,4 +57,3 @@ TEST(DeBruijnNodeTest, equals) {
     EXPECT_NE(n5, n4);
     EXPECT_NE(n4, n5);
 }
-

--- a/test/denovo_discovery/denovo_utils_test.cpp
+++ b/test/denovo_discovery/denovo_utils_test.cpp
@@ -1,18 +1,17 @@
-#include <iostream>
-#include <sstream>
-#include <set>
-#include "gtest/gtest.h"
 #include "../test_macro.cpp"
 #include "denovo_discovery/denovo_utils.h"
 #include "minihit.h"
 #include "pangenome/panread.h"
-
+#include "gtest/gtest.h"
+#include <iostream>
+#include <set>
+#include <sstream>
 
 using PanNodePtr = std::shared_ptr<pangenome::Node>;
 using PanReadPtr = std::shared_ptr<pangenome::Read>;
 
-
-TEST(PathComponentsEqivalenceOperatorTest, twoEqualPathComponentsReturnsTrue) {
+TEST(PathComponentsEqivalenceOperatorTest, twoEqualPathComponentsReturnsTrue)
+{
     prg::Path flank_left;
     flank_left.initialize(Interval(0, 2));
     prg::Path slice;
@@ -25,8 +24,8 @@ TEST(PathComponentsEqivalenceOperatorTest, twoEqualPathComponentsReturnsTrue) {
     EXPECT_TRUE(x == y);
 }
 
-
-TEST(PathComponentsEqivalenceOperatorTest, twoDifferentPathComponentsReturnsFalse) {
+TEST(PathComponentsEqivalenceOperatorTest, twoDifferentPathComponentsReturnsFalse)
+{
     prg::Path flank_left_x;
     flank_left_x.initialize(Interval(0, 1));
     prg::Path flank_left_y;
@@ -41,8 +40,8 @@ TEST(PathComponentsEqivalenceOperatorTest, twoDifferentPathComponentsReturnsFals
     EXPECT_FALSE(x == y);
 }
 
-
-TEST(PathComponentsNonEqivalenceOperatorTest, twoEqualPathComponentsReturnsFalse) {
+TEST(PathComponentsNonEqivalenceOperatorTest, twoEqualPathComponentsReturnsFalse)
+{
     prg::Path flank_left;
     flank_left.initialize(Interval(0, 2));
     prg::Path slice;
@@ -55,8 +54,8 @@ TEST(PathComponentsNonEqivalenceOperatorTest, twoEqualPathComponentsReturnsFalse
     EXPECT_FALSE(x != y);
 }
 
-
-TEST(PathComponentsNonEqivalenceOperatorTest, twoDifferentPathComponentsReturnsTrue) {
+TEST(PathComponentsNonEqivalenceOperatorTest, twoDifferentPathComponentsReturnsTrue)
+{
     prg::Path flank_left_x;
     flank_left_x.initialize(Interval(0, 1));
     prg::Path flank_left_y;
@@ -71,47 +70,55 @@ TEST(PathComponentsNonEqivalenceOperatorTest, twoDifferentPathComponentsReturnsT
     EXPECT_TRUE(x != y);
 }
 
-
-TEST(FindIntervalInLocalPathTest, emptyIntervalReturnsEmptyResult) {
+TEST(FindIntervalInLocalPathTest, emptyIntervalReturnsEmptyResult)
+{
     const Interval interval;
     LocalPRG local_prg { 0, "test", "A" };
-    const std::vector<LocalNodePtr> local_node_max_likelihood_path { local_prg.prg.nodes[0] };
+    const std::vector<LocalNodePtr> local_node_max_likelihood_path {
+        local_prg.prg.nodes[0]
+    };
 
-    const auto actual { find_interval_and_flanks_in_localpath(interval, local_node_max_likelihood_path) };
+    const auto actual { find_interval_and_flanks_in_localpath(
+        interval, local_node_max_likelihood_path) };
     const PathComponents expected;
 
     EXPECT_EQ(actual, expected);
 }
 
-
-TEST(FindIntervalInLocalPathTest, emptyPrgReturnsEmptyResult) {
+TEST(FindIntervalInLocalPathTest, emptyPrgReturnsEmptyResult)
+{
     const Interval interval { 0, 5 };
     const std::vector<LocalNodePtr> local_node_max_likelihood_path;
 
-    const auto actual { find_interval_and_flanks_in_localpath(interval, local_node_max_likelihood_path) };
+    const auto actual { find_interval_and_flanks_in_localpath(
+        interval, local_node_max_likelihood_path) };
     const PathComponents expected;
 
     EXPECT_EQ(actual, expected);
 }
 
-
-TEST(FindIntervalInLocalPathTest, emptyInputsReturnsEmptyResult) {
+TEST(FindIntervalInLocalPathTest, emptyInputsReturnsEmptyResult)
+{
     const Interval interval;
     const std::vector<LocalNodePtr> local_node_max_likelihood_path;
 
-    const auto actual { find_interval_and_flanks_in_localpath(interval, local_node_max_likelihood_path) };
+    const auto actual { find_interval_and_flanks_in_localpath(
+        interval, local_node_max_likelihood_path) };
     const PathComponents expected;
 
     EXPECT_EQ(actual, expected);
 }
 
-
-TEST(FindIntervalInLocalPathTest, singleBaseIntervalSingleBasePrgReturnsSingleBase) {
+TEST(FindIntervalInLocalPathTest, singleBaseIntervalSingleBasePrgReturnsSingleBase)
+{
     const Interval interval { 0, 1 };
     LocalPRG local_prg { 0, "test", "A" };
-    const std::vector<LocalNodePtr> local_node_max_likelihood_path { local_prg.prg.nodes[0] };
+    const std::vector<LocalNodePtr> local_node_max_likelihood_path {
+        local_prg.prg.nodes[0]
+    };
 
-    const auto actual { find_interval_and_flanks_in_localpath(interval, local_node_max_likelihood_path) };
+    const auto actual { find_interval_and_flanks_in_localpath(
+        interval, local_node_max_likelihood_path) };
     prg::Path expected_slice;
     expected_slice.initialize(interval);
     const PathComponents expected { prg::Path(), expected_slice, prg::Path() };
@@ -119,13 +126,17 @@ TEST(FindIntervalInLocalPathTest, singleBaseIntervalSingleBasePrgReturnsSingleBa
     EXPECT_EQ(actual, expected);
 }
 
-
-TEST(FindIntervalInLocalPathTest, singleBaseIntervalMultiBasePrgReturnsSingleBaseAndRightFlank) {
+TEST(FindIntervalInLocalPathTest,
+    singleBaseIntervalMultiBasePrgReturnsSingleBaseAndRightFlank)
+{
     const Interval interval { 0, 1 };
     LocalPRG local_prg { 0, "test", "AT" };
-    const std::vector<LocalNodePtr> local_node_max_likelihood_path { local_prg.prg.nodes[0] };
+    const std::vector<LocalNodePtr> local_node_max_likelihood_path {
+        local_prg.prg.nodes[0]
+    };
 
-    const auto actual { find_interval_and_flanks_in_localpath(interval, local_node_max_likelihood_path) };
+    const auto actual { find_interval_and_flanks_in_localpath(
+        interval, local_node_max_likelihood_path) };
     prg::Path expected_slice;
     expected_slice.initialize(interval);
     prg::Path expected_right_flank;
@@ -135,13 +146,17 @@ TEST(FindIntervalInLocalPathTest, singleBaseIntervalMultiBasePrgReturnsSingleBas
     EXPECT_EQ(actual, expected);
 }
 
-
-TEST(FindIntervalInLocalPathTest, singleBaseIntervalMultiBasePrgReturnsSingleBaseAndLeftFlank) {
+TEST(FindIntervalInLocalPathTest,
+    singleBaseIntervalMultiBasePrgReturnsSingleBaseAndLeftFlank)
+{
     const Interval interval { 1, 2 };
     LocalPRG local_prg { 0, "test", "AT" };
-    const std::vector<LocalNodePtr> local_node_max_likelihood_path { local_prg.prg.nodes[0] };
+    const std::vector<LocalNodePtr> local_node_max_likelihood_path {
+        local_prg.prg.nodes[0]
+    };
 
-    const auto actual { find_interval_and_flanks_in_localpath(interval, local_node_max_likelihood_path) };
+    const auto actual { find_interval_and_flanks_in_localpath(
+        interval, local_node_max_likelihood_path) };
     prg::Path expected_slice;
     expected_slice.initialize(interval);
     prg::Path expected_left_flank;
@@ -151,11 +166,14 @@ TEST(FindIntervalInLocalPathTest, singleBaseIntervalMultiBasePrgReturnsSingleBas
     EXPECT_EQ(actual, expected);
 }
 
-
-TEST(FindIntervalInLocalPathTest, singleBaseIntervalMultiBasePrgReturnsSingleBaseAndBothFlanks) {
+TEST(FindIntervalInLocalPathTest,
+    singleBaseIntervalMultiBasePrgReturnsSingleBaseAndBothFlanks)
+{
     const Interval interval { 1, 2 };
     LocalPRG local_prg { 0, "test", "TAT" };
-    const std::vector<LocalNodePtr> local_node_max_likelihood_path { local_prg.prg.nodes[0] };
+    const std::vector<LocalNodePtr> local_node_max_likelihood_path {
+        local_prg.prg.nodes[0]
+    };
 
     prg::Path expected_slice;
     prg::Path expected_left_flank;
@@ -163,314 +181,390 @@ TEST(FindIntervalInLocalPathTest, singleBaseIntervalMultiBasePrgReturnsSingleBas
     expected_slice.initialize(interval);
     expected_left_flank.initialize(Interval(0, 1));
     expected_right_flank.initialize(Interval(2, 3));
-    const PathComponents expected { expected_left_flank, expected_slice, expected_right_flank };
-    const auto actual { find_interval_and_flanks_in_localpath(interval, local_node_max_likelihood_path) };
+    const PathComponents expected { expected_left_flank, expected_slice,
+        expected_right_flank };
+    const auto actual { find_interval_and_flanks_in_localpath(
+        interval, local_node_max_likelihood_path) };
 
     EXPECT_EQ(actual, expected);
 }
 
-
-TEST(FindIntervalInLocalPathTest, singleBaseIntervalMultiNodeSingleBasePrgReturnsSingleBaseAndBothFlanks) {
+TEST(FindIntervalInLocalPathTest,
+    singleBaseIntervalMultiNodeSingleBasePrgReturnsSingleBaseAndBothFlanks)
+{
     const Interval interval { 1, 2 };
     LocalPRG local_prg { 0, "test", "T 5 A 6 C 5 T" };
-    const std::vector<LocalNodePtr> local_node_max_likelihood_path { local_prg.prg.nodes[0], local_prg.prg.nodes[1],
-                                                                     local_prg.prg.nodes[3] };
+    const std::vector<LocalNodePtr> local_node_max_likelihood_path {
+        local_prg.prg.nodes[0], local_prg.prg.nodes[1], local_prg.prg.nodes[3]
+    };
 
     prg::Path expected_slice;
     prg::Path expected_left_flank;
     prg::Path expected_right_flank;
-    expected_slice.initialize(Interval(4, 5));  // the A in the PRG
+    expected_slice.initialize(Interval(4, 5)); // the A in the PRG
     expected_left_flank.initialize(Interval(0, 1));
     expected_right_flank.initialize(Interval(12, 13));
-    const PathComponents expected { expected_left_flank, expected_slice, expected_right_flank };
-    const auto actual { find_interval_and_flanks_in_localpath(interval, local_node_max_likelihood_path) };
+    const PathComponents expected { expected_left_flank, expected_slice,
+        expected_right_flank };
+    const auto actual { find_interval_and_flanks_in_localpath(
+        interval, local_node_max_likelihood_path) };
 
     EXPECT_EQ(actual, expected);
 }
-
-
-TEST(FindIntervalInLocalPathTest, singleBaseIntervalMultiNodeSingleBasePrgReturnsSingleBaseAndLeftFlank) {
-    const Interval interval { 2, 3 };
-    LocalPRG local_prg { 0, "test", "T 5 A 6 C 5 T" };
-    const std::vector<LocalNodePtr> local_node_max_likelihood_path { local_prg.prg.nodes[0], local_prg.prg.nodes[1],
-                                                                     local_prg.prg.nodes[3] };
-
-    prg::Path expected_slice;
-    prg::Path expected_left_flank;
-    prg::Path expected_right_flank;
-    expected_slice.initialize(Interval(12, 13));  // the T at the end of the PRG
-    expected_left_flank.initialize(std::vector<Interval> { Interval(0, 1), Interval(4, 5) });
-    const PathComponents expected { expected_left_flank, expected_slice, expected_right_flank };
-    const auto actual { find_interval_and_flanks_in_localpath(interval, local_node_max_likelihood_path) };
-
-    EXPECT_EQ(actual, expected);
-}
-
-
-TEST(FindIntervalInLocalPathTest, singleBaseIntervalMultiNodeSingleBasePrgReturnsSingleBaseAndRightFlank) {
-    const Interval interval { 0, 1 };
-    LocalPRG local_prg { 0, "test", "T 5 A 6 C 5 T" };
-    const std::vector<LocalNodePtr> local_node_max_likelihood_path { local_prg.prg.nodes[0], local_prg.prg.nodes[1],
-                                                                     local_prg.prg.nodes[3] };
-
-    prg::Path expected_slice;
-    prg::Path expected_left_flank;
-    prg::Path expected_right_flank;
-    expected_slice.initialize(Interval(0, 1));  // the T at the start of the PRG
-    expected_right_flank.initialize(std::vector<Interval> { Interval(4, 5), Interval(12, 13) });
-    const PathComponents expected { expected_left_flank, expected_slice, expected_right_flank };
-    const auto actual { find_interval_and_flanks_in_localpath(interval, local_node_max_likelihood_path) };
-
-    EXPECT_EQ(actual, expected);
-}
-
-
-TEST(FindIntervalInLocalPathTest, singleBaseIntervalMultiNodeMultiBasePrgReturnsSingleBaseAndRightFlank) {
-    const Interval interval { 0, 1 };
-    LocalPRG local_prg { 0, "test", "TT 5 AA 6 CC 5 TT" };
-    const std::vector<LocalNodePtr> local_node_max_likelihood_path { local_prg.prg.nodes[0], local_prg.prg.nodes[1],
-                                                                     local_prg.prg.nodes[3] };
-
-    prg::Path expected_slice;
-    prg::Path expected_left_flank;
-    prg::Path expected_right_flank;
-    expected_slice.initialize(Interval(0, 1));  // the T at the start of the PRG
-    expected_right_flank.initialize(std::vector<Interval> { Interval(1, 2), Interval(5, 7), Interval(15, 17) });
-    const PathComponents expected { expected_left_flank, expected_slice, expected_right_flank };
-    const auto actual { find_interval_and_flanks_in_localpath(interval, local_node_max_likelihood_path) };
-
-    EXPECT_EQ(actual, expected);
-}
-
 
 TEST(FindIntervalInLocalPathTest,
-     singleBaseIntervalMultiNodeMultiBasePrgReturnsSingleBaseSingleLeftFlankAndMultiRightFlank) {
+    singleBaseIntervalMultiNodeSingleBasePrgReturnsSingleBaseAndLeftFlank)
+{
+    const Interval interval { 2, 3 };
+    LocalPRG local_prg { 0, "test", "T 5 A 6 C 5 T" };
+    const std::vector<LocalNodePtr> local_node_max_likelihood_path {
+        local_prg.prg.nodes[0], local_prg.prg.nodes[1], local_prg.prg.nodes[3]
+    };
+
+    prg::Path expected_slice;
+    prg::Path expected_left_flank;
+    prg::Path expected_right_flank;
+    expected_slice.initialize(Interval(12, 13)); // the T at the end of the PRG
+    expected_left_flank.initialize(
+        std::vector<Interval> { Interval(0, 1), Interval(4, 5) });
+    const PathComponents expected { expected_left_flank, expected_slice,
+        expected_right_flank };
+    const auto actual { find_interval_and_flanks_in_localpath(
+        interval, local_node_max_likelihood_path) };
+
+    EXPECT_EQ(actual, expected);
+}
+
+TEST(FindIntervalInLocalPathTest,
+    singleBaseIntervalMultiNodeSingleBasePrgReturnsSingleBaseAndRightFlank)
+{
+    const Interval interval { 0, 1 };
+    LocalPRG local_prg { 0, "test", "T 5 A 6 C 5 T" };
+    const std::vector<LocalNodePtr> local_node_max_likelihood_path {
+        local_prg.prg.nodes[0], local_prg.prg.nodes[1], local_prg.prg.nodes[3]
+    };
+
+    prg::Path expected_slice;
+    prg::Path expected_left_flank;
+    prg::Path expected_right_flank;
+    expected_slice.initialize(Interval(0, 1)); // the T at the start of the PRG
+    expected_right_flank.initialize(
+        std::vector<Interval> { Interval(4, 5), Interval(12, 13) });
+    const PathComponents expected { expected_left_flank, expected_slice,
+        expected_right_flank };
+    const auto actual { find_interval_and_flanks_in_localpath(
+        interval, local_node_max_likelihood_path) };
+
+    EXPECT_EQ(actual, expected);
+}
+
+TEST(FindIntervalInLocalPathTest,
+    singleBaseIntervalMultiNodeMultiBasePrgReturnsSingleBaseAndRightFlank)
+{
+    const Interval interval { 0, 1 };
+    LocalPRG local_prg { 0, "test", "TT 5 AA 6 CC 5 TT" };
+    const std::vector<LocalNodePtr> local_node_max_likelihood_path {
+        local_prg.prg.nodes[0], local_prg.prg.nodes[1], local_prg.prg.nodes[3]
+    };
+
+    prg::Path expected_slice;
+    prg::Path expected_left_flank;
+    prg::Path expected_right_flank;
+    expected_slice.initialize(Interval(0, 1)); // the T at the start of the PRG
+    expected_right_flank.initialize(
+        std::vector<Interval> { Interval(1, 2), Interval(5, 7), Interval(15, 17) });
+    const PathComponents expected { expected_left_flank, expected_slice,
+        expected_right_flank };
+    const auto actual { find_interval_and_flanks_in_localpath(
+        interval, local_node_max_likelihood_path) };
+
+    EXPECT_EQ(actual, expected);
+}
+
+TEST(FindIntervalInLocalPathTest,
+    singleBaseIntervalMultiNodeMultiBasePrgReturnsSingleBaseSingleLeftFlankAndMultiRightFlank)
+{
     const Interval interval { 1, 2 };
     LocalPRG local_prg { 0, "test", "TT 5 AA 6 CC 5 TT" };
-    const std::vector<LocalNodePtr> local_node_max_likelihood_path { local_prg.prg.nodes[0], local_prg.prg.nodes[1],
-                                                                     local_prg.prg.nodes[3] };
+    const std::vector<LocalNodePtr> local_node_max_likelihood_path {
+        local_prg.prg.nodes[0], local_prg.prg.nodes[1], local_prg.prg.nodes[3]
+    };
 
     prg::Path expected_slice;
     prg::Path expected_left_flank;
     prg::Path expected_right_flank;
-    expected_slice.initialize(Interval(1, 2));  // the second T at the start of the PRG
+    expected_slice.initialize(Interval(1, 2)); // the second T at the start of the PRG
     expected_left_flank.initialize(std::vector<Interval> { Interval(0, 1) });
-    expected_right_flank.initialize(std::vector<Interval> { Interval(5, 7), Interval(15, 17) });
-    const PathComponents expected { expected_left_flank, expected_slice, expected_right_flank };
-    const auto actual { find_interval_and_flanks_in_localpath(interval, local_node_max_likelihood_path) };
+    expected_right_flank.initialize(
+        std::vector<Interval> { Interval(5, 7), Interval(15, 17) });
+    const PathComponents expected { expected_left_flank, expected_slice,
+        expected_right_flank };
+    const auto actual { find_interval_and_flanks_in_localpath(
+        interval, local_node_max_likelihood_path) };
 
     EXPECT_EQ(actual, expected);
 }
 
-
-TEST(FindIntervalInLocalPathTest, singleBaseIntervalMultiNodeMultiBasePrgReturnsSingleBaseAndLeftFlank) {
+TEST(FindIntervalInLocalPathTest,
+    singleBaseIntervalMultiNodeMultiBasePrgReturnsSingleBaseAndLeftFlank)
+{
     const Interval interval { 5, 6 };
     LocalPRG local_prg { 0, "test", "TT 5 AA 6 CC 5 TT" };
-    const std::vector<LocalNodePtr> local_node_max_likelihood_path { local_prg.prg.nodes[0], local_prg.prg.nodes[1],
-                                                                     local_prg.prg.nodes[3] };
+    const std::vector<LocalNodePtr> local_node_max_likelihood_path {
+        local_prg.prg.nodes[0], local_prg.prg.nodes[1], local_prg.prg.nodes[3]
+    };
 
     prg::Path expected_slice;
     prg::Path expected_left_flank;
     prg::Path expected_right_flank;
-    expected_slice.initialize(Interval(16, 17));  // the T at the end of the PRG
-    expected_left_flank.initialize(std::vector<Interval> { Interval(0, 2), Interval(5, 7), Interval(15, 16) });
-    const PathComponents expected { expected_left_flank, expected_slice, expected_right_flank };
-    const auto actual { find_interval_and_flanks_in_localpath(interval, local_node_max_likelihood_path) };
+    expected_slice.initialize(Interval(16, 17)); // the T at the end of the PRG
+    expected_left_flank.initialize(
+        std::vector<Interval> { Interval(0, 2), Interval(5, 7), Interval(15, 16) });
+    const PathComponents expected { expected_left_flank, expected_slice,
+        expected_right_flank };
+    const auto actual { find_interval_and_flanks_in_localpath(
+        interval, local_node_max_likelihood_path) };
 
     EXPECT_EQ(actual, expected);
 }
 
-
 TEST(FindIntervalInLocalPathTest,
-     singleBaseIntervalMultiNodeMultiBasePrgReturnsSingleBaseSingleRightFlankAndMultiLeftFlank) {
+    singleBaseIntervalMultiNodeMultiBasePrgReturnsSingleBaseSingleRightFlankAndMultiLeftFlank)
+{
     const Interval interval { 4, 5 };
     LocalPRG local_prg { 0, "test", "TT 5 AA 6 CC 5 TT" };
-    const std::vector<LocalNodePtr> local_node_max_likelihood_path { local_prg.prg.nodes[0], local_prg.prg.nodes[1],
-                                                                     local_prg.prg.nodes[3] };
+    const std::vector<LocalNodePtr> local_node_max_likelihood_path {
+        local_prg.prg.nodes[0], local_prg.prg.nodes[1], local_prg.prg.nodes[3]
+    };
 
     prg::Path expected_slice;
     prg::Path expected_left_flank;
     prg::Path expected_right_flank;
-    expected_slice.initialize(Interval(15, 16));  // the second last T at the end of the PRG
+    expected_slice.initialize(
+        Interval(15, 16)); // the second last T at the end of the PRG
     expected_right_flank.initialize(std::vector<Interval> { Interval(16, 17) });
-    expected_left_flank.initialize(std::vector<Interval> { Interval(0, 2), Interval(5, 7) });
-    const PathComponents expected { expected_left_flank, expected_slice, expected_right_flank };
-    const auto actual { find_interval_and_flanks_in_localpath(interval, local_node_max_likelihood_path) };
+    expected_left_flank.initialize(
+        std::vector<Interval> { Interval(0, 2), Interval(5, 7) });
+    const PathComponents expected { expected_left_flank, expected_slice,
+        expected_right_flank };
+    const auto actual { find_interval_and_flanks_in_localpath(
+        interval, local_node_max_likelihood_path) };
 
     EXPECT_EQ(actual, expected);
 }
 
-
-TEST(FindIntervalInLocalPathTest, singleBaseIntervalMultiNodeMultiBasePrgReturnsSingleBaseAndFlanks) {
+TEST(FindIntervalInLocalPathTest,
+    singleBaseIntervalMultiNodeMultiBasePrgReturnsSingleBaseAndFlanks)
+{
     const Interval interval { 2, 3 };
     LocalPRG local_prg { 0, "test", "TT 5 AA 6 CC 5 TT" };
-    const std::vector<LocalNodePtr> local_node_max_likelihood_path { local_prg.prg.nodes[0], local_prg.prg.nodes[2],
-                                                                     local_prg.prg.nodes[3] };
+    const std::vector<LocalNodePtr> local_node_max_likelihood_path {
+        local_prg.prg.nodes[0], local_prg.prg.nodes[2], local_prg.prg.nodes[3]
+    };
 
     prg::Path expected_slice;
     prg::Path expected_left_flank;
     prg::Path expected_right_flank;
-    expected_slice.initialize(Interval(10, 11));  // the first C in the PRG
-    expected_right_flank.initialize(std::vector<Interval> { Interval(11, 12), Interval(15, 17) });
+    expected_slice.initialize(Interval(10, 11)); // the first C in the PRG
+    expected_right_flank.initialize(
+        std::vector<Interval> { Interval(11, 12), Interval(15, 17) });
     expected_left_flank.initialize(std::vector<Interval> { Interval(0, 2) });
-    const PathComponents expected { expected_left_flank, expected_slice, expected_right_flank };
-    const auto actual { find_interval_and_flanks_in_localpath(interval, local_node_max_likelihood_path) };
+    const PathComponents expected { expected_left_flank, expected_slice,
+        expected_right_flank };
+    const auto actual { find_interval_and_flanks_in_localpath(
+        interval, local_node_max_likelihood_path) };
 
     EXPECT_EQ(actual, expected);
 }
 
-
-TEST(FindIntervalInLocalPathTest, multiBaseIntervalMultiNodeMultiBasePrgReturnsSingleNodeAndRightFlanks) {
+TEST(FindIntervalInLocalPathTest,
+    multiBaseIntervalMultiNodeMultiBasePrgReturnsSingleNodeAndRightFlanks)
+{
     const Interval interval { 0, 2 };
     LocalPRG local_prg { 0, "test", "TT 5 AA 6 CC 5 TT" };
-    const std::vector<LocalNodePtr> local_node_max_likelihood_path { local_prg.prg.nodes[0], local_prg.prg.nodes[1],
-                                                                     local_prg.prg.nodes[3] };
+    const std::vector<LocalNodePtr> local_node_max_likelihood_path {
+        local_prg.prg.nodes[0], local_prg.prg.nodes[1], local_prg.prg.nodes[3]
+    };
 
     prg::Path expected_slice;
     prg::Path expected_left_flank;
     prg::Path expected_right_flank;
-    expected_slice.initialize(Interval(0, 2));  // the TT at the start of the PRG
-    expected_right_flank.initialize(std::vector<Interval> { Interval(5, 7), Interval(15, 17) });
-    const PathComponents expected { expected_left_flank, expected_slice, expected_right_flank };
-    const auto actual { find_interval_and_flanks_in_localpath(interval, local_node_max_likelihood_path) };
+    expected_slice.initialize(Interval(0, 2)); // the TT at the start of the PRG
+    expected_right_flank.initialize(
+        std::vector<Interval> { Interval(5, 7), Interval(15, 17) });
+    const PathComponents expected { expected_left_flank, expected_slice,
+        expected_right_flank };
+    const auto actual { find_interval_and_flanks_in_localpath(
+        interval, local_node_max_likelihood_path) };
 
     EXPECT_EQ(actual, expected);
 }
 
-
-TEST(FindIntervalInLocalPathTest, multiBaseIntervalMultiNodeMultiBasePrgReturnsSingleNodeAndLeftFlanks) {
+TEST(FindIntervalInLocalPathTest,
+    multiBaseIntervalMultiNodeMultiBasePrgReturnsSingleNodeAndLeftFlanks)
+{
     const Interval interval { 4, 6 };
     LocalPRG local_prg { 0, "test", "TT 5 AA 6 CC 5 TT" };
-    const std::vector<LocalNodePtr> local_node_max_likelihood_path { local_prg.prg.nodes[0], local_prg.prg.nodes[1],
-                                                                     local_prg.prg.nodes[3] };
+    const std::vector<LocalNodePtr> local_node_max_likelihood_path {
+        local_prg.prg.nodes[0], local_prg.prg.nodes[1], local_prg.prg.nodes[3]
+    };
 
     prg::Path expected_slice;
     prg::Path expected_left_flank;
     prg::Path expected_right_flank;
-    expected_slice.initialize(Interval(15, 17));  // the TT at the end of the PRG
-    expected_left_flank.initialize(std::vector<Interval> { Interval(0, 2), Interval(5, 7) });
-    const PathComponents expected { expected_left_flank, expected_slice, expected_right_flank };
-    const auto actual { find_interval_and_flanks_in_localpath(interval, local_node_max_likelihood_path) };
+    expected_slice.initialize(Interval(15, 17)); // the TT at the end of the PRG
+    expected_left_flank.initialize(
+        std::vector<Interval> { Interval(0, 2), Interval(5, 7) });
+    const PathComponents expected { expected_left_flank, expected_slice,
+        expected_right_flank };
+    const auto actual { find_interval_and_flanks_in_localpath(
+        interval, local_node_max_likelihood_path) };
 
     EXPECT_EQ(actual, expected);
 }
 
-
-TEST(FindIntervalInLocalPathTest, multiBaseIntervalMultiNodeMultiBasePrgReturnsSingleNodeAndBothFlanks) {
+TEST(FindIntervalInLocalPathTest,
+    multiBaseIntervalMultiNodeMultiBasePrgReturnsSingleNodeAndBothFlanks)
+{
     const Interval interval { 2, 4 };
     LocalPRG local_prg { 0, "test", "TT 5 AA 6 CC 5 TT" };
-    const std::vector<LocalNodePtr> local_node_max_likelihood_path { local_prg.prg.nodes[0], local_prg.prg.nodes[2],
-                                                                     local_prg.prg.nodes[3] };
+    const std::vector<LocalNodePtr> local_node_max_likelihood_path {
+        local_prg.prg.nodes[0], local_prg.prg.nodes[2], local_prg.prg.nodes[3]
+    };
 
     prg::Path expected_slice;
     prg::Path expected_left_flank;
     prg::Path expected_right_flank;
-    expected_slice.initialize(Interval(10, 12));  // the CC in the PRG
+    expected_slice.initialize(Interval(10, 12)); // the CC in the PRG
     expected_right_flank.initialize(std::vector<Interval> { Interval(15, 17) });
     expected_left_flank.initialize(std::vector<Interval> { Interval(0, 2) });
-    const PathComponents expected { expected_left_flank, expected_slice, expected_right_flank };
-    const auto actual { find_interval_and_flanks_in_localpath(interval, local_node_max_likelihood_path) };
+    const PathComponents expected { expected_left_flank, expected_slice,
+        expected_right_flank };
+    const auto actual { find_interval_and_flanks_in_localpath(
+        interval, local_node_max_likelihood_path) };
 
     EXPECT_EQ(actual, expected);
 }
 
-
 TEST(FindIntervalInLocalPathTest,
-     nodeSpanningIntervalMultiNodeMultiBasePrgReturnsMultiNodeSingleLeftAndMultiRightFlanks) {
+    nodeSpanningIntervalMultiNodeMultiBasePrgReturnsMultiNodeSingleLeftAndMultiRightFlanks)
+{
     const Interval interval { 1, 3 };
     LocalPRG local_prg { 0, "test", "TT 5 AA 6 CC 5 GG" };
-    const std::vector<LocalNodePtr> local_node_max_likelihood_path { local_prg.prg.nodes[0], local_prg.prg.nodes[2],
-                                                                     local_prg.prg.nodes[3] };
+    const std::vector<LocalNodePtr> local_node_max_likelihood_path {
+        local_prg.prg.nodes[0], local_prg.prg.nodes[2], local_prg.prg.nodes[3]
+    };
 
     prg::Path expected_slice;
     prg::Path expected_left_flank;
     prg::Path expected_right_flank;
-    expected_slice.initialize(std::vector<Interval> { Interval(1, 2), Interval(10, 11) });  // TC
-    expected_right_flank.initialize(std::vector<Interval> { Interval(11, 12), Interval(15, 17) });
+    expected_slice.initialize(
+        std::vector<Interval> { Interval(1, 2), Interval(10, 11) }); // TC
+    expected_right_flank.initialize(
+        std::vector<Interval> { Interval(11, 12), Interval(15, 17) });
     expected_left_flank.initialize(std::vector<Interval> { Interval(0, 1) });
-    const PathComponents expected { expected_left_flank, expected_slice, expected_right_flank };
-    const auto actual { find_interval_and_flanks_in_localpath(interval, local_node_max_likelihood_path) };
+    const PathComponents expected { expected_left_flank, expected_slice,
+        expected_right_flank };
+    const auto actual { find_interval_and_flanks_in_localpath(
+        interval, local_node_max_likelihood_path) };
 
     EXPECT_EQ(actual, expected);
 }
 
-
 TEST(FindIntervalInLocalPathTest,
-     nodeSpanningIntervalMultiNodeMultiBasePrgReturnsMultiNodeMultiLeftAndSingleRightFlanks) {
+    nodeSpanningIntervalMultiNodeMultiBasePrgReturnsMultiNodeMultiLeftAndSingleRightFlanks)
+{
     const Interval interval { 3, 5 };
     LocalPRG local_prg { 0, "test", "TT 5 AA 6 CC 5 GG" };
-    const std::vector<LocalNodePtr> local_node_max_likelihood_path { local_prg.prg.nodes[0], local_prg.prg.nodes[2],
-                                                                     local_prg.prg.nodes[3] };
+    const std::vector<LocalNodePtr> local_node_max_likelihood_path {
+        local_prg.prg.nodes[0], local_prg.prg.nodes[2], local_prg.prg.nodes[3]
+    };
 
     prg::Path expected_slice;
     prg::Path expected_left_flank;
     prg::Path expected_right_flank;
-    expected_slice.initialize(std::vector<Interval> { Interval(11, 12), Interval(15, 16) });  // CG
+    expected_slice.initialize(
+        std::vector<Interval> { Interval(11, 12), Interval(15, 16) }); // CG
     expected_right_flank.initialize(std::vector<Interval> { Interval(16, 17) });
-    expected_left_flank.initialize(std::vector<Interval> { Interval(0, 2), Interval(10, 11) });
-    const PathComponents expected { expected_left_flank, expected_slice, expected_right_flank };
-    const auto actual { find_interval_and_flanks_in_localpath(interval, local_node_max_likelihood_path) };
+    expected_left_flank.initialize(
+        std::vector<Interval> { Interval(0, 2), Interval(10, 11) });
+    const PathComponents expected { expected_left_flank, expected_slice,
+        expected_right_flank };
+    const auto actual { find_interval_and_flanks_in_localpath(
+        interval, local_node_max_likelihood_path) };
 
     EXPECT_EQ(actual, expected);
 }
-
 
 TEST(FindIntervalInLocalPathTest,
-     nodeSpanningIntervalMultiNodeMultiBasePrgReturnsMultiNodeSingleLeftAndSingleRightFlanks) {
+    nodeSpanningIntervalMultiNodeMultiBasePrgReturnsMultiNodeSingleLeftAndSingleRightFlanks)
+{
     const Interval interval { 1, 5 };
     LocalPRG local_prg { 0, "test", "TT 5 AA 6 CC 5 GG" };
-    const std::vector<LocalNodePtr> local_node_max_likelihood_path { local_prg.prg.nodes[0], local_prg.prg.nodes[2],
-                                                                     local_prg.prg.nodes[3] };
+    const std::vector<LocalNodePtr> local_node_max_likelihood_path {
+        local_prg.prg.nodes[0], local_prg.prg.nodes[2], local_prg.prg.nodes[3]
+    };
 
     prg::Path expected_slice;
     prg::Path expected_left_flank;
     prg::Path expected_right_flank;
-    expected_slice.initialize(std::vector<Interval> { Interval(1, 2), Interval(10, 12), Interval(15, 16) });  // TCCG
+    expected_slice.initialize(std::vector<Interval> {
+        Interval(1, 2), Interval(10, 12), Interval(15, 16) }); // TCCG
     expected_right_flank.initialize(std::vector<Interval> { Interval(16, 17) });
     expected_left_flank.initialize(std::vector<Interval> { Interval(0, 1) });
-    const PathComponents expected { expected_left_flank, expected_slice, expected_right_flank };
-    const auto actual { find_interval_and_flanks_in_localpath(interval, local_node_max_likelihood_path) };
+    const PathComponents expected { expected_left_flank, expected_slice,
+        expected_right_flank };
+    const auto actual { find_interval_and_flanks_in_localpath(
+        interval, local_node_max_likelihood_path) };
 
     EXPECT_EQ(actual, expected);
 }
 
-
-TEST(FindIntervalInLocalPathTest, intervalSpanningWholePrgReturnsNoFlanks) {
+TEST(FindIntervalInLocalPathTest, intervalSpanningWholePrgReturnsNoFlanks)
+{
     const Interval interval { 0, 6 };
     LocalPRG local_prg { 0, "test", "TT 5 AA 6 CC 5 GG" };
-    const std::vector<LocalNodePtr> local_node_max_likelihood_path { local_prg.prg.nodes[0], local_prg.prg.nodes[1],
-                                                                     local_prg.prg.nodes[3] };
+    const std::vector<LocalNodePtr> local_node_max_likelihood_path {
+        local_prg.prg.nodes[0], local_prg.prg.nodes[1], local_prg.prg.nodes[3]
+    };
 
     prg::Path expected_slice;
     prg::Path expected_left_flank;
     prg::Path expected_right_flank;
-    expected_slice.initialize(std::vector<Interval> { Interval(0, 2), Interval(5, 7), Interval(15, 17) });  // TTAAGG
-    const PathComponents expected { expected_left_flank, expected_slice, expected_right_flank };
-    const auto actual { find_interval_and_flanks_in_localpath(interval, local_node_max_likelihood_path) };
+    expected_slice.initialize(std::vector<Interval> {
+        Interval(0, 2), Interval(5, 7), Interval(15, 17) }); // TTAAGG
+    const PathComponents expected { expected_left_flank, expected_slice,
+        expected_right_flank };
+    const auto actual { find_interval_and_flanks_in_localpath(
+        interval, local_node_max_likelihood_path) };
 
     EXPECT_EQ(actual, expected);
 }
 
-
-TEST(FindIntervalInLocalPathTest, intervalSpanningPastEndOfPrgReturnsUpToEndOfPrg) {
+TEST(FindIntervalInLocalPathTest, intervalSpanningPastEndOfPrgReturnsUpToEndOfPrg)
+{
     const Interval interval { 2, 8 };
     LocalPRG local_prg { 0, "test", "TT 5 AA 6 CC 5 GG" };
-    const std::vector<LocalNodePtr> local_node_max_likelihood_path { local_prg.prg.nodes[0], local_prg.prg.nodes[1],
-                                                                     local_prg.prg.nodes[3] };
+    const std::vector<LocalNodePtr> local_node_max_likelihood_path {
+        local_prg.prg.nodes[0], local_prg.prg.nodes[1], local_prg.prg.nodes[3]
+    };
 
     prg::Path expected_slice;
     prg::Path expected_left_flank;
     prg::Path expected_right_flank;
-    expected_slice.initialize(std::vector<Interval> { Interval(5, 7), Interval(15, 17) });  // AAGG
+    expected_slice.initialize(
+        std::vector<Interval> { Interval(5, 7), Interval(15, 17) }); // AAGG
     expected_left_flank.initialize(std::vector<Interval> { Interval(0, 2) });
-    const PathComponents expected { expected_left_flank, expected_slice, expected_right_flank };
-    const auto actual { find_interval_and_flanks_in_localpath(interval, local_node_max_likelihood_path) };
+    const PathComponents expected { expected_left_flank, expected_slice,
+        expected_right_flank };
+    const auto actual { find_interval_and_flanks_in_localpath(
+        interval, local_node_max_likelihood_path) };
 
     EXPECT_EQ(actual, expected);
 }
 
-
-TEST(FindHitsInsidePathTest, emptyPathReturnsEmpty) {
+TEST(FindHitsInsidePathTest, emptyPathReturnsEmpty)
+{
     std::vector<MinimizerHitPtr> hits;
     prg::Path local_path;
 
@@ -480,12 +574,13 @@ TEST(FindHitsInsidePathTest, emptyPathReturnsEmpty) {
     EXPECT_EQ(actual, expected);
 }
 
-
-TEST(FindHitsInsidePathTest, hitNotOnPathReturnEmpty) {
-    LocalPRG local_prg(3, "nested varsite", "A 5 G 7 C 8 T 7 T 9 CCG 10 CGG 9  6 G 5 TAT");
-    const std::vector<LocalNodePtr> local_max_likelihood_path { local_prg.prg.nodes[1], local_prg.prg.nodes[2],
-                                                                local_prg.prg.nodes[4], local_prg.prg.nodes[6],
-                                                                local_prg.prg.nodes[7] };  // A G C T CGG  TAT
+TEST(FindHitsInsidePathTest, hitNotOnPathReturnEmpty)
+{
+    LocalPRG local_prg(
+        3, "nested varsite", "A 5 G 7 C 8 T 7 T 9 CCG 10 CGG 9  6 G 5 TAT");
+    const std::vector<LocalNodePtr> local_max_likelihood_path { local_prg.prg.nodes[1],
+        local_prg.prg.nodes[2], local_prg.prg.nodes[4], local_prg.prg.nodes[6],
+        local_prg.prg.nodes[7] }; // A G C T CGG  TAT
     const uint32_t read_id { 0 };
     const uint32_t prg_id { 3 };
     const uint32_t knode_id { 0 };
@@ -496,66 +591,75 @@ TEST(FindHitsInsidePathTest, hitNotOnPathReturnEmpty) {
     prg_path.initialize(intervals);
 
     std::vector<MinimizerHitPtr> read_hits;
-    const Minimizer readMinimizer(0, read_interval.start, read_interval.get_end(), is_forward);
+    const Minimizer readMinimizer(
+        0, read_interval.start, read_interval.get_end(), is_forward);
     const MiniRecord miniRecord(prg_id, prg_path, knode_id, is_forward);
-    MinimizerHitPtr minimizer_hit {
-            std::make_shared<MinimizerHit>(read_id, readMinimizer, miniRecord) };
+    MinimizerHitPtr minimizer_hit { std::make_shared<MinimizerHit>(
+        read_id, readMinimizer, miniRecord) };
     read_hits.push_back(minimizer_hit);
     prg::Path local_path;
-    for (const auto &node : local_max_likelihood_path) {
+    for (const auto& node : local_max_likelihood_path) {
         local_path.add_end_interval(node->pos);
     }
-    std::vector<MinimizerHitPtr> actual { find_hits_inside_path(read_hits, local_path) };
+    std::vector<MinimizerHitPtr> actual { find_hits_inside_path(
+        read_hits, local_path) };
     std::vector<MinimizerHitPtr> expected;
 
     EXPECT_EQ(actual, expected);
 }
 
-
-TEST(FindHitsInsidePathTest, hitsBranchingFromPathReturnEmpty) {
-    LocalPRG local_prg(3, "nested varsite", "A 5 G 7 C 8 T 7 T 9 CCG 10 CGG 9  6 G 5 TAT");
-    const std::vector<LocalNodePtr> local_max_likelihood_path { local_prg.prg.nodes[1], local_prg.prg.nodes[2],
-                                                                local_prg.prg.nodes[4], local_prg.prg.nodes[6],
-                                                                local_prg.prg.nodes[7] };  // A G C T CGG  TAT
+TEST(FindHitsInsidePathTest, hitsBranchingFromPathReturnEmpty)
+{
+    LocalPRG local_prg(
+        3, "nested varsite", "A 5 G 7 C 8 T 7 T 9 CCG 10 CGG 9  6 G 5 TAT");
+    const std::vector<LocalNodePtr> local_max_likelihood_path { local_prg.prg.nodes[1],
+        local_prg.prg.nodes[2], local_prg.prg.nodes[4], local_prg.prg.nodes[6],
+        local_prg.prg.nodes[7] }; // A G C T CGG  TAT
     const uint32_t read_id { 0 };
     const uint32_t prg_id { 3 };
     const uint32_t knode_id { 0 };
     const Interval read_interval { 1, 4 };
     const bool is_forward { true };
-    std::deque<Interval> intervals { Interval(7, 8), Interval(16, 17), Interval(27, 28) };
+    std::deque<Interval> intervals { Interval(7, 8), Interval(16, 17),
+        Interval(27, 28) };
     prg::Path prg_path;
     prg_path.initialize(intervals);
 
     std::vector<MinimizerHitPtr> read_hits;
-    const Minimizer readMinimizer1(0, read_interval.start, read_interval.get_end(), is_forward);
+    const Minimizer readMinimizer1(
+        0, read_interval.start, read_interval.get_end(), is_forward);
     const MiniRecord miniRecord1(prg_id, prg_path, knode_id, is_forward);
-    MinimizerHitPtr minimizer_hit {
-            std::make_shared<MinimizerHit>(read_id, readMinimizer1, miniRecord1) };
+    MinimizerHitPtr minimizer_hit { std::make_shared<MinimizerHit>(
+        read_id, readMinimizer1, miniRecord1) };
     read_hits.push_back(minimizer_hit);
 
     intervals = { Interval(29, 30), Interval(31, 33) };
     prg_path.initialize(intervals);
-    const Minimizer readMinimizer2(0, read_interval.start, read_interval.get_end(), is_forward);
+    const Minimizer readMinimizer2(
+        0, read_interval.start, read_interval.get_end(), is_forward);
     const MiniRecord miniRecord2(prg_id, prg_path, knode_id, is_forward);
-    minimizer_hit = { std::make_shared<MinimizerHit>(read_id, readMinimizer2, miniRecord2) };
+    minimizer_hit
+        = { std::make_shared<MinimizerHit>(read_id, readMinimizer2, miniRecord2) };
     read_hits.push_back(minimizer_hit);
 
     prg::Path local_path;
-    for (const auto &node : local_max_likelihood_path) {
+    for (const auto& node : local_max_likelihood_path) {
         local_path.add_end_interval(node->pos);
     }
-    std::vector<MinimizerHitPtr> actual { find_hits_inside_path(read_hits, local_path) };
+    std::vector<MinimizerHitPtr> actual { find_hits_inside_path(
+        read_hits, local_path) };
     std::vector<MinimizerHitPtr> expected;
 
     EXPECT_EQ(actual, expected);
 }
 
-
-TEST(FindHitsInsidePathTest, hitsOverlappingEdgesOfPathReturnEmpty) {
-    LocalPRG local_prg(3, "nested varsite", "A 5 G 7 C 8 T 7 T 9 CCG 10 CGG 9  6 G 5 TAT");
-    const std::vector<LocalNodePtr> local_max_likelihood_path { local_prg.prg.nodes[1], local_prg.prg.nodes[2],
-                                                                local_prg.prg.nodes[4], local_prg.prg.nodes[6],
-                                                                local_prg.prg.nodes[7] };  // A G C T CGG  TAT
+TEST(FindHitsInsidePathTest, hitsOverlappingEdgesOfPathReturnEmpty)
+{
+    LocalPRG local_prg(
+        3, "nested varsite", "A 5 G 7 C 8 T 7 T 9 CCG 10 CGG 9  6 G 5 TAT");
+    const std::vector<LocalNodePtr> local_max_likelihood_path { local_prg.prg.nodes[1],
+        local_prg.prg.nodes[2], local_prg.prg.nodes[4], local_prg.prg.nodes[6],
+        local_prg.prg.nodes[7] }; // A G C T CGG  TAT
     const uint32_t read_id { 0 };
     const uint32_t prg_id { 3 };
     const uint32_t knode_id { 0 };
@@ -566,43 +670,49 @@ TEST(FindHitsInsidePathTest, hitsOverlappingEdgesOfPathReturnEmpty) {
     prg_path.initialize(intervals);
 
     std::vector<MinimizerHitPtr> read_hits;
-    const Minimizer readMinimizer1(0, read_interval.start, read_interval.get_end(), is_forward);
+    const Minimizer readMinimizer1(
+        0, read_interval.start, read_interval.get_end(), is_forward);
     const MiniRecord miniRecord1(prg_id, prg_path, knode_id, is_forward);
-    MinimizerHitPtr minimizer_hit {
-            std::make_shared<MinimizerHit>(read_id, readMinimizer1, miniRecord1) };
+    MinimizerHitPtr minimizer_hit { std::make_shared<MinimizerHit>(
+        read_id, readMinimizer1, miniRecord1) };
     read_hits.push_back(minimizer_hit);
-
 
     intervals = { Interval(29, 30), Interval(33, 33), Interval(40, 42) };
     prg_path.initialize(intervals);
-    const Minimizer readMinimizer2(0, read_interval.start, read_interval.get_end(), is_forward);
+    const Minimizer readMinimizer2(
+        0, read_interval.start, read_interval.get_end(), is_forward);
     const MiniRecord miniRecord2(prg_id, prg_path, knode_id, is_forward);
-    minimizer_hit = { std::make_shared<MinimizerHit>(read_id, readMinimizer2, miniRecord2) };
+    minimizer_hit
+        = { std::make_shared<MinimizerHit>(read_id, readMinimizer2, miniRecord2) };
     read_hits.push_back(minimizer_hit);
 
     intervals = { Interval(28, 30), Interval(33, 33), Interval(40, 41) };
     prg_path.initialize(intervals);
-    const Minimizer readMinimizer3(0, read_interval.start, read_interval.get_end(), is_forward);
+    const Minimizer readMinimizer3(
+        0, read_interval.start, read_interval.get_end(), is_forward);
     const MiniRecord miniRecord3(prg_id, prg_path, knode_id, is_forward);
-    minimizer_hit = { std::make_shared<MinimizerHit>(read_id, readMinimizer3, miniRecord3) };
+    minimizer_hit
+        = { std::make_shared<MinimizerHit>(read_id, readMinimizer3, miniRecord3) };
     read_hits.push_back(minimizer_hit);
 
     prg::Path local_path;
-    for (const auto &node : local_max_likelihood_path) {
+    for (const auto& node : local_max_likelihood_path) {
         local_path.add_end_interval(node->pos);
     }
-    std::vector<MinimizerHitPtr> actual { find_hits_inside_path(read_hits, local_path) };
+    std::vector<MinimizerHitPtr> actual { find_hits_inside_path(
+        read_hits, local_path) };
     std::vector<MinimizerHitPtr> expected;
 
     EXPECT_EQ(actual, expected);
 }
 
-
-TEST(FindHitsInsidePathTest, hitsOnPathReturnCorrectHits) {
-    LocalPRG local_prg(3, "nested varsite", "A 5 G 7 C 8 T 7 T 9 CCG 10 CGG 9  6 G 5 TAT");
-    const std::vector<LocalNodePtr> local_max_likelihood_path { local_prg.prg.nodes[1], local_prg.prg.nodes[2],
-                                                                local_prg.prg.nodes[4], local_prg.prg.nodes[6],
-                                                                local_prg.prg.nodes[7] };  // A G C T CGG  TAT
+TEST(FindHitsInsidePathTest, hitsOnPathReturnCorrectHits)
+{
+    LocalPRG local_prg(
+        3, "nested varsite", "A 5 G 7 C 8 T 7 T 9 CCG 10 CGG 9  6 G 5 TAT");
+    const std::vector<LocalNodePtr> local_max_likelihood_path { local_prg.prg.nodes[1],
+        local_prg.prg.nodes[2], local_prg.prg.nodes[4], local_prg.prg.nodes[6],
+        local_prg.prg.nodes[7] }; // A G C T CGG  TAT
     const uint32_t read_id { 0 };
     const uint32_t prg_id { 3 };
     const uint32_t knode_id { 0 };
@@ -616,120 +726,130 @@ TEST(FindHitsInsidePathTest, hitsOnPathReturnCorrectHits) {
 
     std::vector<MinimizerHitPtr> read_hits;
 
-    const Minimizer readMinimizer1(0, read_interval.start, read_interval.get_end(), is_forward);
+    const Minimizer readMinimizer1(
+        0, read_interval.start, read_interval.get_end(), is_forward);
     const MiniRecord miniRecord1(prg_id, prg_path, knode_id, is_forward);
-    MinimizerHitPtr minimizer_hit {
-            std::make_shared<MinimizerHit>(read_id, readMinimizer1, miniRecord1) };
+    MinimizerHitPtr minimizer_hit { std::make_shared<MinimizerHit>(
+        read_id, readMinimizer1, miniRecord1) };
     read_hits.push_back(minimizer_hit);
     expected.push_back(minimizer_hit);
 
     intervals = { Interval(8, 9), Interval(16, 17), Interval(27, 28) };
     prg_path.initialize(intervals);
-    const Minimizer readMinimizer2(0, read_interval.start, read_interval.get_end(), is_forward);
+    const Minimizer readMinimizer2(
+        0, read_interval.start, read_interval.get_end(), is_forward);
     const MiniRecord miniRecord2(prg_id, prg_path, knode_id, is_forward);
-    minimizer_hit = { std::make_shared<MinimizerHit>(read_id, readMinimizer2, miniRecord2) };
+    minimizer_hit
+        = { std::make_shared<MinimizerHit>(read_id, readMinimizer2, miniRecord2) };
     read_hits.push_back(minimizer_hit);
     expected.push_back(minimizer_hit);
 
     intervals = { Interval(16, 17), Interval(27, 29) };
     prg_path.initialize(intervals);
-    const Minimizer readMinimizer3(0, read_interval.start, read_interval.get_end(), is_forward);
+    const Minimizer readMinimizer3(
+        0, read_interval.start, read_interval.get_end(), is_forward);
     const MiniRecord miniRecord3(prg_id, prg_path, knode_id, is_forward);
-    minimizer_hit = { std::make_shared<MinimizerHit>(read_id, readMinimizer3, miniRecord3) };
+    minimizer_hit
+        = { std::make_shared<MinimizerHit>(read_id, readMinimizer3, miniRecord3) };
     read_hits.push_back(minimizer_hit);
     expected.push_back(minimizer_hit);
 
     intervals = { Interval(27, 30) };
     prg_path.initialize(intervals);
-    const Minimizer readMinimizer4(0, read_interval.start, read_interval.get_end(), is_forward);
+    const Minimizer readMinimizer4(
+        0, read_interval.start, read_interval.get_end(), is_forward);
     const MiniRecord miniRecord4(prg_id, prg_path, knode_id, is_forward);
-    minimizer_hit = { std::make_shared<MinimizerHit>(read_id, readMinimizer4, miniRecord4) };
+    minimizer_hit
+        = { std::make_shared<MinimizerHit>(read_id, readMinimizer4, miniRecord4) };
     read_hits.push_back(minimizer_hit);
     expected.push_back(minimizer_hit);
 
     prg::Path local_path;
-    for (const auto &node : local_max_likelihood_path) {
+    for (const auto& node : local_max_likelihood_path) {
         local_path.add_end_interval(node->pos);
     }
-    std::vector<MinimizerHitPtr> actual { find_hits_inside_path(read_hits, local_path) };
+    std::vector<MinimizerHitPtr> actual { find_hits_inside_path(
+        read_hits, local_path) };
 
     EXPECT_EQ(actual, expected);
 }
 
-
-TEST(ReadCoordinateLessThanOperatorTest, idLessThanRHSReturnTrue) {
+TEST(ReadCoordinateLessThanOperatorTest, idLessThanRHSReturnTrue)
+{
     ReadCoordinate lhs { 0, 6, 10, true };
     ReadCoordinate rhs { 1, 16, 22, true };
 
     EXPECT_TRUE(lhs < rhs);
 }
 
-
-TEST(ReadCoordinateLessThanOperatorTest, idGreaterThanRHSReturnFalse) {
+TEST(ReadCoordinateLessThanOperatorTest, idGreaterThanRHSReturnFalse)
+{
     ReadCoordinate lhs { 2, 6, 10, true };
     ReadCoordinate rhs { 1, 16, 22, true };
 
     EXPECT_FALSE(lhs < rhs);
 }
 
-
-TEST(ReadCoordinateLessThanOperatorTest, idEqualStartLessThanRHSReturnTrue) {
+TEST(ReadCoordinateLessThanOperatorTest, idEqualStartLessThanRHSReturnTrue)
+{
     ReadCoordinate lhs { 1, 6, 10, true };
     ReadCoordinate rhs { 1, 16, 22, true };
 
     EXPECT_TRUE(lhs < rhs);
 }
 
-
-TEST(ReadCoordinateLessThanOperatorTest, idEqualStartGreaterThanRHSReturnFalse) {
+TEST(ReadCoordinateLessThanOperatorTest, idEqualStartGreaterThanRHSReturnFalse)
+{
     ReadCoordinate lhs { 1, 26, 10, true };
     ReadCoordinate rhs { 1, 16, 22, true };
 
     EXPECT_FALSE(lhs < rhs);
 }
 
-
-TEST(ReadCoordinateLessThanOperatorTest, idEqualStartEqualEndLessThanRHSReturnTrue) {
+TEST(ReadCoordinateLessThanOperatorTest, idEqualStartEqualEndLessThanRHSReturnTrue)
+{
     ReadCoordinate lhs { 1, 6, 10, true };
     ReadCoordinate rhs { 1, 6, 22, true };
 
     EXPECT_TRUE(lhs < rhs);
 }
 
-
-TEST(ReadCoordinateLessThanOperatorTest, idEqualStartEqualEndGreaterThanRHSReturnFalse) {
+TEST(ReadCoordinateLessThanOperatorTest, idEqualStartEqualEndGreaterThanRHSReturnFalse)
+{
     ReadCoordinate lhs { 1, 6, 10, true };
     ReadCoordinate rhs { 1, 6, 2, true };
 
     EXPECT_FALSE(lhs < rhs);
 }
 
-
-TEST(ReadCoordinateLessThanOperatorTest, idEqualStartEqualEndEqualStrandLessThanRHSReturnTrue) {
+TEST(ReadCoordinateLessThanOperatorTest,
+    idEqualStartEqualEndEqualStrandLessThanRHSReturnTrue)
+{
     ReadCoordinate lhs { 1, 6, 10, true };
     ReadCoordinate rhs { 1, 6, 10, false };
 
     EXPECT_TRUE(lhs < rhs);
 }
 
-
-TEST(ReadCoordinateLessThanOperatorTest, idEqualStartEqualEndEqualStrandGreaterThanRHSReturnFalse) {
+TEST(ReadCoordinateLessThanOperatorTest,
+    idEqualStartEqualEndEqualStrandGreaterThanRHSReturnFalse)
+{
     ReadCoordinate lhs { 1, 6, 10, false };
     ReadCoordinate rhs { 1, 6, 10, true };
 
     EXPECT_FALSE(lhs < rhs);
 }
 
-
-TEST(ReadCoordinateLessThanOperatorTest, lhsEqualsRHSReturnFalse) {
+TEST(ReadCoordinateLessThanOperatorTest, lhsEqualsRHSReturnFalse)
+{
     ReadCoordinate lhs { 1, 6, 10, false };
     ReadCoordinate rhs { 1, 6, 10, false };
 
     EXPECT_FALSE(lhs < rhs);
 }
 
-
-TEST(ReadCoordinateEqualityOperatorTest, variousEqualityAndNonEqualityTests) {
+TEST(ReadCoordinateEqualityOperatorTest, variousEqualityAndNonEqualityTests)
+{
     ReadCoordinate read_coord1 { 0, 6, 10, true };
     ReadCoordinate read_coord2 { 1, 16, 22, true };
     ReadCoordinate read_coord3 { 2, 3, 6, true };
@@ -813,8 +933,9 @@ TEST(ReadCoordinateEqualityOperatorTest, variousEqualityAndNonEqualityTests) {
     EXPECT_NE(read_coord8, read_coord1);
 }
 
-
-TEST(ReadCoordinateInsertionOperatorTest, basicObjectReturnsStringAsExpectedFromStringstream) {
+TEST(ReadCoordinateInsertionOperatorTest,
+    basicObjectReturnsStringAsExpectedFromStringstream)
+{
     ReadCoordinate read_coord { 0, 6, 10, true };
     std::stringstream out;
 
@@ -826,9 +947,9 @@ TEST(ReadCoordinateInsertionOperatorTest, basicObjectReturnsStringAsExpectedFrom
     EXPECT_EQ(actual, expected);
 }
 
-
-TEST(ReadCoordinateHashTest, queryNotInUnorderedSet) {
-    std::unordered_set<ReadCoordinate> myset {{ 0, 6, 10, true }};
+TEST(ReadCoordinateHashTest, queryNotInUnorderedSet)
+{
+    std::unordered_set<ReadCoordinate> myset { { 0, 6, 10, true } };
     ReadCoordinate query { 1, 6, 10, true };
 
     const bool query_in_myset { myset.find(query) != myset.end() };
@@ -836,9 +957,9 @@ TEST(ReadCoordinateHashTest, queryNotInUnorderedSet) {
     EXPECT_FALSE(query_in_myset);
 }
 
-
-TEST(ReadCoordinateHashTest, queryInUnorderedSet) {
-    std::unordered_set<ReadCoordinate> myset {{ 1, 6, 10, true }};
+TEST(ReadCoordinateHashTest, queryInUnorderedSet)
+{
+    std::unordered_set<ReadCoordinate> myset { { 1, 6, 10, true } };
     ReadCoordinate query { 1, 6, 10, true };
 
     const bool query_in_myset { myset.find(query) != myset.end() };

--- a/test/estimate_parameters_test.cpp
+++ b/test/estimate_parameters_test.cpp
@@ -1,130 +1,149 @@
-#include <stdint.h>
+#include "estimate_parameters.h"
+#include "pangenome/pangraph.h"
+#include "gtest/gtest.h"
 #include <cstring>
 #include <iostream>
-#include "gtest/gtest.h"
-#include "pangenome/pangraph.h"
-#include "estimate_parameters.h"
+#include <stdint.h>
 
 using namespace std;
 
-TEST(EstimateParameters_FitMeanCovg, Empty) {
+TEST(EstimateParameters_FitMeanCovg, Empty)
+{
     std::vector<uint> v = {};
     EXPECT_NEAR(0, fit_mean_covg(v, 0), 0.000001);
 }
 
-TEST(EstimateParameters_FitMeanCovg, SimpleMean) {
-    std::vector<uint> v = {30, 24, 12, 3, 6, 2, 14, 15, 16, 18};
+TEST(EstimateParameters_FitMeanCovg, SimpleMean)
+{
+    std::vector<uint> v = { 30, 24, 12, 3, 6, 2, 14, 15, 16, 18 };
     EXPECT_NEAR(4.071428571, fit_mean_covg(v, 0), 0.000001);
 }
 
-TEST(EstimateParameters_FitMeanCovg, SimpleMean_ZeroThreshOne) {
-    std::vector<uint> v = {30, 24, 12, 3, 6, 2, 14, 15, 16, 18};
+TEST(EstimateParameters_FitMeanCovg, SimpleMean_ZeroThreshOne)
+{
+    std::vector<uint> v = { 30, 24, 12, 3, 6, 2, 14, 15, 16, 18 };
     EXPECT_NEAR(5.181818182, fit_mean_covg(v, 1), 0.000001);
 }
 
-TEST(EstimateParameters_FitMeanCovg, SimpleMean_ZeroThreshTwo) {
-    std::vector<uint> v = {30, 24, 12, 3, 6, 2, 14, 15, 16, 18};
+TEST(EstimateParameters_FitMeanCovg, SimpleMean_ZeroThreshTwo)
+{
+    std::vector<uint> v = { 30, 24, 12, 3, 6, 2, 14, 15, 16, 18 };
     EXPECT_NEAR(6.348837209, fit_mean_covg(v, 2), 0.000001);
 }
 
-TEST(EstimateParameters_FitVarianceCovg, Empty) {
+TEST(EstimateParameters_FitVarianceCovg, Empty)
+{
     std::vector<uint> v = {};
     double mean = 0;
     EXPECT_NEAR(0, fit_variance_covg(v, mean, 0), 0.000001);
 }
 
-TEST(EstimateParameters_FitVarianceCovg, SimpleVar) {
-    std::vector<uint> v = {30, 24, 12, 3, 6, 2, 14, 15, 16, 18};
+TEST(EstimateParameters_FitVarianceCovg, SimpleVar)
+{
+    std::vector<uint> v = { 30, 24, 12, 3, 6, 2, 14, 15, 16, 18 };
     double mean = fit_mean_covg(v, 0);
     EXPECT_NEAR(11.75204082, fit_variance_covg(v, mean, 0), 0.000001);
 }
 
-TEST(EstimateParameters_FitVarianceCovg, SimpleVar_ZeroThreshOne) {
-    std::vector<uint> v = {30, 24, 12, 3, 6, 2, 14, 15, 16, 18};
+TEST(EstimateParameters_FitVarianceCovg, SimpleVar_ZeroThreshOne)
+{
+    std::vector<uint> v = { 30, 24, 12, 3, 6, 2, 14, 15, 16, 18 };
     double mean = fit_mean_covg(v, 1);
     EXPECT_NEAR(9.203305785, fit_variance_covg(v, mean, 1), 0.000001);
 }
 
-TEST(EstimateParameters_FitVarianceCovg, SimpleVar_ZeroThreshTwo) {
-    std::vector<uint> v = {30, 24, 12, 3, 6, 2, 14, 15, 16, 18};
+TEST(EstimateParameters_FitVarianceCovg, SimpleVar_ZeroThreshTwo)
+{
+    std::vector<uint> v = { 30, 24, 12, 3, 6, 2, 14, 15, 16, 18 };
     double mean = fit_mean_covg(v, 2);
     EXPECT_NEAR(5.529475392, fit_variance_covg(v, mean, 2), 0.000001);
 }
 
-TEST(EstimateParameters_FitNegativeBinomial, MeanZero_Death) {
-    double mean=0, variance=1;
+TEST(EstimateParameters_FitNegativeBinomial, MeanZero_Death)
+{
+    double mean = 0, variance = 1;
     float p, r;
-    EXPECT_DEATH(fit_negative_binomial(mean, variance, p, r),"");
+    EXPECT_DEATH(fit_negative_binomial(mean, variance, p, r), "");
 }
 
-TEST(EstimateParameters_FitNegativeBinomial, VarianceZero_Death) {
-    double mean=1, variance=0;
+TEST(EstimateParameters_FitNegativeBinomial, VarianceZero_Death)
+{
+    double mean = 1, variance = 0;
     float p, r;
-    EXPECT_DEATH(fit_negative_binomial(mean, variance, p, r),"");
+    EXPECT_DEATH(fit_negative_binomial(mean, variance, p, r), "");
 }
 
-TEST(EstimateParameters_FitNegativeBinomial, MeanVarianceEqual_Death) {
-    double mean=1, variance=1;
+TEST(EstimateParameters_FitNegativeBinomial, MeanVarianceEqual_Death)
+{
+    double mean = 1, variance = 1;
     float p, r;
-    EXPECT_DEATH(fit_negative_binomial(mean, variance, p, r),"");
+    EXPECT_DEATH(fit_negative_binomial(mean, variance, p, r), "");
 }
 
-TEST(EstimateParameters_FitNegativeBinomial, MeanGreaterThanVariance_Death) {
-    double mean=2, variance=1;
+TEST(EstimateParameters_FitNegativeBinomial, MeanGreaterThanVariance_Death)
+{
+    double mean = 2, variance = 1;
     float p, r;
-    EXPECT_DEATH(fit_negative_binomial(mean, variance, p, r),"");
+    EXPECT_DEATH(fit_negative_binomial(mean, variance, p, r), "");
 }
 
-TEST(EstimateParameters_FitNegativeBinomial, SimpleFit) {
-    double mean=1, variance=2;
-    float p, r;
-    fit_negative_binomial(mean, variance, p, r);
-    EXPECT_FLOAT_EQ(p,0.5);
-    EXPECT_FLOAT_EQ(r,1);
-}
-
-TEST(EstimateParameters_FitNegativeBinomial, Fit) {
-    double mean=1, variance=4;
+TEST(EstimateParameters_FitNegativeBinomial, SimpleFit)
+{
+    double mean = 1, variance = 2;
     float p, r;
     fit_negative_binomial(mean, variance, p, r);
-    EXPECT_FLOAT_EQ(p,0.25);
-    EXPECT_FLOAT_EQ(r,(float)1/3);
+    EXPECT_FLOAT_EQ(p, 0.5);
+    EXPECT_FLOAT_EQ(r, 1);
 }
 
-TEST(EstimateParameters_FindMeanCovg, Examples) {
-    //NB this finds the position in vector at which max of the second peak occurs
-    std::vector<uint> v1 = {30, 24, 12, 3, 6, 2, 14, 15, 16, 18, 40, 26, 35, 14};
+TEST(EstimateParameters_FitNegativeBinomial, Fit)
+{
+    double mean = 1, variance = 4;
+    float p, r;
+    fit_negative_binomial(mean, variance, p, r);
+    EXPECT_FLOAT_EQ(p, 0.25);
+    EXPECT_FLOAT_EQ(r, (float)1 / 3);
+}
+
+TEST(EstimateParameters_FindMeanCovg, Examples)
+{
+    // NB this finds the position in vector at which max of the second peak occurs
+    std::vector<uint> v1 = { 30, 24, 12, 3, 6, 2, 14, 15, 16, 18, 40, 26, 35, 14 };
     EXPECT_EQ(uint(10), find_mean_covg(v1));
     // not thrown by a single weird one not near peak
-    std::vector<uint> v2 = {30, 24, 12, 3, 70, 2, 14, 15, 16, 18, 40, 26, 35, 14};
+    std::vector<uint> v2 = { 30, 24, 12, 3, 70, 2, 14, 15, 16, 18, 40, 26, 35, 14 };
     EXPECT_EQ(uint(10), find_mean_covg(v2));
     // doesn't matter if second peak much lower
-    std::vector<uint> v3 = {30, 24, 12, 3, 6, 2, 14, 15, 16, 18, 14, 8, 9, 1};
+    std::vector<uint> v3 = { 30, 24, 12, 3, 6, 2, 14, 15, 16, 18, 14, 8, 9, 1 };
     EXPECT_EQ(uint(9), find_mean_covg(v3));
     // do need an increase three times
-    std::vector<uint> v4 = {30, 24, 12, 3, 6, 2, 11, 10, 9, 8, 4, 3, 2, 1};
+    std::vector<uint> v4 = { 30, 24, 12, 3, 6, 2, 11, 10, 9, 8, 4, 3, 2, 1 };
     EXPECT_EQ(uint(0), find_mean_covg(v4));
     // a too clean one with run of zeroes doing it
-    std::vector<uint> v5 = {30, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 12, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 5};
+    std::vector<uint> v5 = { 30, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 12, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 5 };
     EXPECT_EQ(uint(12), find_mean_covg(v5));
     // insufficient zeroes with a peak
-    std::vector<uint> v6 = {30, 0, 0, 0, 0, 0, 0, 0, 0, 2, 14, 15, 16, 18, 14, 8, 9, 1};
+    std::vector<uint> v6
+        = { 30, 0, 0, 0, 0, 0, 0, 0, 0, 2, 14, 15, 16, 18, 14, 8, 9, 1 };
     EXPECT_EQ(uint(13), find_mean_covg(v6));
-
 }
 
-TEST(EstimateParameters_FindProbThresh, Empty_Zero) {
-    //NB this finds the position in vector at which min occurs between 2 peaks
+TEST(EstimateParameters_FindProbThresh, Empty_Zero)
+{
+    // NB this finds the position in vector at which min occurs between 2 peaks
     std::vector<uint> v = {};
     EXPECT_EQ(0, find_prob_thresh(v));
 }
 
-TEST(EstimateParameters_FindProbThresh, SimpleCases) {
-    //NB this finds the position in vector at which min occurs between 2 peaks
-    std::vector<uint> v1 = {30, 24, 18, 16, 12, 3, 6, 2, 1, 15, 16, 18, 12, 26, 35, 40};
+TEST(EstimateParameters_FindProbThresh, SimpleCases)
+{
+    // NB this finds the position in vector at which min occurs between 2 peaks
+    std::vector<uint> v1
+        = { 30, 24, 18, 16, 12, 3, 6, 2, 1, 15, 16, 18, 12, 26, 35, 40 };
     EXPECT_EQ(8 - 200, find_prob_thresh(v1));
     // not thrown by low values outside of valley
-    std::vector<uint> v2 = {1, 30, 24, 12, 3, 6, 2, 0, 15, 16, 18, 12, 26, 35, 40, 0};
+    std::vector<uint> v2 = { 1, 30, 24, 12, 3, 6, 2, 0, 15, 16, 18, 12, 26, 35, 40, 0 };
     EXPECT_EQ(7 - 200, find_prob_thresh(v2));
 }
 
@@ -136,17 +155,22 @@ TEST(EstimateParameters_FindProbThresh, SecondPeakClose)
 
 TEST(EstimateParameters_FindProbThresh, OnePeak)
 {
-    std::vector<uint> v = {30, 24, 12, 3, 3, 2, 0, 0};
+    std::vector<uint> v = { 30, 24, 12, 3, 3, 2, 0, 0 };
     EXPECT_EQ(5 - 200, find_prob_thresh(v));
 }
 
-void setup_index_estimate_parameters(std::vector<std::shared_ptr<LocalPRG>> &prgs, std::shared_ptr<Index> &index){
-    auto s = std::make_shared<LocalPRG>(LocalPRG(0, "nested varsite", "AAA 5 GGGG 7 CCC 8 TTT 7  6 GG 5 TTTTTACAGACGT"));
+void setup_index_estimate_parameters(
+    std::vector<std::shared_ptr<LocalPRG>>& prgs, std::shared_ptr<Index>& index)
+{
+    auto s = std::make_shared<LocalPRG>(LocalPRG(
+        0, "nested varsite", "AAA 5 GGGG 7 CCC 8 TTT 7  6 GG 5 TTTTTACAGACGT"));
     prgs.emplace_back(s);
-    s = std::make_shared<LocalPRG>(LocalPRG(1, "much more complex", "TCATTC 5 ACTC 7 TAGTCA 8 TTGTGA 7  6 AACTAG 5 AGCTG"));
+    s = std::make_shared<LocalPRG>(LocalPRG(
+        1, "much more complex", "TCATTC 5 ACTC 7 TAGTCA 8 TTGTGA 7  6 AACTAG 5 AGCTG"));
     prgs.emplace_back(s);
-    s = std::make_shared<LocalPRG>(LocalPRG(2, "one with lots of null at start and end, and a long stretch in between",
-                " 5  7  9  11 AGTTCTGAAACATTGCGCGTGAGATCTCTG 12 T 11  10 A 9  8 C 7  6 G 5 "));
+    s = std::make_shared<LocalPRG>(LocalPRG(2,
+        "one with lots of null at start and end, and a long stretch in between",
+        " 5  7  9  11 AGTTCTGAAACATTGCGCGTGAGATCTCTG 12 T 11  10 A 9  8 C 7  6 G 5 "));
     prgs.emplace_back(s);
     prgs[0]->minimizer_sketch(index, 1, 6);
     prgs[1]->minimizer_sketch(index, 1, 6);
@@ -156,132 +180,156 @@ void setup_index_estimate_parameters(std::vector<std::shared_ptr<LocalPRG>> &prg
 TEST(EstimateParameters_EstimateParameters, NoPangraphNodes)
 {
     auto outdir = "test";
-    uint32_t k=6, covg=10, sample_id=0;
-    float e_rate=0.01;
-    bool bin=false;
+    uint32_t k = 6, covg = 10, sample_id = 0;
+    float e_rate = 0.01;
+    bool bin = false;
 
     auto pangraph = std::make_shared<pangenome::Graph>(pangenome::Graph());
 
-    auto expected_depth_covg = estimate_parameters(pangraph,outdir,k,e_rate,covg,bin,sample_id);
-    EXPECT_EQ(expected_depth_covg,(uint)10);
+    auto expected_depth_covg
+        = estimate_parameters(pangraph, outdir, k, e_rate, covg, bin, sample_id);
+    EXPECT_EQ(expected_depth_covg, (uint)10);
 }
 
 TEST(EstimateParameters_EstimateParameters, PangraphWithNodes_SimpleBinomial)
 {
     std::vector<std::shared_ptr<LocalPRG>> prgs;
     auto index = std::make_shared<Index>();
-    setup_index_estimate_parameters(prgs,index);
+    setup_index_estimate_parameters(prgs, index);
 
     auto outdir = "estimate_parameters_test";
-    uint32_t w=1, k=6, covg=10, sample_id=0, min_cluster_size=1, genome_size=22;
-    float e_rate=0.01;
-    bool bin=true, illumina=true;
+    uint32_t w = 1, k = 6, covg = 10, sample_id = 0, min_cluster_size = 1,
+             genome_size = 22;
+    float e_rate = 0.01;
+    bool bin = true, illumina = true;
 
     auto pangraph = std::make_shared<pangenome::Graph>(pangenome::Graph());
-    pangraph_from_read_file("../../test/test_cases/estimate_parameters_reads.fa", pangraph, index, prgs, w, k, 1, e_rate,
-        min_cluster_size, genome_size, illumina);
+    pangraph_from_read_file("../../test/test_cases/estimate_parameters_reads.fa",
+        pangraph, index, prgs, w, k, 1, e_rate, min_cluster_size, genome_size,
+        illumina);
     pangraph->add_hits_to_kmergraphs(prgs);
 
-    auto expected_depth_covg = estimate_parameters(pangraph,outdir,k,e_rate,covg,bin,sample_id);
-    EXPECT_NEAR(expected_depth_covg,(uint)4, 1);
+    auto expected_depth_covg
+        = estimate_parameters(pangraph, outdir, k, e_rate, covg, bin, sample_id);
+    EXPECT_NEAR(expected_depth_covg, (uint)4, 1);
 }
 
-TEST(EstimateParameters_EstimateParameters, PangraphWithNodes_SimpleBinomial_LowCoverage)
+TEST(
+    EstimateParameters_EstimateParameters, PangraphWithNodes_SimpleBinomial_LowCoverage)
 {
     std::vector<std::shared_ptr<LocalPRG>> prgs;
     auto index = std::make_shared<Index>();
-    setup_index_estimate_parameters(prgs,index);
+    setup_index_estimate_parameters(prgs, index);
 
     auto outdir = "estimate_parameters_test";
-    uint32_t w=1, k=6, covg=10, sample_id=0, min_cluster_size=1, genome_size=22;
-    float e_rate=0.01;
-    bool bin=true, illumina=true;
+    uint32_t w = 1, k = 6, covg = 10, sample_id = 0, min_cluster_size = 1,
+             genome_size = 22;
+    float e_rate = 0.01;
+    bool bin = true, illumina = true;
 
     auto pangraph = std::make_shared<pangenome::Graph>(pangenome::Graph());
-    pangraph_from_read_file("../../test/test_cases/estimate_parameters_reads3.fa", pangraph, index, prgs, w, k, 1, e_rate,
-        min_cluster_size, genome_size, illumina);
+    pangraph_from_read_file("../../test/test_cases/estimate_parameters_reads3.fa",
+        pangraph, index, prgs, w, k, 1, e_rate, min_cluster_size, genome_size,
+        illumina);
     pangraph->add_hits_to_kmergraphs(prgs);
 
-    auto expected_depth_covg = estimate_parameters(pangraph,outdir,k,e_rate,covg,bin,sample_id);
-    EXPECT_NEAR(expected_depth_covg,(uint)2, 1);
+    auto expected_depth_covg
+        = estimate_parameters(pangraph, outdir, k, e_rate, covg, bin, sample_id);
+    EXPECT_NEAR(expected_depth_covg, (uint)2, 1);
 }
 
 TEST(EstimateParameters_EstimateParameters, PangraphWithNodes_SimpleNegativeBinomial)
 {
     std::vector<std::shared_ptr<LocalPRG>> prgs;
     auto index = std::make_shared<Index>();
-    setup_index_estimate_parameters(prgs,index);
+    setup_index_estimate_parameters(prgs, index);
 
     auto outdir = "estimate_parameters_test";
-    uint32_t w=1, k=6, covg=10, sample_id=0, min_cluster_size=1, genome_size=22;
-    float e_rate=0.01;
-    bool bin=false, illumina=true;
+    uint32_t w = 1, k = 6, covg = 10, sample_id = 0, min_cluster_size = 1,
+             genome_size = 22;
+    float e_rate = 0.01;
+    bool bin = false, illumina = true;
 
     auto pangraph = std::make_shared<pangenome::Graph>(pangenome::Graph());
-    pangraph_from_read_file("../../test/test_cases/estimate_parameters_reads.fa", pangraph, index, prgs, w, k, 1, e_rate,
-                            min_cluster_size, genome_size, illumina);
+    pangraph_from_read_file("../../test/test_cases/estimate_parameters_reads.fa",
+        pangraph, index, prgs, w, k, 1, e_rate, min_cluster_size, genome_size,
+        illumina);
     pangraph->add_hits_to_kmergraphs(prgs);
 
-    auto expected_depth_covg = estimate_parameters(pangraph,outdir,k,e_rate,covg,bin,sample_id);
-    EXPECT_NEAR(expected_depth_covg,(uint)4, 1);
+    auto expected_depth_covg
+        = estimate_parameters(pangraph, outdir, k, e_rate, covg, bin, sample_id);
+    EXPECT_NEAR(expected_depth_covg, (uint)4, 1);
 }
 
-TEST(EstimateParameters_EstimateParameters, PangraphWithNodes_SimpleNegativeBinomial_HighCoverage)
-{
-std::vector<std::shared_ptr<LocalPRG>> prgs;
-auto index = std::make_shared<Index>();
-setup_index_estimate_parameters(prgs,index);
-
-auto outdir = "estimate_parameters_test";
-uint32_t w=1, k=6, covg=32, sample_id=0, min_cluster_size=1, genome_size=22;
-float e_rate=0.01;
-bool bin=false, illumina=true;
-
-auto pangraph = std::make_shared<pangenome::Graph>(pangenome::Graph());
-pangraph_from_read_file("../../test/test_cases/estimate_parameters_reads4.fa", pangraph, index, prgs, w, k, 1, e_rate,
-min_cluster_size, genome_size, illumina);
-pangraph->add_hits_to_kmergraphs(prgs);
-
-auto expected_depth_covg = estimate_parameters(pangraph,outdir,k,e_rate,covg,bin,sample_id);
-EXPECT_NEAR(expected_depth_covg,(uint)40, 1); //NB method overestimates covg, true is 32
-}
-
-TEST(EstimateParameters_EstimateParameters, PangraphWithNodes_SimpleBinomial_HighCoverage)
+TEST(EstimateParameters_EstimateParameters,
+    PangraphWithNodes_SimpleNegativeBinomial_HighCoverage)
 {
     std::vector<std::shared_ptr<LocalPRG>> prgs;
     auto index = std::make_shared<Index>();
-    setup_index_estimate_parameters(prgs,index);
+    setup_index_estimate_parameters(prgs, index);
 
     auto outdir = "estimate_parameters_test";
-    uint32_t w=1, k=6, covg=32, sample_id=0, min_cluster_size=1, genome_size=22;
-    float e_rate=0.01;
-    bool bin=true, illumina=true;
+    uint32_t w = 1, k = 6, covg = 32, sample_id = 0, min_cluster_size = 1,
+             genome_size = 22;
+    float e_rate = 0.01;
+    bool bin = false, illumina = true;
 
     auto pangraph = std::make_shared<pangenome::Graph>(pangenome::Graph());
-    pangraph_from_read_file("../../test/test_cases/estimate_parameters_reads4.fa", pangraph, index, prgs, w, k, 1, e_rate,
-                            min_cluster_size, genome_size, illumina);
+    pangraph_from_read_file("../../test/test_cases/estimate_parameters_reads4.fa",
+        pangraph, index, prgs, w, k, 1, e_rate, min_cluster_size, genome_size,
+        illumina);
     pangraph->add_hits_to_kmergraphs(prgs);
 
-    auto expected_depth_covg = estimate_parameters(pangraph,outdir,k,e_rate,covg,bin,sample_id);
-    EXPECT_NEAR(expected_depth_covg,(uint)32, 1); //NB method overestimates covg, true is 32
+    auto expected_depth_covg
+        = estimate_parameters(pangraph, outdir, k, e_rate, covg, bin, sample_id);
+    EXPECT_NEAR(
+        expected_depth_covg, (uint)40, 1); // NB method overestimates covg, true is 32
+}
+
+TEST(EstimateParameters_EstimateParameters,
+    PangraphWithNodes_SimpleBinomial_HighCoverage)
+{
+    std::vector<std::shared_ptr<LocalPRG>> prgs;
+    auto index = std::make_shared<Index>();
+    setup_index_estimate_parameters(prgs, index);
+
+    auto outdir = "estimate_parameters_test";
+    uint32_t w = 1, k = 6, covg = 32, sample_id = 0, min_cluster_size = 1,
+             genome_size = 22;
+    float e_rate = 0.01;
+    bool bin = true, illumina = true;
+
+    auto pangraph = std::make_shared<pangenome::Graph>(pangenome::Graph());
+    pangraph_from_read_file("../../test/test_cases/estimate_parameters_reads4.fa",
+        pangraph, index, prgs, w, k, 1, e_rate, min_cluster_size, genome_size,
+        illumina);
+    pangraph->add_hits_to_kmergraphs(prgs);
+
+    auto expected_depth_covg
+        = estimate_parameters(pangraph, outdir, k, e_rate, covg, bin, sample_id);
+    EXPECT_NEAR(
+        expected_depth_covg, (uint)32, 1); // NB method overestimates covg, true is 32
 }
 
 TEST(EstimateParameters_EstimateParameters, PangraphWithNodes_NoiseReads)
 {
     std::vector<std::shared_ptr<LocalPRG>> prgs;
     auto index = std::make_shared<Index>();
-    setup_index_estimate_parameters(prgs,index);
+    setup_index_estimate_parameters(prgs, index);
 
     auto outdir = "estimate_parameters_test";
-    uint32_t w=1, k=6, covg=10, sample_id=0, min_cluster_size=1, genome_size=22;
-    float e_rate=0.01;
-    bool bin=false, illumina=true;
+    uint32_t w = 1, k = 6, covg = 10, sample_id = 0, min_cluster_size = 1,
+             genome_size = 22;
+    float e_rate = 0.01;
+    bool bin = false, illumina = true;
 
     auto pangraph = std::make_shared<pangenome::Graph>(pangenome::Graph());
-    pangraph_from_read_file("../../test/test_cases/estimate_parameters_reads2.fa", pangraph, index, prgs, w, k, 1, e_rate,
-                            min_cluster_size, genome_size, illumina);
+    pangraph_from_read_file("../../test/test_cases/estimate_parameters_reads2.fa",
+        pangraph, index, prgs, w, k, 1, e_rate, min_cluster_size, genome_size,
+        illumina);
     pangraph->add_hits_to_kmergraphs(prgs);
 
-    auto expected_depth_covg = estimate_parameters(pangraph,outdir,k,e_rate,covg,bin,sample_id);
-    EXPECT_NEAR(expected_depth_covg,(uint)5, 1);
+    auto expected_depth_covg
+        = estimate_parameters(pangraph, outdir, k, e_rate, covg, bin, sample_id);
+    EXPECT_NEAR(expected_depth_covg, (uint)5, 1);
 }

--- a/test/fastaq_handler_test.cpp
+++ b/test/fastaq_handler_test.cpp
@@ -1,37 +1,41 @@
-#include <iostream>
-#include <fstream>
-#include <cstdint>
-#include "gtest/gtest.h"
 #include "fastaq_handler.h"
-
+#include "gtest/gtest.h"
+#include <cstdint>
+#include <fstream>
+#include <iostream>
 
 using namespace std;
 
-TEST(FastaqHandlerTest, create_fa) {
+TEST(FastaqHandlerTest, create_fa)
+{
     FastaqHandler fh("../../test/test_cases/reads.fa");
-    EXPECT_EQ((uint32_t) 0, fh.num_reads_parsed);
+    EXPECT_EQ((uint32_t)0, fh.num_reads_parsed);
     EXPECT_TRUE(fh.fastaq_file.is_open());
 }
 
-TEST(FastaqHandlerTest, create_fq) {
+TEST(FastaqHandlerTest, create_fq)
+{
     FastaqHandler fh("../../test/test_cases/reads.fq");
-    EXPECT_EQ((uint) 0, fh.num_reads_parsed);
+    EXPECT_EQ((uint)0, fh.num_reads_parsed);
     EXPECT_TRUE(fh.fastaq_file.is_open());
 }
 
-TEST(FastaqHandlerTest, create_fagz) {
+TEST(FastaqHandlerTest, create_fagz)
+{
     FastaqHandler fh("../../test/test_cases/reads.fa.gz");
-    EXPECT_EQ((uint) 0, fh.num_reads_parsed);
+    EXPECT_EQ((uint)0, fh.num_reads_parsed);
     EXPECT_TRUE(fh.fastaq_file.is_open());
 }
 
-TEST(FastaqHandlerTest, create_fqgz) {
+TEST(FastaqHandlerTest, create_fqgz)
+{
     FastaqHandler fh("../../test/test_cases/reads.fq.gz");
-    EXPECT_EQ((uint) 0, fh.num_reads_parsed);
+    EXPECT_EQ((uint)0, fh.num_reads_parsed);
     EXPECT_TRUE(fh.fastaq_file.is_open());
 }
 
-TEST(FastaqHandlerTest, getline_fa) {
+TEST(FastaqHandlerTest, getline_fa)
+{
     FastaqHandler fh("../../test/test_cases/reads.fa");
     bool foundline = false;
     while (std::getline(fh.instream, fh.line)) {
@@ -40,7 +44,8 @@ TEST(FastaqHandlerTest, getline_fa) {
     EXPECT_TRUE(foundline);
 }
 
-TEST(FastaqHandlerTest, getline_fagz) {
+TEST(FastaqHandlerTest, getline_fagz)
+{
     FastaqHandler fh("../../test/test_cases/reads.fa.gz");
     bool foundline = false;
     while (std::getline(fh.instream, fh.line)) {
@@ -49,215 +54,221 @@ TEST(FastaqHandlerTest, getline_fagz) {
     EXPECT_TRUE(foundline);
 }
 
-TEST(FastaqHandlerTest, get_next) {
+TEST(FastaqHandlerTest, get_next)
+{
     FastaqHandler fh("../../test/test_cases/reads.fa");
     fh.get_next();
-    EXPECT_EQ((uint32_t) 1, fh.num_reads_parsed);
+    EXPECT_EQ((uint32_t)1, fh.num_reads_parsed);
     EXPECT_EQ(fh.name, "read0");
     EXPECT_EQ(fh.read, "to be ignored");
 
     fh.get_next();
-    EXPECT_EQ((uint32_t) 2, fh.num_reads_parsed);
+    EXPECT_EQ((uint32_t)2, fh.num_reads_parsed);
     EXPECT_EQ(fh.name, "read1");
     EXPECT_EQ(fh.read, "should copy the phrase *should*");
 
     fh.get_next();
-    EXPECT_EQ((uint32_t) 3, fh.num_reads_parsed);
+    EXPECT_EQ((uint32_t)3, fh.num_reads_parsed);
     EXPECT_EQ(fh.name, "read2");
     EXPECT_EQ(fh.read, "this time we should get *is time *");
 
     fh.get_next();
-    EXPECT_EQ((uint) 4, fh.num_reads_parsed);
+    EXPECT_EQ((uint)4, fh.num_reads_parsed);
     EXPECT_EQ(fh.name, "read3");
     EXPECT_EQ(fh.read, "nonsense");
 
     fh.get_next();
-    EXPECT_EQ((uint) 5, fh.num_reads_parsed);
+    EXPECT_EQ((uint)5, fh.num_reads_parsed);
     EXPECT_EQ(fh.name, "read4");
     EXPECT_EQ(fh.read, "another junk line");
 
     fh.get_next();
-    EXPECT_EQ((uint) 5, fh.num_reads_parsed);
+    EXPECT_EQ((uint)5, fh.num_reads_parsed);
     EXPECT_EQ(fh.name, "read4");
     EXPECT_EQ(fh.read, "another junk line");
 }
 
-TEST(FastaqHandlerTest, get_id_fa) {
+TEST(FastaqHandlerTest, get_id_fa)
+{
     FastaqHandler fh("../../test/test_cases/reads.fa");
 
     fh.get_id(1);
-    EXPECT_EQ((uint32_t) 2, fh.num_reads_parsed);
+    EXPECT_EQ((uint32_t)2, fh.num_reads_parsed);
     EXPECT_EQ(fh.name, "read1");
     EXPECT_EQ(fh.read, "should copy the phrase *should*");
 
     fh.get_id(0);
-    EXPECT_EQ((uint32_t) 1, fh.num_reads_parsed);
+    EXPECT_EQ((uint32_t)1, fh.num_reads_parsed);
     EXPECT_EQ(fh.name, "read0");
     EXPECT_EQ(fh.read, "to be ignored");
 
     fh.get_id(2);
-    EXPECT_EQ((uint32_t) 3, fh.num_reads_parsed);
+    EXPECT_EQ((uint32_t)3, fh.num_reads_parsed);
     EXPECT_EQ(fh.name, "read2");
     EXPECT_EQ(fh.read, "this time we should get *is time *");
 
     fh.get_id(1);
-    EXPECT_EQ((uint32_t) 2, fh.num_reads_parsed);
+    EXPECT_EQ((uint32_t)2, fh.num_reads_parsed);
     EXPECT_EQ(fh.name, "read1");
     EXPECT_EQ(fh.read, "should copy the phrase *should*");
 
     fh.get_id(0);
-    EXPECT_EQ((uint32_t) 1, fh.num_reads_parsed);
+    EXPECT_EQ((uint32_t)1, fh.num_reads_parsed);
     EXPECT_EQ(fh.name, "read0");
     EXPECT_EQ(fh.read, "to be ignored");
 
     fh.get_id(1);
-    EXPECT_EQ((uint32_t) 2, fh.num_reads_parsed);
+    EXPECT_EQ((uint32_t)2, fh.num_reads_parsed);
     EXPECT_EQ(fh.name, "read1");
     EXPECT_EQ(fh.read, "should copy the phrase *should*");
 
     fh.get_id(2);
-    EXPECT_EQ((uint32_t) 3, fh.num_reads_parsed);
+    EXPECT_EQ((uint32_t)3, fh.num_reads_parsed);
     EXPECT_EQ(fh.name, "read2");
     EXPECT_EQ(fh.read, "this time we should get *is time *");
 }
 
-TEST(FastaqHandlerTest, get_id_fq) {
+TEST(FastaqHandlerTest, get_id_fq)
+{
     FastaqHandler fh("../../test/test_cases/reads.fq");
 
     fh.get_id(1);
-    EXPECT_EQ((uint32_t) 2, fh.num_reads_parsed);
+    EXPECT_EQ((uint32_t)2, fh.num_reads_parsed);
     EXPECT_EQ(fh.name, "read1");
     EXPECT_EQ(fh.read, "should copy the phrase *should*");
 
     fh.get_id(0);
-    EXPECT_EQ((uint32_t) 1, fh.num_reads_parsed);
+    EXPECT_EQ((uint32_t)1, fh.num_reads_parsed);
     EXPECT_EQ(fh.name, "read0");
     EXPECT_EQ(fh.read, "to be ignored");
 
     fh.get_id(2);
-    EXPECT_EQ((uint32_t) 3, fh.num_reads_parsed);
+    EXPECT_EQ((uint32_t)3, fh.num_reads_parsed);
     EXPECT_EQ(fh.name, "read2");
     EXPECT_EQ(fh.read, "this time we should get *is time *");
 
     fh.get_id(1);
-    EXPECT_EQ((uint32_t) 2, fh.num_reads_parsed);
+    EXPECT_EQ((uint32_t)2, fh.num_reads_parsed);
     EXPECT_EQ(fh.name, "read1");
     EXPECT_EQ(fh.read, "should copy the phrase *should*");
 
     fh.get_id(0);
-    EXPECT_EQ((uint32_t) 1, fh.num_reads_parsed);
+    EXPECT_EQ((uint32_t)1, fh.num_reads_parsed);
     EXPECT_EQ(fh.name, "read0");
     EXPECT_EQ(fh.read, "to be ignored");
 
     fh.get_id(1);
-    EXPECT_EQ((uint32_t) 2, fh.num_reads_parsed);
+    EXPECT_EQ((uint32_t)2, fh.num_reads_parsed);
     EXPECT_EQ(fh.name, "read1");
     EXPECT_EQ(fh.read, "should copy the phrase *should*");
 
     fh.get_id(2);
-    EXPECT_EQ((uint32_t) 3, fh.num_reads_parsed);
+    EXPECT_EQ((uint32_t)3, fh.num_reads_parsed);
     EXPECT_EQ(fh.name, "read2");
     EXPECT_EQ(fh.read, "this time we should get *is time *");
 
     fh.get_id(4);
-    EXPECT_EQ((uint) 5, fh.num_reads_parsed);
+    EXPECT_EQ((uint)5, fh.num_reads_parsed);
     EXPECT_EQ(fh.name, "read4");
 
     fh.get_id(3);
-    EXPECT_EQ((uint) 4, fh.num_reads_parsed);
+    EXPECT_EQ((uint)4, fh.num_reads_parsed);
     EXPECT_EQ(fh.name, "read3");
-
 }
 
-TEST(FastaqHandlerTest, get_id_fagz) {
+TEST(FastaqHandlerTest, get_id_fagz)
+{
     FastaqHandler fh("../../test/test_cases/reads.fa.gz");
 
     fh.get_id(1);
-    EXPECT_EQ((uint) 2, fh.num_reads_parsed);
+    EXPECT_EQ((uint)2, fh.num_reads_parsed);
     EXPECT_EQ(fh.name, "read1");
     EXPECT_EQ(fh.read, "should copy the phrase *should*");
 
     fh.get_id(0);
-    EXPECT_EQ((uint) 1, fh.num_reads_parsed);
+    EXPECT_EQ((uint)1, fh.num_reads_parsed);
     EXPECT_EQ(fh.name, "read0");
     EXPECT_EQ(fh.read, "to be ignored");
 
     fh.get_id(2);
-    EXPECT_EQ((uint) 3, fh.num_reads_parsed);
+    EXPECT_EQ((uint)3, fh.num_reads_parsed);
     EXPECT_EQ(fh.name, "read2");
     EXPECT_EQ(fh.read, "this time we should get *is time *");
 
     fh.get_id(1);
-    EXPECT_EQ((uint) 2, fh.num_reads_parsed);
+    EXPECT_EQ((uint)2, fh.num_reads_parsed);
     EXPECT_EQ(fh.name, "read1");
     EXPECT_EQ(fh.read, "should copy the phrase *should*");
 
     fh.get_id(0);
-    EXPECT_EQ((uint) 1, fh.num_reads_parsed);
+    EXPECT_EQ((uint)1, fh.num_reads_parsed);
     EXPECT_EQ(fh.name, "read0");
     EXPECT_EQ(fh.read, "to be ignored");
 
     fh.get_id(1);
-    EXPECT_EQ((uint) 2, fh.num_reads_parsed);
+    EXPECT_EQ((uint)2, fh.num_reads_parsed);
     EXPECT_EQ(fh.name, "read1");
     EXPECT_EQ(fh.read, "should copy the phrase *should*");
 
     fh.get_id(2);
-    EXPECT_EQ((uint) 3, fh.num_reads_parsed);
+    EXPECT_EQ((uint)3, fh.num_reads_parsed);
     EXPECT_EQ(fh.name, "read2");
     EXPECT_EQ(fh.read, "this time we should get *is time *");
 }
 
-TEST(FastaqHandlerTest, get_id_fqgz) {
+TEST(FastaqHandlerTest, get_id_fqgz)
+{
     FastaqHandler fh("../../test/test_cases/reads.fq.gz");
 
     fh.get_id(1);
-    EXPECT_EQ((uint) 2, fh.num_reads_parsed);
+    EXPECT_EQ((uint)2, fh.num_reads_parsed);
     EXPECT_EQ(fh.name, "read1");
     EXPECT_EQ(fh.read, "should copy the phrase *should*");
 
     fh.get_id(0);
-    EXPECT_EQ((uint) 1, fh.num_reads_parsed);
+    EXPECT_EQ((uint)1, fh.num_reads_parsed);
     EXPECT_EQ(fh.name, "read0");
     EXPECT_EQ(fh.read, "to be ignored");
 
     fh.get_id(2);
-    EXPECT_EQ((uint) 3, fh.num_reads_parsed);
+    EXPECT_EQ((uint)3, fh.num_reads_parsed);
     EXPECT_EQ(fh.name, "read2");
     EXPECT_EQ(fh.read, "this time we should get *is time *");
 
     fh.get_id(1);
-    EXPECT_EQ((uint) 2, fh.num_reads_parsed);
+    EXPECT_EQ((uint)2, fh.num_reads_parsed);
     EXPECT_EQ(fh.name, "read1");
     EXPECT_EQ(fh.read, "should copy the phrase *should*");
 
     fh.get_id(0);
-    EXPECT_EQ((uint) 1, fh.num_reads_parsed);
+    EXPECT_EQ((uint)1, fh.num_reads_parsed);
     EXPECT_EQ(fh.name, "read0");
     EXPECT_EQ(fh.read, "to be ignored");
 
     fh.get_id(1);
-    EXPECT_EQ((uint) 2, fh.num_reads_parsed);
+    EXPECT_EQ((uint)2, fh.num_reads_parsed);
     EXPECT_EQ(fh.name, "read1");
     EXPECT_EQ(fh.read, "should copy the phrase *should*");
 
     fh.get_id(2);
-    EXPECT_EQ((uint) 3, fh.num_reads_parsed);
+    EXPECT_EQ((uint)3, fh.num_reads_parsed);
     EXPECT_EQ(fh.name, "read2");
     EXPECT_EQ(fh.read, "this time we should get *is time *");
 }
 
-TEST(FastaqHandlerTest, close) {
+TEST(FastaqHandlerTest, close)
+{
     FastaqHandler fh("../../test/test_cases/reads.fa");
-    EXPECT_EQ((uint32_t) 0, fh.num_reads_parsed);
+    EXPECT_EQ((uint32_t)0, fh.num_reads_parsed);
     EXPECT_TRUE(fh.fastaq_file.is_open());
     fh.close();
     EXPECT_FALSE(fh.fastaq_file.is_open());
 }
 
-TEST(FastaqHandlerTest, close_fqgz) {
+TEST(FastaqHandlerTest, close_fqgz)
+{
     FastaqHandler fh("../../test/test_cases/reads.fq.gz");
-    EXPECT_EQ((uint) 0, fh.num_reads_parsed);
+    EXPECT_EQ((uint)0, fh.num_reads_parsed);
     EXPECT_TRUE(fh.fastaq_file.is_open());
     fh.close();
     EXPECT_FALSE(fh.fastaq_file.is_open());

--- a/test/fastaq_test.cpp
+++ b/test/fastaq_test.cpp
@@ -1,139 +1,155 @@
-#include "gtest/gtest.h"
 #include "fastaq.h"
+#include "gtest/gtest.h"
 #include <iostream>
-
 
 using namespace std;
 
-TEST(FastaqTest, create_null) {
+TEST(FastaqTest, create_null)
+{
     Fastaq f1;
     EXPECT_FALSE(f1.gzipped);
     EXPECT_FALSE(f1.fastq);
-    EXPECT_EQ(f1.names.size(), (uint) 0);
-    EXPECT_EQ(f1.sequences.size(), (uint) 0);
-    EXPECT_EQ(f1.scores.size(), (uint) 0);
+    EXPECT_EQ(f1.names.size(), (uint)0);
+    EXPECT_EQ(f1.sequences.size(), (uint)0);
+    EXPECT_EQ(f1.scores.size(), (uint)0);
 }
 
-TEST(FastaqTest, create_with_args) {
+TEST(FastaqTest, create_with_args)
+{
     Fastaq f1(true, false);
     EXPECT_TRUE(f1.gzipped);
     EXPECT_FALSE(f1.fastq);
-    EXPECT_EQ(f1.names.size(), (uint) 0);
-    EXPECT_EQ(f1.sequences.size(), (uint) 0);
-    EXPECT_EQ(f1.scores.size(), (uint) 0);
+    EXPECT_EQ(f1.names.size(), (uint)0);
+    EXPECT_EQ(f1.sequences.size(), (uint)0);
+    EXPECT_EQ(f1.scores.size(), (uint)0);
 
     Fastaq f2(false, true);
     EXPECT_FALSE(f2.gzipped);
     EXPECT_TRUE(f2.fastq);
-    EXPECT_EQ(f2.names.size(), (uint) 0);
-    EXPECT_EQ(f2.sequences.size(), (uint) 0);
-    EXPECT_EQ(f2.scores.size(), (uint) 0);
+    EXPECT_EQ(f2.names.size(), (uint)0);
+    EXPECT_EQ(f2.sequences.size(), (uint)0);
+    EXPECT_EQ(f2.scores.size(), (uint)0);
 
     Fastaq f3(true, true);
     EXPECT_TRUE(f3.gzipped);
     EXPECT_TRUE(f3.fastq);
-    EXPECT_EQ(f3.names.size(), (uint) 0);
-    EXPECT_EQ(f3.sequences.size(), (uint) 0);
-    EXPECT_EQ(f3.scores.size(), (uint) 0);
+    EXPECT_EQ(f3.names.size(), (uint)0);
+    EXPECT_EQ(f3.sequences.size(), (uint)0);
+    EXPECT_EQ(f3.scores.size(), (uint)0);
 }
 
-TEST(FastaqTest, covg_to_score) {
+TEST(FastaqTest, covg_to_score)
+{
     Fastaq f;
-    char ascii_range[] = "!\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrstuvwxyz{|}~";
+    char ascii_range[] = "!\"#$%&'()*+,-./"
+                         "0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`"
+                         "abcdefghijklmnopqrstuvwxyz{|}~";
     for (uint i = 0; i < 40; ++i) {
         EXPECT_EQ(f.covg_to_score(i, 40), ascii_range[i]);
     }
 }
 
-TEST(FastaqTest, covg_to_score_with_rounding) {
+TEST(FastaqTest, covg_to_score_with_rounding)
+{
     Fastaq f;
-    char ascii_range[] = "!\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrstuvwxyz{|}~";
+    char ascii_range[] = "!\"#$%&'()*+,-./"
+                         "0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`"
+                         "abcdefghijklmnopqrstuvwxyz{|}~";
     for (uint i = 0; i < 40; ++i) {
         EXPECT_EQ(f.covg_to_score(3 * i, 119), ascii_range[i]);
     }
 }
 
-TEST(AltCovgToScore, CovgToScoreWithAltTrue_ReturnAltCovgToScoreResult) {
+TEST(AltCovgToScore, CovgToScoreWithAltTrue_ReturnAltCovgToScoreResult)
+{
     Fastaq f;
-    const uint_least16_t covg{0};
+    const uint_least16_t covg { 0 };
 
-    const auto result{f.covg_to_score(covg, 0, true)};
-    const char expected{'!'};
+    const auto result { f.covg_to_score(covg, 0, true) };
+    const char expected { '!' };
 
     EXPECT_EQ(result, expected);
 }
 
-TEST(AltCovgToScore, CovgZero_ReturnFirstPrintableAscii) {
+TEST(AltCovgToScore, CovgZero_ReturnFirstPrintableAscii)
+{
     Fastaq f;
-    const uint_least16_t covg{0};
+    const uint_least16_t covg { 0 };
 
-    const auto result{f.alt_covg_to_score(covg)};
-    const char expected{'!'};
+    const auto result { f.alt_covg_to_score(covg) };
+    const char expected { '!' };
 
     EXPECT_EQ(result, expected);
 }
 
-TEST(AltCovgToScore, CovgFive_ReturnSixthPrintableAscii) {
+TEST(AltCovgToScore, CovgFive_ReturnSixthPrintableAscii)
+{
     Fastaq f;
-    const uint_least16_t covg{5};
+    const uint_least16_t covg { 5 };
 
-    const auto result{f.alt_covg_to_score(covg)};
-    const char expected{'&'};
+    const auto result { f.alt_covg_to_score(covg) };
+    const char expected { '&' };
 
     EXPECT_EQ(result, expected);
 }
 
-TEST(AltCovgToScore, CovgNinetyThree_ReturnLastPrintableAscii) {
+TEST(AltCovgToScore, CovgNinetyThree_ReturnLastPrintableAscii)
+{
     Fastaq f;
-    const uint_least16_t covg{93};
+    const uint_least16_t covg { 93 };
 
-    const auto result{f.alt_covg_to_score(covg)};
-    const char expected{'~'};
+    const auto result { f.alt_covg_to_score(covg) };
+    const char expected { '~' };
 
     EXPECT_EQ(result, expected);
 }
 
-TEST(AltCovgToScore, CovgNinetyFour_ReturnLastPrintableAscii) {
+TEST(AltCovgToScore, CovgNinetyFour_ReturnLastPrintableAscii)
+{
     Fastaq f;
-    const uint_least16_t covg{94};
+    const uint_least16_t covg { 94 };
 
-    const auto result{f.alt_covg_to_score(covg)};
-    const char expected{'~'};
+    const auto result { f.alt_covg_to_score(covg) };
+    const char expected { '~' };
 
     EXPECT_EQ(result, expected);
 }
 
-TEST(AltCovgToScore, CovgNinetyTwo_ReturnSecondLastPrintableAscii) {
+TEST(AltCovgToScore, CovgNinetyTwo_ReturnSecondLastPrintableAscii)
+{
     Fastaq f;
-    const uint_least16_t covg{92};
+    const uint_least16_t covg { 92 };
 
-    const auto result{f.alt_covg_to_score(covg)};
-    const char expected{'}'};
+    const auto result { f.alt_covg_to_score(covg) };
+    const char expected { '}' };
 
     EXPECT_EQ(result, expected);
 }
 
-TEST(AltCovgToScore, CrazyHighCovg_ReturnLastPrintableAscii) {
+TEST(AltCovgToScore, CrazyHighCovg_ReturnLastPrintableAscii)
+{
     Fastaq f;
-    const uint_least16_t covg{920};
+    const uint_least16_t covg { 920 };
 
-    const auto result{f.alt_covg_to_score(covg)};
-    const char expected{'~'};
+    const auto result { f.alt_covg_to_score(covg) };
+    const char expected { '~' };
 
     EXPECT_EQ(result, expected);
 }
 
-TEST(FastaqTest, add_entry_catch_asserts) {
+TEST(FastaqTest, add_entry_catch_asserts)
+{
     Fastaq f;
-    EXPECT_DEATH(f.add_entry("", "ACGT", {0, 1, 2, 3}, 40), "");
-    EXPECT_DEATH(f.add_entry("dummy", "ACGT", {0, 1, 2}, 40), "");
-    EXPECT_DEATH(f.add_entry("dummy", "ACG", {0, 1, 2, 3}, 40), "");
-    //EXPECT_DEATH(f.add_entry("dummy", "ACGT", {0, 1, 2, 3}, 0), "");
+    EXPECT_DEATH(f.add_entry("", "ACGT", { 0, 1, 2, 3 }, 40), "");
+    EXPECT_DEATH(f.add_entry("dummy", "ACGT", { 0, 1, 2 }, 40), "");
+    EXPECT_DEATH(f.add_entry("dummy", "ACG", { 0, 1, 2, 3 }, 40), "");
+    // EXPECT_DEATH(f.add_entry("dummy", "ACGT", {0, 1, 2, 3}, 0), "");
 }
 
-TEST(FastaqTest, add_entry_works) {
+TEST(FastaqTest, add_entry_works)
+{
     Fastaq f;
-    f.add_entry("dummy", "ACGTA", {2, 3, 4, 5, 6}, 40);
+    f.add_entry("dummy", "ACGTA", { 2, 3, 4, 5, 6 }, 40);
     bool found_name = find(f.names.begin(), f.names.end(), "dummy") != f.names.end();
     EXPECT_TRUE(found_name);
     bool added_seq = f.sequences.find("dummy") != f.sequences.end();
@@ -144,84 +160,93 @@ TEST(FastaqTest, add_entry_works) {
     EXPECT_EQ(f.scores["dummy"], "#$%&'");
 }
 
-TEST(FastaqTest, different_fastaq_equals_false) {
+TEST(FastaqTest, different_fastaq_equals_false)
+{
     Fastaq f1(false, true);
-    f1.add_entry("dummy", "ACGTA", {2, 3, 4, 5, 6}, 40);
+    f1.add_entry("dummy", "ACGTA", { 2, 3, 4, 5, 6 }, 40);
     Fastaq f2(false, false);
-    f2.add_entry("dummy", "ACGTA", {2, 3, 4, 5, 6}, 40);
+    f2.add_entry("dummy", "ACGTA", { 2, 3, 4, 5, 6 }, 40);
     EXPECT_FALSE(f1 == f2);
     EXPECT_FALSE(f2 == f1);
 }
 
-TEST(FastaqTest, different_gzipped_equals_true) {
+TEST(FastaqTest, different_gzipped_equals_true)
+{
     Fastaq f1(true, true);
-    f1.add_entry("dummy", "ACGTA", {2, 3, 4, 5, 6}, 40);
+    f1.add_entry("dummy", "ACGTA", { 2, 3, 4, 5, 6 }, 40);
     Fastaq f2(false, true);
-    f2.add_entry("dummy", "ACGTA", {2, 3, 4, 5, 6}, 40);
+    f2.add_entry("dummy", "ACGTA", { 2, 3, 4, 5, 6 }, 40);
     EXPECT_TRUE(f1 == f2);
     EXPECT_TRUE(f2 == f1);
 }
 
-TEST(FastaqTest, different_names_equals_false) {
+TEST(FastaqTest, different_names_equals_false)
+{
     Fastaq f1(false, true);
-    f1.add_entry("dummy", "ACGTA", {2, 3, 4, 5, 6}, 40);
+    f1.add_entry("dummy", "ACGTA", { 2, 3, 4, 5, 6 }, 40);
     Fastaq f2(false, true);
-    f2.add_entry("dummer", "ACGTA", {2, 3, 4, 5, 6}, 40);
+    f2.add_entry("dummer", "ACGTA", { 2, 3, 4, 5, 6 }, 40);
     EXPECT_FALSE(f1 == f2);
     EXPECT_FALSE(f2 == f1);
 }
 
-TEST(FastaqTest, different_num_seqs_equals_false) {
+TEST(FastaqTest, different_num_seqs_equals_false)
+{
     Fastaq f1(false, true);
-    f1.add_entry("dummy", "ACGTA", {2, 3, 4, 5, 6}, 40);
+    f1.add_entry("dummy", "ACGTA", { 2, 3, 4, 5, 6 }, 40);
     Fastaq f2(false, true);
-    f2.add_entry("dummy", "ACGTA", {2, 3, 4, 5, 6}, 40);
-    f2.add_entry("dummer", "ACGTA", {2, 3, 4, 5, 6}, 40);
+    f2.add_entry("dummy", "ACGTA", { 2, 3, 4, 5, 6 }, 40);
+    f2.add_entry("dummer", "ACGTA", { 2, 3, 4, 5, 6 }, 40);
     EXPECT_FALSE(f1 == f2);
     EXPECT_FALSE(f2 == f1);
 }
 
-TEST(FastaqTest, different_seqs_equals_false) {
+TEST(FastaqTest, different_seqs_equals_false)
+{
     Fastaq f1(false, true);
-    f1.add_entry("dummy", "ACGTT", {2, 3, 4, 5, 6}, 40);
+    f1.add_entry("dummy", "ACGTT", { 2, 3, 4, 5, 6 }, 40);
     Fastaq f2(false, true);
-    f2.add_entry("dummy", "ACGTA", {2, 3, 4, 5, 6}, 40);
+    f2.add_entry("dummy", "ACGTA", { 2, 3, 4, 5, 6 }, 40);
     EXPECT_FALSE(f1 == f2);
     EXPECT_FALSE(f2 == f1);
 }
 
-TEST(FastaqTest, different_scores_equals_false) {
+TEST(FastaqTest, different_scores_equals_false)
+{
     Fastaq f1(false, true);
-    f1.add_entry("dummy", "ACGTA", {2, 3, 4, 5, 7}, 40);
+    f1.add_entry("dummy", "ACGTA", { 2, 3, 4, 5, 7 }, 40);
     Fastaq f2(false, true);
-    f2.add_entry("dummy", "ACGTA", {2, 3, 4, 5, 6}, 40);
+    f2.add_entry("dummy", "ACGTA", { 2, 3, 4, 5, 6 }, 40);
     EXPECT_FALSE(f1 == f2);
     EXPECT_FALSE(f2 == f1);
 }
 
-TEST(FastaqTest, same_equals_false) {
+TEST(FastaqTest, same_equals_false)
+{
     Fastaq f1(false, true);
-    f1.add_entry("dummy", "ACGTA", {2, 3, 4, 5, 6}, 40);
+    f1.add_entry("dummy", "ACGTA", { 2, 3, 4, 5, 6 }, 40);
     Fastaq f2(false, true);
-    f2.add_entry("dummy", "ACGTA", {2, 3, 4, 5, 6}, 40);
+    f2.add_entry("dummy", "ACGTA", { 2, 3, 4, 5, 6 }, 40);
     EXPECT_TRUE(f1 == f2);
     EXPECT_TRUE(f2 == f1);
 }
 
-
-TEST(FastaqTest, ostream) {
+TEST(FastaqTest, ostream)
+{
     Fastaq f_out(false, true);
-    f_out.add_entry("dummy", "ACGTA", {2, 3, 4, 5, 6}, 40);
+    f_out.add_entry("dummy", "ACGTA", { 2, 3, 4, 5, 6 }, 40);
 }
 
-TEST(FastaqTest, istream_fq) {
+TEST(FastaqTest, istream_fq)
+{
     Fastaq f_in;
     istringstream is("@dummy\nACGTA\n+\n#$%&'");
     is >> f_in;
 
     EXPECT_TRUE(f_in.fastq);
     EXPECT_FALSE(f_in.gzipped);
-    bool found_name = find(f_in.names.begin(), f_in.names.end(), "dummy") != f_in.names.end();
+    bool found_name
+        = find(f_in.names.begin(), f_in.names.end(), "dummy") != f_in.names.end();
     EXPECT_TRUE(found_name);
     bool added_seq = f_in.sequences.find("dummy") != f_in.sequences.end();
     EXPECT_TRUE(added_seq);
@@ -229,38 +254,42 @@ TEST(FastaqTest, istream_fq) {
     bool added_score = f_in.scores.find("dummy") != f_in.scores.end();
     EXPECT_TRUE(added_score);
     EXPECT_EQ(f_in.scores["dummy"], "#$%&'");
-
 }
 
-TEST(FastaqTest, istream_fa) {
+TEST(FastaqTest, istream_fa)
+{
     Fastaq f_in;
     istringstream is(">dummy\nACGTA\n>dummer\nGTGGC");
     is >> f_in;
 
     EXPECT_FALSE(f_in.fastq);
     EXPECT_FALSE(f_in.gzipped);
-    bool found_name = find(f_in.names.begin(), f_in.names.end(), "dummy") != f_in.names.end();
+    bool found_name
+        = find(f_in.names.begin(), f_in.names.end(), "dummy") != f_in.names.end();
     EXPECT_TRUE(found_name);
     bool added_seq = f_in.sequences.find("dummy") != f_in.sequences.end();
     EXPECT_TRUE(added_seq);
     EXPECT_EQ(f_in.sequences["dummy"], "ACGTA");
     bool added_score = f_in.scores.find("dummy") != f_in.scores.end();
     EXPECT_FALSE(added_score);
-    found_name = find(f_in.names.begin(), f_in.names.end(), "dummer") != f_in.names.end();
+    found_name
+        = find(f_in.names.begin(), f_in.names.end(), "dummer") != f_in.names.end();
     EXPECT_TRUE(found_name);
     added_seq = f_in.sequences.find("dummer") != f_in.sequences.end();
     EXPECT_TRUE(added_seq);
     EXPECT_EQ(f_in.sequences["dummer"], "GTGGC");
 }
 
-TEST(FastaqTest, istream_fa_with_extra_header) {
+TEST(FastaqTest, istream_fa_with_extra_header)
+{
     Fastaq f_in;
     istringstream is(">dummy with header\nACGTA\n>dummer also with header\nGTGGC");
     is >> f_in;
 
     EXPECT_FALSE(f_in.fastq);
     EXPECT_FALSE(f_in.gzipped);
-    bool found_name = find(f_in.names.begin(), f_in.names.end(), "dummy") != f_in.names.end();
+    bool found_name
+        = find(f_in.names.begin(), f_in.names.end(), "dummy") != f_in.names.end();
     EXPECT_TRUE(found_name);
     bool added_seq = f_in.sequences.find("dummy") != f_in.sequences.end();
     EXPECT_TRUE(added_seq);
@@ -270,7 +299,8 @@ TEST(FastaqTest, istream_fa_with_extra_header) {
     bool added_header = f_in.headers.find("dummy") != f_in.headers.end();
     EXPECT_TRUE(added_header);
     EXPECT_EQ(f_in.headers["dummy"], " with header");
-    found_name = find(f_in.names.begin(), f_in.names.end(), "dummer") != f_in.names.end();
+    found_name
+        = find(f_in.names.begin(), f_in.names.end(), "dummer") != f_in.names.end();
     EXPECT_TRUE(found_name);
     added_seq = f_in.sequences.find("dummer") != f_in.sequences.end();
     EXPECT_TRUE(added_seq);
@@ -280,10 +310,10 @@ TEST(FastaqTest, istream_fa_with_extra_header) {
     EXPECT_EQ(f_in.headers["dummer"], " also with header");
 }
 
-
-TEST(FastaqTest, iostream) {
+TEST(FastaqTest, iostream)
+{
     Fastaq f_out(false, true);
-    f_out.add_entry("dummy", "ACGTA", {2, 3, 4, 5, 6}, 40);
+    f_out.add_entry("dummy", "ACGTA", { 2, 3, 4, 5, 6 }, 40);
     Fastaq f_in;
     stringstream out;
     out << f_out;
@@ -291,7 +321,8 @@ TEST(FastaqTest, iostream) {
 
     EXPECT_TRUE(f_in.fastq);
     EXPECT_FALSE(f_in.gzipped);
-    bool found_name = find(f_in.names.begin(), f_in.names.end(), "dummy") != f_in.names.end();
+    bool found_name
+        = find(f_in.names.begin(), f_in.names.end(), "dummy") != f_in.names.end();
     EXPECT_TRUE(found_name);
     bool added_seq = f_in.sequences.find("dummy") != f_in.sequences.end();
     EXPECT_TRUE(added_seq);
@@ -300,4 +331,3 @@ TEST(FastaqTest, iostream) {
     EXPECT_TRUE(added_score);
     EXPECT_EQ(f_in.scores["dummy"], "#$%&'");
 }
-

--- a/test/index_test.cpp
+++ b/test/index_test.cpp
@@ -1,22 +1,22 @@
-#include "gtest/gtest.h"
-#include "minirecord.h"
-#include "prg/path.h"
 #include "index.h"
 #include "interval.h"
 #include "inthash.h"
+#include "minirecord.h"
+#include "prg/path.h"
 #include "utils.h"
-#include <vector>
-#include <stdint.h>
-#include <iostream>
+#include "gtest/gtest.h"
 #include <algorithm>
-
+#include <iostream>
+#include <stdint.h>
+#include <vector>
 
 using namespace std;
 
-TEST(IndexTest, add_record) {
+TEST(IndexTest, add_record)
+{
     Index idx;
     KmerHash hash;
-    deque<Interval> d = {Interval(3, 5), Interval(9, 12)};
+    deque<Interval> d = { Interval(3, 5), Interval(9, 12) };
     prg::Path p;
     p.initialize(d);
     pair<uint64_t, uint64_t> kh = hash.kmerhash("ACGTA", 5);
@@ -41,10 +41,11 @@ TEST(IndexTest, add_record) {
     EXPECT_EQ(j, idx.minhash[min(kh.first, kh.second)]->size());
 }
 
-TEST(IndexTest, clear) {
+TEST(IndexTest, clear)
+{
     Index idx;
     KmerHash hash;
-    deque<Interval> d = {Interval(3, 5), Interval(9, 12)};
+    deque<Interval> d = { Interval(3, 5), Interval(9, 12) };
     prg::Path p;
     p.initialize(d);
     pair<uint64_t, uint64_t> kh = hash.kmerhash("ACGTA", 5);
@@ -58,10 +59,11 @@ TEST(IndexTest, clear) {
     EXPECT_EQ(j, idx.minhash.size());
 }
 
-TEST(IndexTest, save) {
+TEST(IndexTest, save)
+{
     Index idx;
     KmerHash hash;
-    deque<Interval> d = {Interval(3, 5), Interval(9, 12)};
+    deque<Interval> d = { Interval(3, 5), Interval(9, 12) };
     prg::Path p;
     p.initialize(d);
     pair<uint64_t, uint64_t> kh = hash.kmerhash("ACGTA", 5);
@@ -74,10 +76,11 @@ TEST(IndexTest, save) {
     ASSERT_TRUE(fopen("indextext.k5.w1.idx", "r") != NULL);
 }
 
-TEST(IndexTest, load) {
+TEST(IndexTest, load)
+{
     Index idx1, idx2;
     KmerHash hash;
-    deque<Interval> d = {Interval(3, 5), Interval(9, 12)};
+    deque<Interval> d = { Interval(3, 5), Interval(9, 12) };
     prg::Path p;
     p.initialize(d);
     pair<uint64_t, uint64_t> kh1 = hash.kmerhash("ACGTA", 5);
@@ -88,17 +91,23 @@ TEST(IndexTest, load) {
 
     idx2.load("indextext", 1, 5);
     EXPECT_EQ(idx1.minhash.size(), idx2.minhash.size());
-    EXPECT_EQ(idx1.minhash[min(kh1.first, kh1.second)]->size(), idx2.minhash[min(kh1.first, kh1.second)]->size());
-    EXPECT_EQ(idx1.minhash[min(kh2.first, kh2.second)]->size(), idx2.minhash[min(kh2.first, kh2.second)]->size());
-    EXPECT_EQ(idx1.minhash[min(kh1.first, kh1.second)]->at(0), idx2.minhash[min(kh1.first, kh1.second)]->at(0));
-    EXPECT_EQ(idx1.minhash[min(kh1.first, kh1.second)]->at(1), idx2.minhash[min(kh1.first, kh1.second)]->at(1));
-    EXPECT_EQ(idx1.minhash[min(kh2.first, kh2.second)]->at(0), idx2.minhash[min(kh2.first, kh2.second)]->at(0));
+    EXPECT_EQ(idx1.minhash[min(kh1.first, kh1.second)]->size(),
+        idx2.minhash[min(kh1.first, kh1.second)]->size());
+    EXPECT_EQ(idx1.minhash[min(kh2.first, kh2.second)]->size(),
+        idx2.minhash[min(kh2.first, kh2.second)]->size());
+    EXPECT_EQ(idx1.minhash[min(kh1.first, kh1.second)]->at(0),
+        idx2.minhash[min(kh1.first, kh1.second)]->at(0));
+    EXPECT_EQ(idx1.minhash[min(kh1.first, kh1.second)]->at(1),
+        idx2.minhash[min(kh1.first, kh1.second)]->at(1));
+    EXPECT_EQ(idx1.minhash[min(kh2.first, kh2.second)]->at(0),
+        idx2.minhash[min(kh2.first, kh2.second)]->at(0));
 }
 
-TEST(IndexTest, equals) {
+TEST(IndexTest, equals)
+{
     Index idx1, idx2;
     KmerHash hash;
-    deque<Interval> d = {Interval(3, 5), Interval(9, 12)};
+    deque<Interval> d = { Interval(3, 5), Interval(9, 12) };
     prg::Path p;
     p.initialize(d);
     pair<uint64_t, uint64_t> kh1 = hash.kmerhash("ACGTA", 5);
@@ -112,17 +121,18 @@ TEST(IndexTest, equals) {
     EXPECT_EQ(idx2, idx1);
 }
 
-TEST(IndexTest, equals_fails) {
+TEST(IndexTest, equals_fails)
+{
     Index idx1, idx2;
     KmerHash hash;
-    deque<Interval> d = {Interval(3, 5), Interval(9, 12)};
+    deque<Interval> d = { Interval(3, 5), Interval(9, 12) };
     prg::Path p;
     p.initialize(d);
     pair<uint64_t, uint64_t> kh1 = hash.kmerhash("ACGTA", 5);
-    //idx1.add_record(min(kh1.first, kh1.second), 1, p, 0, 0);
+    // idx1.add_record(min(kh1.first, kh1.second), 1, p, 0, 0);
     pair<uint64_t, uint64_t> kh2 = hash.kmerhash("ACTGA", 5);
     idx1.add_record(min(kh2.first, kh2.second), 2, p, 0, 0);
-    //idx1.add_record(min(kh1.first, kh1.second), 4, p, 0, 0);
+    // idx1.add_record(min(kh1.first, kh1.second), 4, p, 0, 0);
 
     idx2.load("indextext", 1, 5);
     EXPECT_NE(idx1, idx2);
@@ -137,8 +147,9 @@ TEST(IndexTest, equals_fails) {
     EXPECT_NE(idx2, idx1);
 }
 
-TEST(IndexTest, merging_indexes) {
-    uint32_t w=2,k=3;
+TEST(IndexTest, merging_indexes)
+{
+    uint32_t w = 2, k = 3;
     std::vector<std::shared_ptr<LocalPRG>> prgs;
     auto index = std::make_shared<Index>();
     auto outdir = "../../test/test_cases/kgs/";
@@ -153,14 +164,13 @@ TEST(IndexTest, merging_indexes) {
     index_prgs(prgs, index, w, k, outdir);
     index->save("../../test/test_cases/prg2.fa.idx");
 
-
     prgs.clear();
     index->clear();
     read_prg_file(prgs, "../../test/test_cases/prg3.fa", 3);
     index_prgs(prgs, index, w, k, outdir);
     index->save("../../test/test_cases/prg3.fa.idx");
 
-    //merge
+    // merge
     auto index_merged = std::make_shared<Index>();
     index_merged->load("../../test/test_cases/prg1.fa.idx");
     index_merged->load("../../test/test_cases/prg2.fa.idx");

--- a/test/interval_test.cpp
+++ b/test/interval_test.cpp
@@ -1,10 +1,10 @@
-#include "gtest/gtest.h"
-#include <stdint.h>
-#include <iostream>
 #include "interval.h"
+#include "gtest/gtest.h"
+#include <iostream>
+#include <stdint.h>
 
-
-TEST(IntervalTest, create) {
+TEST(IntervalTest, create)
+{
     Interval i(0, 0);
     uint32_t j = 0;
     EXPECT_EQ(i.start, j);
@@ -25,14 +25,16 @@ TEST(IntervalTest, create) {
     EXPECT_DEATH(Interval(-1, 10), "");
 }
 
-TEST(IntervalTest, write) {
+TEST(IntervalTest, write)
+{
     Interval i(1, 5);
     std::stringstream out;
     out << i;
     EXPECT_EQ(out.str(), "[1, 5)");
 }
 
-TEST(IntervalTest, read) {
+TEST(IntervalTest, read)
+{
     Interval i(1, 5);
     std::stringstream out;
     out << i;
@@ -41,7 +43,8 @@ TEST(IntervalTest, read) {
     EXPECT_EQ(i, j);
 }
 
-TEST(IntervalTest, equals) {
+TEST(IntervalTest, equals)
+{
     Interval i(1, 5);
     Interval j(1, 5);
     EXPECT_EQ(i, j);
@@ -60,7 +63,8 @@ TEST(IntervalTest, equals) {
     EXPECT_EQ(j, j);
 }
 
-TEST(IntervalTest, notequals) {
+TEST(IntervalTest, notequals)
+{
     Interval i(1, 5);
     Interval j(1, 5);
     EXPECT_EQ((i != j), false);
@@ -80,7 +84,8 @@ TEST(IntervalTest, notequals) {
     EXPECT_NE(j, i);
 }
 
-TEST(IntervalTest, lessthan) {
+TEST(IntervalTest, lessthan)
+{
     Interval i(1, 5);
     Interval j(2, 5);
     Interval k(0, 4);
@@ -104,14 +109,16 @@ TEST(IntervalTest, lessthan) {
     EXPECT_EQ((j < l), false);
 }
 
-TEST(intervalEmptyTest, emptyIntervalReturnsTrue) {
-    const Interval empty_interval{};
+TEST(intervalEmptyTest, emptyIntervalReturnsTrue)
+{
+    const Interval empty_interval {};
 
     EXPECT_TRUE(empty_interval.empty());
 }
 
-TEST(intervalEmptyTest, nonEmptyIntervalReturnsFalse) {
-    const Interval non_empty_interval{1, 4};
+TEST(intervalEmptyTest, nonEmptyIntervalReturnsFalse)
+{
+    const Interval non_empty_interval { 1, 4 };
 
     EXPECT_FALSE(non_empty_interval.empty());
 }

--- a/test/inthash_test.cpp
+++ b/test/inthash_test.cpp
@@ -1,23 +1,20 @@
-#include "gtest/gtest.h"
 #include "inthash.h"
-#include <iostream>
-#include <cstring>
-#include <string>
-#include <set>
-#include <vector>
-#include <cmath>
+#include "gtest/gtest.h"
 #include <algorithm>
-#include <stdint.h>
+#include <cmath>
+#include <cstring>
 #include <iostream>
-
+#include <set>
+#include <stdint.h>
+#include <string>
+#include <vector>
 
 using namespace std;
 
-TEST(InthashTest, checkCharToInt) {
-    test_table();
-}
+TEST(InthashTest, checkCharToInt) { test_table(); }
 
-set<string> generate_kmers(vector<string> v, uint32_t k) {
+set<string> generate_kmers(vector<string> v, uint32_t k)
+{
     set<string> current_strings, new_strings;
     if (k >= 1) {
         for (uint32_t j = 0; j < 4; j++) {
@@ -29,7 +26,8 @@ set<string> generate_kmers(vector<string> v, uint32_t k) {
 
     uint32_t n = 1;
     while (n < k) {
-        for (set<string>::iterator it = current_strings.begin(); it != current_strings.end(); ++it) {
+        for (set<string>::iterator it = current_strings.begin();
+             it != current_strings.end(); ++it) {
             for (uint32_t j = 0; j < 4; j++) {
                 new_strings.insert(*it + v[j]);
             }
@@ -41,13 +39,14 @@ set<string> generate_kmers(vector<string> v, uint32_t k) {
     return current_strings;
 }
 
-TEST(InthashTest, check1to1) {
-    vector<uint32_t> ks = {3, 5};
+TEST(InthashTest, check1to1)
+{
+    vector<uint32_t> ks = { 3, 5 };
     KmerHash hash;
     for (vector<uint32_t>::iterator jt = ks.begin(); jt != ks.end(); ++jt) {
         uint32_t k = *jt;
         // generate kmers for a given k
-        vector<string> dna = {"A", "G", "T", "C"};
+        vector<string> dna = { "A", "G", "T", "C" };
         set<string> kmers = generate_kmers(dna, k);
         // generate inthash of each kmer and assert it is different to the previous ones
         vector<uint64_t> khs, khs1, khs2;
@@ -59,13 +58,18 @@ TEST(InthashTest, check1to1) {
             khs.push_back(kh.first); // so each kmerhash value is first in one
 
             // don't expect any kmerhash value to be in more than 2 pairs
-            EXPECT_EQ((find(khs2.begin(), khs2.end(), min(kh.first, kh.second)) == khs2.end()), true);
-            if (find(khs1.begin(), khs1.end(), min(kh.first, kh.second)) != khs1.end()) {
-                khs2.push_back(min(kh.first, kh.second)); // if we found it as min once before, add to things seen twice
+            EXPECT_EQ((find(khs2.begin(), khs2.end(), min(kh.first, kh.second))
+                          == khs2.end()),
+                true);
+            if (find(khs1.begin(), khs1.end(), min(kh.first, kh.second))
+                != khs1.end()) {
+                khs2.push_back(
+                    min(kh.first, kh.second)); // if we found it as min once before, add
+                                               // to things seen twice
             } else {
-                khs1.push_back(min(kh.first, kh.second)); // otherwise, add to list seen once
+                khs1.push_back(
+                    min(kh.first, kh.second)); // otherwise, add to list seen once
             }
         }
     }
 }
-

--- a/test/kmergraph_test.cpp
+++ b/test/kmergraph_test.cpp
@@ -1,24 +1,24 @@
-#include "gtest/gtest.h"
 #include "test_macro.cpp"
+#include "gtest/gtest.h"
 
 #include "interval.h"
-#include "prg/path.h"
 #include "kmergraph.h"
 #include "kmernode.h"
 #include "localPRG.h"
-#include <stdint.h>
-#include <iostream>
+#include "prg/path.h"
 #include <cmath>
-
+#include <iostream>
+#include <stdint.h>
 
 using namespace prg;
 
-TEST(KmerGraphTest, add_node) {
+TEST(KmerGraphTest, add_node)
+{
     // add node and check it's there
     KmerGraph kg;
     uint32_t sample_id = 0;
 
-    deque<Interval> d = {Interval(0, 3)};
+    deque<Interval> d = { Interval(0, 3) };
     prg::Path p;
     p.initialize(d);
     kg.add_node(p);
@@ -39,7 +39,7 @@ TEST(KmerGraphTest, add_node) {
     EXPECT_EQ(j, kg.nodes[0]->num_AT);
 
     // add a second node and check gets next id
-    d = {Interval(1, 4)};
+    d = { Interval(1, 4) };
     p.initialize(d);
     kg.add_node(p);
     j = 2;
@@ -52,12 +52,13 @@ TEST(KmerGraphTest, add_node) {
     EXPECT_EQ(j, kg.nodes[1]->id);
 }
 
-TEST(KmerGraphTest, add_node_with_kh) {
+TEST(KmerGraphTest, add_node_with_kh)
+{
     // add node and check it's there
     KmerGraph kg;
     uint32_t sample_id = 0;
 
-    deque<Interval> d = {Interval(0, 3)};
+    deque<Interval> d = { Interval(0, 3) };
     prg::Path p;
     p.initialize(d);
     uint64_t kh = 469;
@@ -72,15 +73,16 @@ TEST(KmerGraphTest, add_node_with_kh) {
     EXPECT_EQ(kh, kg.nodes[0]->khash);
 }
 
-TEST(KmerGraphTest, add_edge) {
+TEST(KmerGraphTest, add_edge)
+{
     // add edge and check it's there
     KmerGraph kg;
 
-    deque<Interval> d = {Interval(0, 3)};
+    deque<Interval> d = { Interval(0, 3) };
     prg::Path p1, p2, p3;
     p1.initialize(d);
     auto n1 = kg.add_node(p1);
-    d = {Interval(1, 4)};
+    d = { Interval(1, 4) };
     p2.initialize(d);
     auto n2 = kg.add_node(p2);
     uint j = 2;
@@ -89,7 +91,7 @@ TEST(KmerGraphTest, add_edge) {
     kg.add_edge(n1, n2);
     kg.add_edge(n1, n2);
 
-    d = {Interval(4, 7)};
+    d = { Interval(4, 7) };
     p3.initialize(d);
     auto n3 = kg.add_node(p3);
     kg.add_edge(n1, n3);
@@ -114,13 +116,14 @@ TEST(KmerGraphTest, add_edge) {
     EXPECT_EQ(j, kg.nodes[0]->in_nodes.size());
 }
 
-TEST(KmerGraphTest, clear) {
+TEST(KmerGraphTest, clear)
+{
     KmerGraph kg;
-    deque<Interval> d = {Interval(0, 3)};
+    deque<Interval> d = { Interval(0, 3) };
     prg::Path p1, p2;
     p1.initialize(d);
     auto n1 = kg.add_node(p1);
-    d = {Interval(1, 4)};
+    d = { Interval(1, 4) };
     p2.initialize(d);
     auto n2 = kg.add_node(p2);
     kg.add_edge(n1, n2);
@@ -138,21 +141,22 @@ TEST(KmerGraphTest, clear) {
     EXPECT_EQ(j, kg.nodes.size());
 }
 
-TEST(KmerGraphTest, equals) {
+TEST(KmerGraphTest, equals)
+{
     KmerGraph kg1, kg2;
-    deque<Interval> d = {Interval(0, 3)};
+    deque<Interval> d = { Interval(0, 3) };
     prg::Path p1, p2, p3;
     p1.initialize(d);
     auto n1 = kg1.add_node(p1);
     auto m1 = kg2.add_node(p1);
-    d = {Interval(1, 4)};
+    d = { Interval(1, 4) };
     p2.initialize(d);
     auto n2 = kg1.add_node(p2);
     auto m2 = kg2.add_node(p2);
     kg1.add_edge(n1, n2);
     kg2.add_edge(m1, m2);
 
-    d = {Interval(2, 5)};
+    d = { Interval(2, 5) };
     p3.initialize(d);
     auto m3 = kg2.add_node(p3);
 
@@ -180,13 +184,14 @@ TEST(KmerGraphTest, equals) {
     EXPECT_EQ((kg2 == kg1), false);
 }
 
-TEST(KmerGraphTest, copy) {
+TEST(KmerGraphTest, copy)
+{
     KmerGraph kg1;
-    deque<Interval> d = {Interval(0, 3)};
+    deque<Interval> d = { Interval(0, 3) };
     prg::Path p1, p2, p3;
     p1.initialize(d);
     auto n1 = kg1.add_node(p1);
-    d = {Interval(1, 4)};
+    d = { Interval(1, 4) };
     p2.initialize(d);
     auto n2 = kg1.add_node(p2);
     kg1.add_edge(n1, n2);
@@ -197,29 +202,30 @@ TEST(KmerGraphTest, copy) {
     EXPECT_EQ(kg2, kg2);
 }
 
-TEST(KmerGraphTest, assign) {
+TEST(KmerGraphTest, assign)
+{
     KmerGraph kg1;
-    std::deque<Interval> d = {Interval(0, 0)};
+    std::deque<Interval> d = { Interval(0, 0) };
     prg::Path p;
     p.initialize(d);
     auto n = kg1.add_node(p);
-    d = {Interval(0, 3)};
+    d = { Interval(0, 3) };
     prg::Path p1, p2, p3;
     p1.initialize(d);
     auto n1 = kg1.add_node(p1);
-    d = {Interval(1, 4)};
+    d = { Interval(1, 4) };
     p2.initialize(d);
     auto n2 = kg1.add_node(p2);
     kg1.add_edge(n1, n2);
-    d = {Interval(11, 14)};
+    d = { Interval(11, 14) };
     p3.initialize(d);
     auto n3 = kg1.add_node(p3);
     kg1.add_edge(n1, n3);
-    d = {Interval(15, 18)};
+    d = { Interval(15, 18) };
     p1.initialize(d);
     n1 = kg1.add_node(p1);
     kg1.add_edge(n2, n1);
-    d = {Interval(20, 20)};
+    d = { Interval(20, 20) };
     p.initialize(d);
     n = kg1.add_node(p);
     kg1.add_edge(n1, n);
@@ -231,37 +237,38 @@ TEST(KmerGraphTest, assign) {
     EXPECT_EQ(kg2, kg2);
 }
 
-TEST(KmerGraphTest, sort_topologically) {
+TEST(KmerGraphTest, sort_topologically)
+{
     vector<KmerNodePtr> exp_sorted_nodes;
     KmerNodePtr n;
 
     KmerGraph kg;
-    std::deque<Interval> d = {Interval(0, 0)};
+    std::deque<Interval> d = { Interval(0, 0) };
     prg::Path p;
     p.initialize(d);
     n = kg.add_node(p);
     exp_sorted_nodes.push_back(n);
-    d = {Interval(0, 1), Interval(4, 5), Interval(8, 9)};
+    d = { Interval(0, 1), Interval(4, 5), Interval(8, 9) };
     p.initialize(d);
     n = kg.add_node(p);
     exp_sorted_nodes.push_back(n);
-    d = {Interval(0, 1), Interval(4, 5), Interval(12, 13)};
+    d = { Interval(0, 1), Interval(4, 5), Interval(12, 13) };
     p.initialize(d);
     n = kg.add_node(p);
     exp_sorted_nodes.push_back(n);
-    d = {Interval(0, 1), Interval(19, 20), Interval(23, 24)};
+    d = { Interval(0, 1), Interval(19, 20), Interval(23, 24) };
     p.initialize(d);
     n = kg.add_node(p);
     exp_sorted_nodes.push_back(n);
-    d = {Interval(4, 5), Interval(8, 9), Interval(16, 16), Interval(23, 24)};
+    d = { Interval(4, 5), Interval(8, 9), Interval(16, 16), Interval(23, 24) };
     p.initialize(d);
     n = kg.add_node(p);
     exp_sorted_nodes.push_back(n);
-    d = {Interval(4, 5), Interval(12, 13), Interval(16, 16), Interval(23, 24)};
+    d = { Interval(4, 5), Interval(12, 13), Interval(16, 16), Interval(23, 24) };
     p.initialize(d);
     n = kg.add_node(p);
     exp_sorted_nodes.push_back(n);
-    d = {Interval(24, 24)};
+    d = { Interval(24, 24) };
     p.initialize(d);
     n = kg.add_node(p);
     exp_sorted_nodes.push_back(n);
@@ -279,7 +286,7 @@ TEST(KmerGraphTest, sort_topologically) {
     set<KmerNodePtr>::iterator it;
     uint i = 0;
     for (auto c = kg.sorted_nodes.begin(); c != kg.sorted_nodes.end(); ++c) {
-        for (const auto &d: (*c)->out_nodes) {
+        for (const auto& d : (*c)->out_nodes) {
             it = c;
             ++it;
             while ((*it)->path != d.lock()->path and it != kg.sorted_nodes.end()) {
@@ -292,28 +299,29 @@ TEST(KmerGraphTest, sort_topologically) {
     }
 }
 
-TEST(KmerGraphTest, check) {
+TEST(KmerGraphTest, check)
+{
     KmerGraph kg;
-    std::deque<Interval> d = {Interval(0, 0)};
+    std::deque<Interval> d = { Interval(0, 0) };
     prg::Path p;
     p.initialize(d);
     kg.add_node(p);
-    d = {Interval(0, 1), Interval(4, 5), Interval(8, 9)};
+    d = { Interval(0, 1), Interval(4, 5), Interval(8, 9) };
     p.initialize(d);
     kg.add_node(p);
-    d = {Interval(0, 1), Interval(4, 5), Interval(12, 13)};
+    d = { Interval(0, 1), Interval(4, 5), Interval(12, 13) };
     p.initialize(d);
     kg.add_node(p);
-    d = {Interval(0, 1), Interval(19, 20), Interval(23, 24)};
+    d = { Interval(0, 1), Interval(19, 20), Interval(23, 24) };
     p.initialize(d);
     kg.add_node(p);
-    d = {Interval(4, 5), Interval(8, 9), Interval(16, 16), Interval(23, 24)};
+    d = { Interval(4, 5), Interval(8, 9), Interval(16, 16), Interval(23, 24) };
     p.initialize(d);
     kg.add_node(p);
-    d = {Interval(4, 5), Interval(12, 13), Interval(16, 16), Interval(23, 24)};
+    d = { Interval(4, 5), Interval(12, 13), Interval(16, 16), Interval(23, 24) };
     p.initialize(d);
     kg.add_node(p);
-    d = {Interval(24, 24)};
+    d = { Interval(24, 24) };
     p.initialize(d);
     kg.add_node(p);
 
@@ -326,80 +334,116 @@ TEST(KmerGraphTest, check) {
     kg.add_edge(kg.nodes[4], kg.nodes[6]);
     kg.add_edge(kg.nodes[5], kg.nodes[6]);
 
-    kg.sorted_nodes = {kg.nodes[0], kg.nodes[1], kg.nodes[2], kg.nodes[3], kg.nodes[4], kg.nodes[5], kg.nodes[6]};
+    kg.sorted_nodes = { kg.nodes[0], kg.nodes[1], kg.nodes[2], kg.nodes[3], kg.nodes[4],
+        kg.nodes[5], kg.nodes[6] };
     kg.check();
-    kg.sorted_nodes = {kg.nodes[0], kg.nodes[1], kg.nodes[4], kg.nodes[3], kg.nodes[2], kg.nodes[5], kg.nodes[6]};
+    kg.sorted_nodes = { kg.nodes[0], kg.nodes[1], kg.nodes[4], kg.nodes[3], kg.nodes[2],
+        kg.nodes[5], kg.nodes[6] };
     kg.check();
-    kg.sorted_nodes = {kg.nodes[6], kg.nodes[5], kg.nodes[0], kg.nodes[3], kg.nodes[2], kg.nodes[1], kg.nodes[4]};
-    //There is no way to expect death here since kg.sorted_nodes are always sorted now
-    //EXPECT_DEATH(kg.check(), "");
+    kg.sorted_nodes = { kg.nodes[6], kg.nodes[5], kg.nodes[0], kg.nodes[3], kg.nodes[2],
+        kg.nodes[1], kg.nodes[4] };
+    // There is no way to expect death here since kg.sorted_nodes are always sorted now
+    // EXPECT_DEATH(kg.check(), "");
     kg.check();
 }
 
-TEST(KmerGraphTest, remove_shortcut_edges){
+TEST(KmerGraphTest, remove_shortcut_edges)
+{
     auto index = std::make_shared<Index>();
-    uint32_t w=14,k=15;
+    uint32_t w = 14, k = 15;
 
-    auto s = " 5 CATGCGCCAGGGCGCCAATCATGCGGGCGCTCATCAGGGCGAACATCGAATAAGACCGGGTTGCGGCGAGGCAGGAAAACGCGAGGATCAGCATCAGCCCGACCAGCAGCGCCTTGCGGGAAATACGCGCCGGCATTGCGCCGGAAAGCAGAGCCGCCAGGGCGCCTACCCAGCCATAGGCGGTGACGGCGAGGCCCACGCCGGATTCCGTCTGGTGAAAATCCGCCGCCAGGGCGTTGAGCATGCCCACCGGCGCCAGTTCGCTGGTGACGATCGAAAAGGCGCAGATCCCGAGCGCAACGACGGCAGTCCAGACGCGCGCCGGCGCCGGGTGGAGGGGTAAAGCAATCTCTTTCAT 6  6  7  8 AAAGGCGCAGATCCCGAGTGCAACGACGGCTATCCAGACGCGCGCCGGCGCCGGGTGGAGGGGTAA 7 AGCAATCTCTTTCAT 5 ATCAGGC 9 C 10 G 9 TATCCTTAGGAAAGG 11 T 12 A 11 GCGTTCCG 13  15 T 16 C 15 GCGGTGCACG 17 A 18 G 17  14  19 CA 20 CG 19 CGGTACACGG 13 ACGTTCAGGTGA 21  23 T 24 G 23 GAGAGAGCAG 25 GCGACCG 26 GCGACCA 26 ACGACCA 26 GCGATCG 25  22 GGAGAGCACAGGCGATCG 22 GGAGAGAGCAAGCGACCG 22 GGGGAGAGCAGGTGACCG 21 GATGGCCTG 27 T 28 G 27 TTGTCTCCG 29  31 CGAA 32 TGAG 32 CGAG 31 TGGCGTGCAGTATCATCCC 33 TT 34 TG 34 CG 33 CAAAATTGATAAAAAAGAGC 35 A 36 G 35 GAAAACGGAG 37 AGCTG 38 GGCCG 38 AGCTA 38 AGCCG 38 ATCCG 37 TTTTCCATA 39  41 AAC 42 CAT 42 AAT 41 GGAAAAGAG 40  43 T 44 A 44 C 43 ATGGAAAATAG 39  30  45 CGAA 46 CGAG 45 TGGCGTGCAGTATCATCCCTGCGAAA 47 A 48 C 47 TGATAAAAAAGAGCGGAAAACGGAG 49 AGCT 50 AGCC 50 AGTC 50 GGCC 49 GTTTTCCATA 51 T 52 A 52 C 51 ATGGAAAA 53 TAG 54 GAG 53  30  55  57 CA 58 CG 57 AGTGGCGTG 59 T 60 C 59  56 CAAGTGGTGTGC 55 AGTATCATCCCTG 61 T 62 C 61 GAAACTGA 63 T 64 A 63 AAAAAATAGCGGAAAACGGA 65 GAGT 66 TAGC 65 CGTTTTCCATAAATGGAAAACAG 30 CGAGTGGCGTGCAGTATCATCCCTGCGAAAATGATAAAAAAGAGTGGAAAACGGATAGCCGTTTTCCATAAATGGAAAA 67 TAG 68 CAG 67  30  69 CGAA 70 CGAG 69 TGGCGTGCAGTA 30  71 CGAATGGC 72 CGAGTGGT 72 CGAGTGGC 71 GTGCAGTATCATCCCTGCGAAACTGATAAAAAAGAGC 73 A 74 G 73 GAAAACGGAGAGCCGTTTTCCATAAA 75 T 76 C 75 GGAAAAGAG 29 ";
+    auto s
+        = " 5 "
+          "CATGCGCCAGGGCGCCAATCATGCGGGCGCTCATCAGGGCGAACATCGAATAAGACCGGGTTGCGGCGAGGCAGGA"
+          "AAACGCGAGGATCAGCATCAGCCCGACCAGCAGCGCCTTGCGGGAAATACGCGCCGGCATTGCGCCGGAAAGCAGA"
+          "GCCGCCAGGGCGCCTACCCAGCCATAGGCGGTGACGGCGAGGCCCACGCCGGATTCCGTCTGGTGAAAATCCGCCG"
+          "CCAGGGCGTTGAGCATGCCCACCGGCGCCAGTTCGCTGGTGACGATCGAAAAGGCGCAGATCCCGAGCGCAACGAC"
+          "GGCAGTCCAGACGCGCGCCGGCGCCGGGTGGAGGGGTAAAGCAATCTCTTTCAT 6  6  7  8 "
+          "AAAGGCGCAGATCCCGAGTGCAACGACGGCTATCCAGACGCGCGCCGGCGCCGGGTGGAGGGGTAA 7 "
+          "AGCAATCTCTTTCAT 5 ATCAGGC 9 C 10 G 9 TATCCTTAGGAAAGG 11 T 12 A 11 GCGTTCCG "
+          "13  15 T 16 C 15 GCGGTGCACG 17 A 18 G 17  14  19 CA 20 CG 19 CGGTACACGG 13 "
+          "ACGTTCAGGTGA 21  23 T 24 G 23 GAGAGAGCAG 25 GCGACCG 26 GCGACCA 26 ACGACCA "
+          "26 GCGATCG 25  22 GGAGAGCACAGGCGATCG 22 GGAGAGAGCAAGCGACCG 22 "
+          "GGGGAGAGCAGGTGACCG 21 GATGGCCTG 27 T 28 G 27 TTGTCTCCG 29  31 CGAA 32 TGAG "
+          "32 CGAG 31 TGGCGTGCAGTATCATCCC 33 TT 34 TG 34 CG 33 CAAAATTGATAAAAAAGAGC 35 "
+          "A 36 G 35 GAAAACGGAG 37 AGCTG 38 GGCCG 38 AGCTA 38 AGCCG 38 ATCCG 37 "
+          "TTTTCCATA 39  41 AAC 42 CAT 42 AAT 41 GGAAAAGAG 40  43 T 44 A 44 C 43 "
+          "ATGGAAAATAG 39  30  45 CGAA 46 CGAG 45 TGGCGTGCAGTATCATCCCTGCGAAA 47 A 48 C "
+          "47 TGATAAAAAAGAGCGGAAAACGGAG 49 AGCT 50 AGCC 50 AGTC 50 GGCC 49 GTTTTCCATA "
+          "51 T 52 A 52 C 51 ATGGAAAA 53 TAG 54 GAG 53  30  55  57 CA 58 CG 57 "
+          "AGTGGCGTG 59 T 60 C 59  56 CAAGTGGTGTGC 55 AGTATCATCCCTG 61 T 62 C 61 "
+          "GAAACTGA 63 T 64 A 63 AAAAAATAGCGGAAAACGGA 65 GAGT 66 TAGC 65 "
+          "CGTTTTCCATAAATGGAAAACAG 30 "
+          "CGAGTGGCGTGCAGTATCATCCCTGCGAAAATGATAAAAAAGAGTGGAAAACGGATAGCCGTTTTCCATAAATGGA"
+          "AAA 67 TAG 68 CAG 67  30  69 CGAA 70 CGAG 69 TGGCGTGCAGTA 30  71 CGAATGGC "
+          "72 CGAGTGGT 72 CGAGTGGC 71 GTGCAGTATCATCCCTGCGAAACTGATAAAAAAGAGC 73 A 74 G "
+          "73 GAAAACGGAGAGCCGTTTTCCATAAA 75 T 76 C 75 GGAAAAGAG 29 ";
     auto l1 = std::make_shared<LocalPRG>(LocalPRG(1, "Cluster_6369", s));
     l1->minimizer_sketch(index, w, k);
 
-    s = "TTATAAAGTTCTGCAAATGGCGCCATCAAAGCGCCATTGACAGAGTTTTATTTCAATCACCTTTTTCGAGGTATCAAAAATCACGGGGTTTTAATCCCTTCCTCCAATAAGTACCAGTTTAATATTCTGAATGCCCGTCACGGGGCAACATAACCACAGAGCCTTGCGGGGTGGGTCTATGGGGTAGGCAGTAATGCTTTCACTCTGTGGGCTGCTTTTATCCGCGTGAACTTAGGCTCACCACCGAAAGGAAAAGCA";
+    s = "TTATAAAGTTCTGCAAATGGCGCCATCAAAGCGCCATTGACAGAGTTTTATTTCAATCACCTTTTTCGAGGTATCAAA"
+        "AATCACGGGGTTTTAATCCCTTCCTCCAATAAGTACCAGTTTAATATTCTGAATGCCCGTCACGGGGCAACATAACCA"
+        "CAGAGCCTTGCGGGGTGGGTCTATGGGGTAGGCAGTAATGCTTTCACTCTGTGGGCTGCTTTTATCCGCGTGAACTTA"
+        "GGCTCACCACCGAAAGGAAAAGCA";
     auto l2 = std::make_shared<LocalPRG>(LocalPRG(1, "Cluster_15213", s));
     l2->minimizer_sketch(index, w, k);
 }
 
-TEST(KmerGraphTest, save) {
+TEST(KmerGraphTest, save)
+{
     auto l = std::make_shared<LocalPRG>(LocalPRG(1, "test localPRG", "ACGT"));
 
     KmerGraph kg;
-    deque<Interval> d = {Interval(0, 3)};
+    deque<Interval> d = { Interval(0, 3) };
     prg::Path p1, p2;
     p1.initialize(d);
     auto n1 = kg.add_node(p1);
-    d = {Interval(1, 4)};
+    d = { Interval(1, 4) };
     p2.initialize(d);
     auto n2 = kg.add_node(p2);
     kg.add_edge(n1, n2);
-    EXPECT_EQ((uint) 0, kg.nodes[0]->num_AT);
+    EXPECT_EQ((uint)0, kg.nodes[0]->num_AT);
 
-    //kg.save("../test/test_cases/kmergraph_test.gfa");
+    // kg.save("../test/test_cases/kmergraph_test.gfa");
     kg.save("kmergraph_test.gfa", l);
 }
 
-TEST(KmerGraphTest, save_no_prg) {
+TEST(KmerGraphTest, save_no_prg)
+{
     KmerGraph kg;
-    deque<Interval> d = {Interval(0, 3)};
+    deque<Interval> d = { Interval(0, 3) };
     prg::Path p1, p2;
     p1.initialize(d);
     auto n1 = kg.add_node(p1);
-    d = {Interval(1, 4)};
+    d = { Interval(1, 4) };
     p2.initialize(d);
     auto n2 = kg.add_node(p2);
     kg.add_edge(n1, n2);
-    EXPECT_EQ((uint) 0, kg.nodes[0]->num_AT);
+    EXPECT_EQ((uint)0, kg.nodes[0]->num_AT);
 
-    //kg.save("../test/test_cases/kmergraph_test.gfa");
+    // kg.save("../test/test_cases/kmergraph_test.gfa");
     kg.save("kmergraph_test2.gfa");
 }
 
-TEST(KmerGraphTest, load) {
+TEST(KmerGraphTest, load)
+{
     KmerGraph kg, read_kg;
-    deque<Interval> d = {Interval(0, 3)};
+    deque<Interval> d = { Interval(0, 3) };
     prg::Path p1, p2;
     p1.initialize(d);
     auto n1 = kg.add_node(p1);
-    d = {Interval(1, 4)};
+    d = { Interval(1, 4) };
     p2.initialize(d);
     auto n2 = kg.add_node(p2);
     kg.add_edge(n1, n2);
 
-    //read_kg.load("../test/test_cases/kmergraph_test.gfa");
+    // read_kg.load("../test/test_cases/kmergraph_test.gfa");
     read_kg.load("kmergraph_test2.gfa");
     EXPECT_EQ(kg, read_kg);
 }
 
-TEST(KmerGraphTest, load_prg) {
+TEST(KmerGraphTest, load_prg)
+{
     KmerGraph read_kg;
     EXPECT_DEATH(read_kg.load("kmergraph_test.gfa"), "");
 }

--- a/test/kmergraphwithcoverage_test.cpp
+++ b/test/kmergraphwithcoverage_test.cpp
@@ -1,33 +1,33 @@
-#include "gtest/gtest.h"
 #include "test_macro.cpp"
+#include "gtest/gtest.h"
 
 #include "interval.h"
-#include "prg/path.h"
 #include "kmergraphwithcoverage.h"
 #include "kmernode.h"
 #include "localPRG.h"
-#include <stdint.h>
-#include <iostream>
+#include "prg/path.h"
 #include <cmath>
 #include <cstdint>
+#include <iostream>
+#include <stdint.h>
 
 using namespace prg;
 
-
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-//helper functions - used inside the tests to simplify them, and help with their readability and understanding
-//e.g. inside a test, it is better for a reader to read one line:
-//KmerGraph kmergraph = create_kmergraph(nb_of_nodes);
-//than 5+ lines which achieves this
+// helper functions - used inside the tests to simplify them, and help with their
+// readability and understanding e.g. inside a test, it is better for a reader to read
+// one line: KmerGraph kmergraph = create_kmergraph(nb_of_nodes); than 5+ lines which
+// achieves this
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-//create a kmergraph with the given nb of nodes
-KmerGraph create_kmergraph(uint32_t nb_of_nodes) {
+// create a kmergraph with the given nb of nodes
+KmerGraph create_kmergraph(uint32_t nb_of_nodes)
+{
     KmerGraph kmergraph;
 
     for (uint32_t node_index = 0; node_index < nb_of_nodes; ++node_index) {
-        std::deque<Interval> interval = {Interval(node_index, node_index)};
+        std::deque<Interval> interval = { Interval(node_index, node_index) };
         prg::Path path;
         path.initialize(interval);
         kmergraph.add_node(path);
@@ -36,49 +36,49 @@ KmerGraph create_kmergraph(uint32_t nb_of_nodes) {
     return kmergraph;
 }
 
-
 using Nodeindex_Strand_Sampleindex_Tuple = std::tuple<uint32_t, bool, uint32_t>;
 
-//function that will help to check the coverages in the tests
-void check_coverages(const KmerGraphWithCoverage &kmergraph_with_coverage,
-                     std::map<Nodeindex_Strand_Sampleindex_Tuple, uint16_t> &expected_coverage,
-                     uint32_t nb_of_nodes, uint32_t nb_of_samples) {
-    //verifies all <node, strand, sample> coverage matches expected_coverage
-    //if the tuple does not exist, then the expected_coverage is assumed to be 0 (as per std::map::operator[] and uint16_t default constructor)
+// function that will help to check the coverages in the tests
+void check_coverages(const KmerGraphWithCoverage& kmergraph_with_coverage,
+    std::map<Nodeindex_Strand_Sampleindex_Tuple, uint16_t>& expected_coverage,
+    uint32_t nb_of_nodes, uint32_t nb_of_samples)
+{
+    // verifies all <node, strand, sample> coverage matches expected_coverage
+    // if the tuple does not exist, then the expected_coverage is assumed to be 0 (as
+    // per std::map::operator[] and uint16_t default constructor)
     for (uint32_t node_index = 0; node_index < nb_of_nodes; ++node_index) {
         for (uint32_t sample_index = 0; sample_index < nb_of_samples; ++sample_index) {
             EXPECT_EQ(kmergraph_with_coverage.get_covg(node_index, 0, sample_index),
-                      expected_coverage[make_tuple(node_index, 0, sample_index)]);
+                expected_coverage[make_tuple(node_index, 0, sample_index)]);
             EXPECT_EQ(kmergraph_with_coverage.get_covg(node_index, 1, sample_index),
-                      expected_coverage[make_tuple(node_index, 1, sample_index)]);
+                expected_coverage[make_tuple(node_index, 1, sample_index)]);
         }
     }
 }
 
-//set the coverage in both kmergraph_with_coverage and expected_coverage
-void set_covg_helper (KmerGraphWithCoverage &kmergraph_with_coverage,
-                      std::map<Nodeindex_Strand_Sampleindex_Tuple, uint16_t> &expected_coverage,
-                      uint32_t node_id, uint16_t value, bool strand, uint32_t sample_id) {
+// set the coverage in both kmergraph_with_coverage and expected_coverage
+void set_covg_helper(KmerGraphWithCoverage& kmergraph_with_coverage,
+    std::map<Nodeindex_Strand_Sampleindex_Tuple, uint16_t>& expected_coverage,
+    uint32_t node_id, uint16_t value, bool strand, uint32_t sample_id)
+{
     kmergraph_with_coverage.set_covg(node_id, value, strand, sample_id);
     expected_coverage[make_tuple(node_id, strand, sample_id)] = value;
 }
 
-//increment the coverage in both kmergraph_with_coverage and expected_coverage
-void increment_covg_helper(KmerGraphWithCoverage &kmergraph_with_coverage,
-                           std::map<Nodeindex_Strand_Sampleindex_Tuple, uint16_t> &expected_coverage,
-                           uint32_t node_id, bool is_forward, uint32_t sample_id) {
+// increment the coverage in both kmergraph_with_coverage and expected_coverage
+void increment_covg_helper(KmerGraphWithCoverage& kmergraph_with_coverage,
+    std::map<Nodeindex_Strand_Sampleindex_Tuple, uint16_t>& expected_coverage,
+    uint32_t node_id, bool is_forward, uint32_t sample_id)
+{
     auto old_covg = kmergraph_with_coverage.get_covg(node_id, is_forward, sample_id);
     kmergraph_with_coverage.increment_covg(node_id, is_forward, sample_id);
     expected_coverage[make_tuple(node_id, is_forward, sample_id)] = old_covg + 1;
 }
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-//helper functions
+// helper functions
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-
-
-
 
 /*TEST(KmerGraphWithCoverageTest, equals) {
     KmerGraph kmergraph1, kmergraph2;
@@ -173,26 +173,28 @@ TEST(KmerGraphWithCoverageTest, assign) {
     EXPECT_EQ(kmergraph2, kmergraph2);
 }*/
 
-
-TEST(KmerGraphWithCoverageTest, noCoverageSetAllCoverageShouldBe0) {
+TEST(KmerGraphWithCoverageTest, noCoverageSetAllCoverageShouldBe0)
+{
     const uint32_t nb_of_nodes = 5;
     KmerGraph kmergraph = create_kmergraph(nb_of_nodes);
     const uint32_t nb_of_samples = 10;
     KmerGraphWithCoverage kmergraph_with_coverage(&kmergraph, nb_of_samples);
     std::map<Nodeindex_Strand_Sampleindex_Tuple, uint16_t> expected_coverage;
 
-    //expect all coverages to be 0
-    check_coverages(kmergraph_with_coverage, expected_coverage, nb_of_nodes, nb_of_samples);
+    // expect all coverages to be 0
+    check_coverages(
+        kmergraph_with_coverage, expected_coverage, nb_of_nodes, nb_of_samples);
 }
 
-TEST(KmerGraphWithCoverageTest, severalRamdomCoveragesSet) {
+TEST(KmerGraphWithCoverageTest, severalRamdomCoveragesSet)
+{
     const uint32_t nb_of_nodes = 5;
     KmerGraph kmergraph = create_kmergraph(nb_of_nodes);
     const uint32_t nb_of_samples = 10;
     KmerGraphWithCoverage kmergraph_with_coverage(&kmergraph, nb_of_samples);
     std::map<Nodeindex_Strand_Sampleindex_Tuple, uint16_t> expected_coverage;
 
-    //set some random coverages and verify if they are all correctly set
+    // set some random coverages and verify if they are all correctly set
     set_covg_helper(kmergraph_with_coverage, expected_coverage, 0, 100, 0, 5);
     set_covg_helper(kmergraph_with_coverage, expected_coverage, 0, 150, 1, 5);
     set_covg_helper(kmergraph_with_coverage, expected_coverage, 1, 789, 1, 9);
@@ -200,48 +202,51 @@ TEST(KmerGraphWithCoverageTest, severalRamdomCoveragesSet) {
     set_covg_helper(kmergraph_with_coverage, expected_coverage, 3, 130, 0, 2);
     set_covg_helper(kmergraph_with_coverage, expected_coverage, 4, 780, 1, 7);
 
-    check_coverages(kmergraph_with_coverage, expected_coverage, nb_of_nodes, nb_of_samples);
+    check_coverages(
+        kmergraph_with_coverage, expected_coverage, nb_of_nodes, nb_of_samples);
 }
 
-TEST(KmerGraphWithCoverageTest, maximumCoverageSet) {
+TEST(KmerGraphWithCoverageTest, maximumCoverageSet)
+{
     const uint32_t nb_of_nodes = 5;
     KmerGraph kmergraph = create_kmergraph(nb_of_nodes);
     const uint32_t nb_of_samples = 10;
     KmerGraphWithCoverage kmergraph_with_coverage(&kmergraph, nb_of_samples);
     std::map<Nodeindex_Strand_Sampleindex_Tuple, uint16_t> expected_coverage;
 
-    //setup the maximum coverage
+    // setup the maximum coverage
     set_covg_helper(kmergraph_with_coverage, expected_coverage, 4, UINT16_MAX, 0, 1);
     set_covg_helper(kmergraph_with_coverage, expected_coverage, 4, UINT16_MAX, 1, 1);
 
-    check_coverages(kmergraph_with_coverage, expected_coverage, nb_of_nodes, nb_of_samples);
+    check_coverages(
+        kmergraph_with_coverage, expected_coverage, nb_of_nodes, nb_of_samples);
 }
 
-
-TEST(KmerGraphWithCoverageTest, minimumCoverageSet) {
+TEST(KmerGraphWithCoverageTest, minimumCoverageSet)
+{
     const uint32_t nb_of_nodes = 5;
     KmerGraph kmergraph = create_kmergraph(nb_of_nodes);
     const uint32_t nb_of_samples = 10;
     KmerGraphWithCoverage kmergraph_with_coverage(&kmergraph, nb_of_samples);
     std::map<Nodeindex_Strand_Sampleindex_Tuple, uint16_t> expected_coverage;
 
-    //setup the minimum coverage
+    // setup the minimum coverage
     set_covg_helper(kmergraph_with_coverage, expected_coverage, 3, 0, 0, 1);
     set_covg_helper(kmergraph_with_coverage, expected_coverage, 3, 0, 1, 1);
 
-    check_coverages(kmergraph_with_coverage, expected_coverage, nb_of_nodes, nb_of_samples);
+    check_coverages(
+        kmergraph_with_coverage, expected_coverage, nb_of_nodes, nb_of_samples);
 }
 
-
-TEST(KmerGraphWithCoverageTest, incrementCoverage) {
+TEST(KmerGraphWithCoverageTest, incrementCoverage)
+{
     const uint32_t nb_of_nodes = 5;
     KmerGraph kmergraph = create_kmergraph(nb_of_nodes);
     const uint32_t nb_of_samples = 10;
     KmerGraphWithCoverage kmergraph_with_coverage(&kmergraph, nb_of_samples);
     std::map<Nodeindex_Strand_Sampleindex_Tuple, uint16_t> expected_coverage;
 
-
-    //set some random coverages
+    // set some random coverages
     set_covg_helper(kmergraph_with_coverage, expected_coverage, 0, 100, 0, 5);
     set_covg_helper(kmergraph_with_coverage, expected_coverage, 0, 150, 1, 5);
     set_covg_helper(kmergraph_with_coverage, expected_coverage, 1, 789, 1, 9);
@@ -250,7 +255,7 @@ TEST(KmerGraphWithCoverageTest, incrementCoverage) {
     set_covg_helper(kmergraph_with_coverage, expected_coverage, 4, 780, 1, 7);
     set_covg_helper(kmergraph_with_coverage, expected_coverage, 3, 0, 0, 1);
     set_covg_helper(kmergraph_with_coverage, expected_coverage, 3, 0, 1, 1);
-    //test increment coverage
+    // test increment coverage
     increment_covg_helper(kmergraph_with_coverage, expected_coverage, 0, 0, 5);
     increment_covg_helper(kmergraph_with_coverage, expected_coverage, 0, 1, 5);
     increment_covg_helper(kmergraph_with_coverage, expected_coverage, 1, 1, 9);
@@ -260,34 +265,40 @@ TEST(KmerGraphWithCoverageTest, incrementCoverage) {
     increment_covg_helper(kmergraph_with_coverage, expected_coverage, 3, 0, 1);
     increment_covg_helper(kmergraph_with_coverage, expected_coverage, 3, 1, 1);
 
-    check_coverages(kmergraph_with_coverage, expected_coverage, nb_of_nodes, nb_of_samples);
+    check_coverages(
+        kmergraph_with_coverage, expected_coverage, nb_of_nodes, nb_of_samples);
 }
 
-
-TEST(KmerGraphWithCoverageTest, incrementCoverageAboveMaximumValue) {
+TEST(KmerGraphWithCoverageTest, incrementCoverageAboveMaximumValue)
+{
     const uint32_t nb_of_nodes = 5;
     KmerGraph kmergraph = create_kmergraph(nb_of_nodes);
     const uint32_t nb_of_samples = 10;
     KmerGraphWithCoverage kmergraph_with_coverage(&kmergraph, nb_of_samples);
     std::map<Nodeindex_Strand_Sampleindex_Tuple, uint16_t> expected_coverage;
 
-    set_covg_helper(kmergraph_with_coverage, expected_coverage, 2, UINT16_MAX, 0, 9); //first set to max value
-    check_coverages(kmergraph_with_coverage, expected_coverage, nb_of_nodes, nb_of_samples);
-    kmergraph_with_coverage.increment_covg(2, 0, 9); //now try to increment
+    set_covg_helper(kmergraph_with_coverage, expected_coverage, 2, UINT16_MAX, 0,
+        9); // first set to max value
+    check_coverages(
+        kmergraph_with_coverage, expected_coverage, nb_of_nodes, nb_of_samples);
+    kmergraph_with_coverage.increment_covg(2, 0, 9); // now try to increment
 
-    EXPECT_EQ(kmergraph_with_coverage.get_covg(2, 0, 9), UINT16_MAX); //should still be UINT16_MAX
-    check_coverages(kmergraph_with_coverage, expected_coverage, nb_of_nodes, nb_of_samples); //to be sure nothing changed
+    EXPECT_EQ(kmergraph_with_coverage.get_covg(2, 0, 9),
+        UINT16_MAX); // should still be UINT16_MAX
+    check_coverages(kmergraph_with_coverage, expected_coverage, nb_of_nodes,
+        nb_of_samples); // to be sure nothing changed
 }
 
-
-TEST(KmerGraphWithCoverageTest, set_exp_depth_covg){
+TEST(KmerGraphWithCoverageTest, set_exp_depth_covg)
+{
     KmerGraph kmergraph;
     KmerGraphWithCoverage kmergraph_with_coverage(&kmergraph);
     kmergraph_with_coverage.set_exp_depth_covg(10);
     EXPECT_EQ(kmergraph_with_coverage.exp_depth_covg, (uint)10);
 }
 
-TEST(KmerGraphWithCoverageTest, set_p) {
+TEST(KmerGraphWithCoverageTest, set_p)
+{
     KmerGraph kmergraph;
     KmerGraphWithCoverage kmergraph_with_coverage(&kmergraph);
     EXPECT_DEATH(kmergraph_with_coverage.set_binomial_parameter_p(0.4), "");
@@ -295,28 +306,34 @@ TEST(KmerGraphWithCoverageTest, set_p) {
     EXPECT_DEATH(kmergraph_with_coverage.set_binomial_parameter_p(0), "");
     EXPECT_DEATH(kmergraph_with_coverage.set_binomial_parameter_p(1), "");
     kmergraph_with_coverage.set_binomial_parameter_p(0.5);
-    EXPECT_EQ(1 / exp(1.5) - 0.00001 <= kmergraph_with_coverage.binomial_parameter_p and 1 / exp(1.5) + 0.00001 >= kmergraph_with_coverage.binomial_parameter_p, true);
+    EXPECT_EQ(1 / exp(1.5) - 0.00001 <= kmergraph_with_coverage.binomial_parameter_p
+            and 1 / exp(1.5) + 0.00001 >= kmergraph_with_coverage.binomial_parameter_p,
+        true);
 }
 
-TEST(KmerGraphWithCoverageTest, set_nb) {
+TEST(KmerGraphWithCoverageTest, set_nb)
+{
     KmerGraph kmergraph;
     KmerGraphWithCoverage kmergraph_with_coverage(&kmergraph);
     kmergraph_with_coverage.set_negative_binomial_parameters(0, 0);
-    EXPECT_FLOAT_EQ(kmergraph_with_coverage.negative_binomial_parameter_p, 0.015); //unchanged
+    EXPECT_FLOAT_EQ(
+        kmergraph_with_coverage.negative_binomial_parameter_p, 0.015); // unchanged
 }
 
-TEST(KmerGraphWithCoverageTest, prob_failNoNodes) {
+TEST(KmerGraphWithCoverageTest, prob_failNoNodes)
+{
     uint32_t sample_id = 0;
     KmerGraph kmergraph;
     KmerGraphWithCoverage kmergraph_with_coverage(&kmergraph);
     EXPECT_DEATH(kmergraph_with_coverage.bin_prob(0, sample_id), "");
 }
 
-TEST(KmerGraphWithCoverageTest, prob_failNoP) {
+TEST(KmerGraphWithCoverageTest, prob_failNoP)
+{
     uint32_t sample_id = 0;
     KmerGraph kmergraph;
 
-    std::deque<Interval> d = {Interval(0, 0)};
+    std::deque<Interval> d = { Interval(0, 0) };
     prg::Path p;
     p.initialize(d);
     kmergraph.add_node(p);
@@ -325,11 +342,12 @@ TEST(KmerGraphWithCoverageTest, prob_failNoP) {
     EXPECT_DEATH(kmergraph_with_coverage.bin_prob(0, sample_id), "");
 }
 
-TEST(KmerGraphWithCoverageTest, prob_failNoNumReads) {
+TEST(KmerGraphWithCoverageTest, prob_failNoNumReads)
+{
     uint32_t sample_id = 0;
     KmerGraph kmergraph;
 
-    std::deque<Interval> d = {Interval(0, 0)};
+    std::deque<Interval> d = { Interval(0, 0) };
     prg::Path p;
     p.initialize(d);
     kmergraph.add_node(p);
@@ -341,11 +359,12 @@ TEST(KmerGraphWithCoverageTest, prob_failNoNumReads) {
     EXPECT_DEATH(kmergraph_with_coverage.bin_prob(0, sample_id), "");
 }
 
-TEST(KmerGraphWithCoverageTest, prob_simple) {
+TEST(KmerGraphWithCoverageTest, prob_simple)
+{
     uint32_t sample_id = 0;
     KmerGraph kmergraph;
 
-    std::deque<Interval> d = {Interval(0, 0)};
+    std::deque<Interval> d = { Interval(0, 0) };
     prg::Path p;
     p.initialize(d);
     kmergraph.add_node(p);
@@ -355,22 +374,23 @@ TEST(KmerGraphWithCoverageTest, prob_simple) {
     kmergraph_with_coverage.set_binomial_parameter_p(0.5);
     kmergraph_with_coverage.num_reads = 1;
 
-    EXPECT_EQ(kmergraph_with_coverage.kmer_prg->nodes.size(), (uint) 1);
+    EXPECT_EQ(kmergraph_with_coverage.kmer_prg->nodes.size(), (uint)1);
     EXPECT_EQ(0, kmergraph_with_coverage.bin_prob(0, sample_id));
 }
 
-TEST(KmerGraphWithCoverageTest, prob_realNodeCovgs) {
+TEST(KmerGraphWithCoverageTest, prob_realNodeCovgs)
+{
     uint32_t sample_id = 0;
     KmerGraph kmergraph;
 
-    std::deque<Interval> d = {Interval(0, 0)};
+    std::deque<Interval> d = { Interval(0, 0) };
     prg::Path p;
     p.initialize(d);
     kmergraph.add_node(p);
-    d = {Interval(0, 1), Interval(4, 5), Interval(8, 9)};
+    d = { Interval(0, 1), Interval(4, 5), Interval(8, 9) };
     p.initialize(d);
     kmergraph.add_node(p);
-    d = {Interval(0, 1), Interval(4, 5), Interval(12, 13)};
+    d = { Interval(0, 1), Interval(4, 5), Interval(12, 13) };
     p.initialize(d);
     kmergraph.add_node(p);
 
@@ -379,35 +399,37 @@ TEST(KmerGraphWithCoverageTest, prob_realNodeCovgs) {
     kmergraph_with_coverage.set_binomial_parameter_p(0.5);
     kmergraph_with_coverage.num_reads = 1;
 
-    EXPECT_EQ(kmergraph_with_coverage.kmer_prg->nodes.size(), (uint) 3);
+    EXPECT_EQ(kmergraph_with_coverage.kmer_prg->nodes.size(), (uint)3);
 
-    EXPECT_EQ(kmergraph_with_coverage.bin_prob(1, sample_id), kmergraph_with_coverage.bin_prob(1, sample_id));
-    EXPECT_EQ(kmergraph_with_coverage.bin_prob(2, sample_id), kmergraph_with_coverage.bin_prob(2, sample_id));
-
+    EXPECT_EQ(kmergraph_with_coverage.bin_prob(1, sample_id),
+        kmergraph_with_coverage.bin_prob(1, sample_id));
+    EXPECT_EQ(kmergraph_with_coverage.bin_prob(2, sample_id),
+        kmergraph_with_coverage.bin_prob(2, sample_id));
 }
 
-KmerGraph setup_simple_kmergraph(){
+KmerGraph setup_simple_kmergraph()
+{
     KmerGraph kmergraph;
-    std::deque<Interval> d = {Interval(0, 0)};
+    std::deque<Interval> d = { Interval(0, 0) };
     prg::Path p;
     p.initialize(d);
     kmergraph.add_node(p);
-    d = {Interval(0, 1), Interval(4, 5), Interval(8, 9)};
+    d = { Interval(0, 1), Interval(4, 5), Interval(8, 9) };
     p.initialize(d);
     kmergraph.add_node(p);
-    d = {Interval(4, 5), Interval(8, 9), Interval(16, 16), Interval(23, 24)};
+    d = { Interval(4, 5), Interval(8, 9), Interval(16, 16), Interval(23, 24) };
     p.initialize(d);
     kmergraph.add_node(p);
-    d = {Interval(0, 1), Interval(4, 5), Interval(12, 13)};
+    d = { Interval(0, 1), Interval(4, 5), Interval(12, 13) };
     p.initialize(d);
     kmergraph.add_node(p);
-    d = {Interval(4, 5), Interval(12, 13), Interval(16, 16), Interval(23, 24)};
+    d = { Interval(4, 5), Interval(12, 13), Interval(16, 16), Interval(23, 24) };
     p.initialize(d);
     kmergraph.add_node(p);
-    d = {Interval(0, 1), Interval(19, 20), Interval(23, 24)};
+    d = { Interval(0, 1), Interval(19, 20), Interval(23, 24) };
     p.initialize(d);
     kmergraph.add_node(p);
-    d = {Interval(24, 24)};
+    d = { Interval(24, 24) };
     p.initialize(d);
     kmergraph.add_node(p);
 
@@ -424,39 +446,44 @@ KmerGraph setup_simple_kmergraph(){
     return kmergraph;
 }
 
-TEST(KmerGraphWithCoverageTest, findMaxPath_InvalidProbModel) {
+TEST(KmerGraphWithCoverageTest, findMaxPath_InvalidProbModel)
+{
     KmerGraph kmergraph = setup_simple_kmergraph();
     KmerGraphWithCoverage kmergraph_with_coverage(&kmergraph);
     uint32_t sample_id = 0;
     uint32_t max_num_kmers_to_average = 100;
 
-    kmergraph_with_coverage.set_covg(1,4, 0, sample_id);
-    kmergraph_with_coverage.set_covg(2,3, 0, sample_id);
+    kmergraph_with_coverage.set_covg(1, 4, 0, sample_id);
+    kmergraph_with_coverage.set_covg(2, 3, 0, sample_id);
 
     kmergraph_with_coverage.num_reads = 5;
     kmergraph_with_coverage.kmer_prg->k = 3;
 
     vector<KmerNodePtr> mp;
     kmergraph_with_coverage.set_binomial_parameter_p(0.01);
-    EXPECT_DEATH(kmergraph_with_coverage.find_max_path(mp, "exp", max_num_kmers_to_average, sample_id),"");
+    EXPECT_DEATH(kmergraph_with_coverage.find_max_path(
+                     mp, "exp", max_num_kmers_to_average, sample_id),
+        "");
 }
 
-TEST(KmerGraphWithCoverageTest, findMaxPathSimple) {
+TEST(KmerGraphWithCoverageTest, findMaxPathSimple)
+{
     KmerGraph kmergraph = setup_simple_kmergraph();
     KmerGraphWithCoverage kmergraph_with_coverage(&kmergraph);
     uint32_t sample_id = 0;
     uint32_t max_num_kmers_to_average = 100;
 
-    kmergraph_with_coverage.set_covg(1,4, 0, sample_id);
-    kmergraph_with_coverage.set_covg(2,3, 0, sample_id);
+    kmergraph_with_coverage.set_covg(1, 4, 0, sample_id);
+    kmergraph_with_coverage.set_covg(2, 3, 0, sample_id);
 
     kmergraph_with_coverage.num_reads = 5;
     kmergraph_with_coverage.kmer_prg->k = 3;
 
     vector<KmerNodePtr> mp;
     kmergraph_with_coverage.set_binomial_parameter_p(0.01);
-    kmergraph_with_coverage.find_max_path(mp, "bin", max_num_kmers_to_average, sample_id);
-    vector<KmerNodePtr> exp_order = {kmergraph.nodes[1], kmergraph.nodes[2]};
+    kmergraph_with_coverage.find_max_path(
+        mp, "bin", max_num_kmers_to_average, sample_id);
+    vector<KmerNodePtr> exp_order = { kmergraph.nodes[1], kmergraph.nodes[2] };
     EXPECT_ITERABLE_EQ(vector<KmerNodePtr>, exp_order, mp);
 
     mp.clear();
@@ -464,27 +491,30 @@ TEST(KmerGraphWithCoverageTest, findMaxPathSimple) {
     kmergraph_with_coverage.set_covg(2, 0, 0, sample_id);
     kmergraph_with_coverage.set_covg(5, 5, 1, sample_id);
     kmergraph_with_coverage.set_binomial_parameter_p(0.01);
-    kmergraph_with_coverage.find_max_path(mp, "bin", max_num_kmers_to_average, sample_id);
-    exp_order = {kmergraph.nodes[5]};
+    kmergraph_with_coverage.find_max_path(
+        mp, "bin", max_num_kmers_to_average, sample_id);
+    exp_order = { kmergraph.nodes[5] };
     EXPECT_ITERABLE_EQ(vector<KmerNodePtr>, exp_order, mp);
 }
 
-TEST(KmerGraphWithCoverageTest, findMaxPathSimple_WithMaxKmersInAvg) {
+TEST(KmerGraphWithCoverageTest, findMaxPathSimple_WithMaxKmersInAvg)
+{
     KmerGraph kmergraph = setup_simple_kmergraph();
     KmerGraphWithCoverage kmergraph_with_coverage(&kmergraph);
     uint32_t sample_id = 0;
     uint32_t max_num_kmers_to_average = 1;
 
-    kmergraph_with_coverage.set_covg(1,4, 0, sample_id);
-    kmergraph_with_coverage.set_covg(2,3, 0, sample_id);
+    kmergraph_with_coverage.set_covg(1, 4, 0, sample_id);
+    kmergraph_with_coverage.set_covg(2, 3, 0, sample_id);
 
     kmergraph_with_coverage.num_reads = 5;
     kmergraph_with_coverage.kmer_prg->k = 3;
 
     vector<KmerNodePtr> mp;
     kmergraph_with_coverage.set_binomial_parameter_p(0.01);
-    kmergraph_with_coverage.find_max_path(mp, "bin", max_num_kmers_to_average, sample_id);
-    vector<KmerNodePtr> exp_order = {kmergraph.nodes[1], kmergraph.nodes[2]};
+    kmergraph_with_coverage.find_max_path(
+        mp, "bin", max_num_kmers_to_average, sample_id);
+    vector<KmerNodePtr> exp_order = { kmergraph.nodes[1], kmergraph.nodes[2] };
     EXPECT_ITERABLE_EQ(vector<KmerNodePtr>, exp_order, mp);
 
     mp.clear();
@@ -492,42 +522,44 @@ TEST(KmerGraphWithCoverageTest, findMaxPathSimple_WithMaxKmersInAvg) {
     kmergraph_with_coverage.set_covg(2, 0, 0, sample_id);
     kmergraph_with_coverage.set_covg(5, 5, 1, sample_id);
     kmergraph_with_coverage.set_binomial_parameter_p(0.01);
-    kmergraph_with_coverage.find_max_path(mp, "bin", max_num_kmers_to_average, sample_id);
-    exp_order = {kmergraph.nodes[5]};
+    kmergraph_with_coverage.find_max_path(
+        mp, "bin", max_num_kmers_to_average, sample_id);
+    exp_order = { kmergraph.nodes[5] };
     EXPECT_ITERABLE_EQ(vector<KmerNodePtr>, exp_order, mp);
 }
 
-KmerGraph setup_2level_kmergraph() {
+KmerGraph setup_2level_kmergraph()
+{
     KmerGraph kmergraph;
-    std::deque<Interval> d = {Interval(0, 0)};
+    std::deque<Interval> d = { Interval(0, 0) };
     prg::Path p;
     p.initialize(d);
     kmergraph.add_node(p);
-    d = {Interval(0, 1), Interval(4, 5), Interval(8, 9)};
+    d = { Interval(0, 1), Interval(4, 5), Interval(8, 9) };
     p.initialize(d);
     kmergraph.add_node(p);
-    d = {Interval(4, 5), Interval(8, 9), Interval(16, 17)};
+    d = { Interval(4, 5), Interval(8, 9), Interval(16, 17) };
     p.initialize(d);
     kmergraph.add_node(p);
-    d = {Interval(8, 9), Interval(16, 18)};
+    d = { Interval(8, 9), Interval(16, 18) };
     p.initialize(d);
     kmergraph.add_node(p);
-    d = {Interval(0, 1), Interval(4, 5), Interval(12, 13)};
+    d = { Interval(0, 1), Interval(4, 5), Interval(12, 13) };
     p.initialize(d);
     kmergraph.add_node(p);
-    d = {Interval(4, 5), Interval(12, 13), Interval(16, 17)};
+    d = { Interval(4, 5), Interval(12, 13), Interval(16, 17) };
     p.initialize(d);
     kmergraph.add_node(p);
-    d = {Interval(12, 13), Interval(16, 18)};
+    d = { Interval(12, 13), Interval(16, 18) };
     p.initialize(d);
     kmergraph.add_node(p);
-    d = {Interval(16, 18), Interval(23, 24)};
+    d = { Interval(16, 18), Interval(23, 24) };
     p.initialize(d);
     kmergraph.add_node(p);
-    d = {Interval(0, 1), Interval(19, 20), Interval(23, 24)};
+    d = { Interval(0, 1), Interval(19, 20), Interval(23, 24) };
     p.initialize(d);
     kmergraph.add_node(p);
-    d = {Interval(24, 24)};
+    d = { Interval(24, 24) };
     p.initialize(d);
     kmergraph.add_node(p);
 
@@ -547,17 +579,18 @@ KmerGraph setup_2level_kmergraph() {
     return kmergraph;
 }
 
-TEST(KmerGraphWithCoverageTest, findMaxPath2Level_bin) {
+TEST(KmerGraphWithCoverageTest, findMaxPath2Level_bin)
+{
     KmerGraph kmergraph = setup_2level_kmergraph();
     KmerGraphWithCoverage kmergraph_with_coverage(&kmergraph);
 
     uint32_t sample_id = 0;
     uint32_t max_num_kmers_to_average = 100;
 
-    kmergraph_with_coverage.set_covg(4,4, 0, sample_id);
-    kmergraph_with_coverage.set_covg(5,3, 0, sample_id);
-    kmergraph_with_coverage.set_covg(6,4, 0, sample_id);
-    kmergraph_with_coverage.set_covg(7,3, 0, sample_id);
+    kmergraph_with_coverage.set_covg(4, 4, 0, sample_id);
+    kmergraph_with_coverage.set_covg(5, 3, 0, sample_id);
+    kmergraph_with_coverage.set_covg(6, 4, 0, sample_id);
+    kmergraph_with_coverage.set_covg(7, 3, 0, sample_id);
 
     kmergraph_with_coverage.num_reads = 5;
     kmergraph_with_coverage.kmer_prg->k = 3;
@@ -565,8 +598,10 @@ TEST(KmerGraphWithCoverageTest, findMaxPath2Level_bin) {
     std::vector<KmerNodePtr> mp;
     kmergraph_with_coverage.set_binomial_parameter_p(0.01);
 
-    auto mp_p = kmergraph_with_coverage.find_max_path(mp, "bin", max_num_kmers_to_average, sample_id);
-    vector<KmerNodePtr> exp_order = {kmergraph.nodes[4], kmergraph.nodes[5], kmergraph.nodes[6], kmergraph.nodes[7]};
+    auto mp_p = kmergraph_with_coverage.find_max_path(
+        mp, "bin", max_num_kmers_to_average, sample_id);
+    vector<KmerNodePtr> exp_order = { kmergraph.nodes[4], kmergraph.nodes[5],
+        kmergraph.nodes[6], kmergraph.nodes[7] };
     EXPECT_ITERABLE_EQ(vector<KmerNodePtr>, exp_order, mp);
 
     float exp_p = 0;
@@ -582,8 +617,9 @@ TEST(KmerGraphWithCoverageTest, findMaxPath2Level_bin) {
     kmergraph_with_coverage.set_covg(6, 0, 0, sample_id);
     kmergraph_with_coverage.set_covg(7, 0, 0, sample_id);
     kmergraph_with_coverage.set_covg(8, 5, 1, sample_id);
-    mp_p = kmergraph_with_coverage.find_max_path(mp, "bin", max_num_kmers_to_average, sample_id);
-    exp_order = {kmergraph.nodes[8]};
+    mp_p = kmergraph_with_coverage.find_max_path(
+        mp, "bin", max_num_kmers_to_average, sample_id);
+    exp_order = { kmergraph.nodes[8] };
     EXPECT_ITERABLE_EQ(vector<KmerNodePtr>, exp_order, mp);
 
     exp_p = 0;
@@ -593,24 +629,27 @@ TEST(KmerGraphWithCoverageTest, findMaxPath2Level_bin) {
     EXPECT_EQ(mp_p, exp_p);
 }
 
-TEST(KmerGraphWithCoverageTest, findMaxPath2Level_nbin) {
+TEST(KmerGraphWithCoverageTest, findMaxPath2Level_nbin)
+{
     KmerGraph kmergraph = setup_2level_kmergraph();
     KmerGraphWithCoverage kmergraph_with_coverage(&kmergraph);
 
     uint32_t sample_id = 0;
     uint32_t max_num_kmers_to_average = 100;
 
-    kmergraph_with_coverage.set_covg(4,4, 0, sample_id);
-    kmergraph_with_coverage.set_covg(5,3, 0, sample_id);
-    kmergraph_with_coverage.set_covg(6,4, 0, sample_id);
-    kmergraph_with_coverage.set_covg(7,3, 0, sample_id);
+    kmergraph_with_coverage.set_covg(4, 4, 0, sample_id);
+    kmergraph_with_coverage.set_covg(5, 3, 0, sample_id);
+    kmergraph_with_coverage.set_covg(6, 4, 0, sample_id);
+    kmergraph_with_coverage.set_covg(7, 3, 0, sample_id);
 
     kmergraph_with_coverage.num_reads = 5;
     kmergraph_with_coverage.kmer_prg->k = 3;
 
     std::vector<KmerNodePtr> mp;
-    auto mp_p = kmergraph_with_coverage.find_max_path(mp, "nbin", max_num_kmers_to_average, sample_id);
-    vector<KmerNodePtr> exp_order = {kmergraph.nodes[4], kmergraph.nodes[5], kmergraph.nodes[6], kmergraph.nodes[7]};
+    auto mp_p = kmergraph_with_coverage.find_max_path(
+        mp, "nbin", max_num_kmers_to_average, sample_id);
+    vector<KmerNodePtr> exp_order = { kmergraph.nodes[4], kmergraph.nodes[5],
+        kmergraph.nodes[6], kmergraph.nodes[7] };
     EXPECT_ITERABLE_EQ(vector<KmerNodePtr>, exp_order, mp);
 
     float exp_p = 0;
@@ -626,8 +665,9 @@ TEST(KmerGraphWithCoverageTest, findMaxPath2Level_nbin) {
     kmergraph_with_coverage.set_covg(6, 0, 0, sample_id);
     kmergraph_with_coverage.set_covg(7, 0, 0, sample_id);
     kmergraph_with_coverage.set_covg(8, 5, 1, sample_id);
-    mp_p = kmergraph_with_coverage.find_max_path(mp, "nbin", max_num_kmers_to_average, sample_id);
-    exp_order = {kmergraph.nodes[8]};
+    mp_p = kmergraph_with_coverage.find_max_path(
+        mp, "nbin", max_num_kmers_to_average, sample_id);
+    exp_order = { kmergraph.nodes[8] };
     EXPECT_ITERABLE_EQ(vector<KmerNodePtr>, exp_order, mp);
 
     exp_p = 0;
@@ -637,25 +677,28 @@ TEST(KmerGraphWithCoverageTest, findMaxPath2Level_nbin) {
     EXPECT_EQ(mp_p, exp_p);
 }
 
-TEST(KmerGraphWithCoverageTest, findMaxPath2Level_lin) {
+TEST(KmerGraphWithCoverageTest, findMaxPath2Level_lin)
+{
     KmerGraph kmergraph = setup_2level_kmergraph();
     KmerGraphWithCoverage kmergraph_with_coverage(&kmergraph);
 
     uint32_t sample_id = 0;
     uint32_t max_num_kmers_to_average = 100;
 
-    kmergraph_with_coverage.set_covg(4,4, 0, sample_id);
-    kmergraph_with_coverage.set_covg(5,3, 0, sample_id);
-    kmergraph_with_coverage.set_covg(6,4, 0, sample_id);
-    kmergraph_with_coverage.set_covg(7,3, 0, sample_id);
+    kmergraph_with_coverage.set_covg(4, 4, 0, sample_id);
+    kmergraph_with_coverage.set_covg(5, 3, 0, sample_id);
+    kmergraph_with_coverage.set_covg(6, 4, 0, sample_id);
+    kmergraph_with_coverage.set_covg(7, 3, 0, sample_id);
 
     kmergraph_with_coverage.num_reads = 5;
     kmergraph_with_coverage.kmer_prg->k = 3;
 
     std::vector<KmerNodePtr> mp;
     kmergraph_with_coverage.set_binomial_parameter_p(0.01);
-    auto mp_p = kmergraph_with_coverage.find_max_path(mp, "lin", max_num_kmers_to_average, sample_id);
-    vector<KmerNodePtr> exp_order = {kmergraph.nodes[4], kmergraph.nodes[5], kmergraph.nodes[6], kmergraph.nodes[7]};
+    auto mp_p = kmergraph_with_coverage.find_max_path(
+        mp, "lin", max_num_kmers_to_average, sample_id);
+    vector<KmerNodePtr> exp_order = { kmergraph.nodes[4], kmergraph.nodes[5],
+        kmergraph.nodes[6], kmergraph.nodes[7] };
     EXPECT_ITERABLE_EQ(vector<KmerNodePtr>, exp_order, mp);
 
     float exp_p = 0;
@@ -671,8 +714,9 @@ TEST(KmerGraphWithCoverageTest, findMaxPath2Level_lin) {
     kmergraph_with_coverage.set_covg(6, 0, 0, sample_id);
     kmergraph_with_coverage.set_covg(7, 0, 0, sample_id);
     kmergraph_with_coverage.set_covg(8, 5, 1, sample_id);
-    mp_p = kmergraph_with_coverage.find_max_path(mp, "lin", max_num_kmers_to_average, sample_id);
-    exp_order = {kmergraph.nodes[8]};
+    mp_p = kmergraph_with_coverage.find_max_path(
+        mp, "lin", max_num_kmers_to_average, sample_id);
+    exp_order = { kmergraph.nodes[8] };
     EXPECT_ITERABLE_EQ(vector<KmerNodePtr>, exp_order, mp);
 
     exp_p = 0;
@@ -700,9 +744,9 @@ TEST(KmerGraphWithCoverageTest, find_max_paths_2Level) {
     kmergraph_with_coverage.kmer_prg->k = 3;
     kmergraph_with_coverage.set_p(0.01);
 
-    vector<vector<KmerNodePtr>> mps = kmergraph_with_coverage.find_max_paths(2, sample_id);
-    EXPECT_EQ((uint) 2, mps.size());
-    vector<KmerNodePtr> exp_order = {kmergraph.nodes[4], kmergraph.nodes[5], kmergraph.nodes[6], kmergraph.nodes[7]};
+    vector<vector<KmerNodePtr>> mps = kmergraph_with_coverage.find_max_paths(2,
+sample_id); EXPECT_EQ((uint) 2, mps.size()); vector<KmerNodePtr> exp_order =
+{kmergraph.nodes[4], kmergraph.nodes[5], kmergraph.nodes[6], kmergraph.nodes[7]};
     EXPECT_ITERABLE_EQ(vector<KmerNodePtr>, exp_order, mps[1]);
 
     exp_order = {kmergraph.nodes[8]};
@@ -710,14 +754,17 @@ TEST(KmerGraphWithCoverageTest, find_max_paths_2Level) {
 }
  */
 
-TEST(KmerGraphWithCoverageTest, random_paths) {
+TEST(KmerGraphWithCoverageTest, random_paths)
+{
     KmerGraph kmergraph = setup_2level_kmergraph();
     KmerGraphWithCoverage kmergraph_with_coverage(&kmergraph);
 
     vector<vector<KmerNodePtr>> rps;
-    vector<KmerNodePtr> exp_order1 = {kmergraph.nodes[1], kmergraph.nodes[2], kmergraph.nodes[3], kmergraph.nodes[7]};
-    vector<KmerNodePtr> exp_order2 = {kmergraph.nodes[4], kmergraph.nodes[5], kmergraph.nodes[6], kmergraph.nodes[7]};
-    vector<KmerNodePtr> exp_order3 = {kmergraph.nodes[8]};
+    vector<KmerNodePtr> exp_order1 = { kmergraph.nodes[1], kmergraph.nodes[2],
+        kmergraph.nodes[3], kmergraph.nodes[7] };
+    vector<KmerNodePtr> exp_order2 = { kmergraph.nodes[4], kmergraph.nodes[5],
+        kmergraph.nodes[6], kmergraph.nodes[7] };
+    vector<KmerNodePtr> exp_order3 = { kmergraph.nodes[8] };
 
     rps = kmergraph_with_coverage.get_random_paths(10);
     for (uint i = 0; i != rps.size(); ++i) {
@@ -795,30 +842,30 @@ TEST(KmerGraphWithCoverageTest, path_probs) {
     EXPECT_EQ((uint) 2, mps.size());
 
     // check get right answer
-    vector<KmerNodePtr> exp_nodes = {kmergraph.nodes[4], kmergraph.nodes[5], kmergraph.nodes[6], kmergraph.nodes[7], kmergraph.nodes[8]};
-    float exp_p = 0;
-    for (uint i = 0; i != exp_nodes.size(); ++i) {
-        exp_p += kmergraph.prob(exp_nodes[i]->id, 5);
+    vector<KmerNodePtr> exp_nodes = {kmergraph.nodes[4], kmergraph.nodes[5],
+kmergraph.nodes[6], kmergraph.nodes[7], kmergraph.nodes[8]}; float exp_p = 0; for (uint
+i = 0; i != exp_nodes.size(); ++i) { exp_p += kmergraph.prob(exp_nodes[i]->id, 5);
     }
     exp_p /= 5;
     EXPECT_EQ(kmergraph.prob_paths(mps), exp_p);
 }
  */
 
-TEST(KmerGraphWithCoverageTest, save_covg_dist) {
+TEST(KmerGraphWithCoverageTest, save_covg_dist)
+{
     KmerGraph kmergraph;
-    std::deque<Interval> d = {Interval(0, 0)};
+    std::deque<Interval> d = { Interval(0, 0) };
     prg::Path p, p1, p2;
     p.initialize(d);
     kmergraph.add_node(p);
-    d = {Interval(0, 3)};
+    d = { Interval(0, 3) };
     p1.initialize(d);
     auto n1 = kmergraph.add_node(p1);
-    d = {Interval(1, 4)};
+    d = { Interval(1, 4) };
     p2.initialize(d);
     auto n2 = kmergraph.add_node(p2);
     kmergraph.add_edge(n1, n2);
-    d = {Interval(4, 4)};
+    d = { Interval(4, 4) };
     p.initialize(d);
     kmergraph.add_node(p);
 
@@ -829,17 +876,18 @@ TEST(KmerGraphWithCoverageTest, save_covg_dist) {
     kmergraph_with_coverage.save_covg_dist("test_cases/kmergraph_test.covg.txt");
 }
 
-TEST(KmerGraphWithCoverageTest, save_no_prg) {
+TEST(KmerGraphWithCoverageTest, save_no_prg)
+{
     KmerGraph kmergraph;
-    deque<Interval> d = {Interval(0, 3)};
+    deque<Interval> d = { Interval(0, 3) };
     prg::Path p1, p2;
     p1.initialize(d);
     auto n1 = kmergraph.add_node(p1);
-    d = {Interval(1, 4)};
+    d = { Interval(1, 4) };
     p2.initialize(d);
     auto n2 = kmergraph.add_node(p2);
     kmergraph.add_edge(n1, n2);
-    EXPECT_EQ((uint) 0, kmergraph.nodes[0]->num_AT);
+    EXPECT_EQ((uint)0, kmergraph.nodes[0]->num_AT);
 
     KmerGraphWithCoverage kmergraph_with_coverage(&kmergraph);
     kmergraph_with_coverage.set_covg(0, 4, 1, 0);
@@ -848,13 +896,14 @@ TEST(KmerGraphWithCoverageTest, save_no_prg) {
     kmergraph_with_coverage.save("kmergraphwithcoverage_test.gfa");
 }
 
-TEST(KmerGraphWithCoverageTest, load) {
+TEST(KmerGraphWithCoverageTest, load)
+{
     KmerGraph kmergraph;
-    deque<Interval> d = {Interval(0, 3)};
+    deque<Interval> d = { Interval(0, 3) };
     prg::Path p1, p2;
     p1.initialize(d);
     auto n1 = kmergraph.add_node(p1);
-    d = {Interval(1, 4)};
+    d = { Interval(1, 4) };
     p2.initialize(d);
     auto n2 = kmergraph.add_node(p2);
     kmergraph.add_edge(n1, n2);
@@ -865,10 +914,11 @@ TEST(KmerGraphWithCoverageTest, load) {
 
     KmerGraphWithCoverage read_kmergraph_with_coverage(&kmergraph);
     read_kmergraph_with_coverage.load("kmergraphwithcoverage_test.gfa");
-    //EXPECT_EQ(kmergraph_with_coverage, read_kmergraph_with_coverage);
+    // EXPECT_EQ(kmergraph_with_coverage, read_kmergraph_with_coverage);
 }
 
-TEST(KmerGraphWithCoverageTest, load_prg) {
+TEST(KmerGraphWithCoverageTest, load_prg)
+{
     KmerGraph kmergraph;
     KmerGraphWithCoverage read_kmergraph_with_coverage(&kmergraph);
     EXPECT_DEATH(read_kmergraph_with_coverage.load("kmergraph_test.gfa"), "");

--- a/test/kmernode_test.cpp
+++ b/test/kmernode_test.cpp
@@ -1,15 +1,14 @@
-#include "gtest/gtest.h"
-#include "kmernode.h"
 #include "interval.h"
+#include "kmernode.h"
 #include "prg/path.h"
-#include <stdint.h>
+#include "gtest/gtest.h"
 #include <iostream>
+#include <stdint.h>
 
+TEST(KmerNodeTest, create)
+{
 
-
-TEST(KmerNodeTest, create) {
-
-    std::deque<Interval> d = {Interval(0, 4)};
+    std::deque<Interval> d = { Interval(0, 4) };
     prg::Path p;
     p.initialize(d);
     KmerNode kn(0, p);
@@ -20,9 +19,10 @@ TEST(KmerNodeTest, create) {
     EXPECT_EQ(p, kn.path);
 }
 
-TEST(KmerNodeTest, assign) {
+TEST(KmerNodeTest, assign)
+{
 
-    std::deque<Interval> d = {Interval(0, 4)};
+    std::deque<Interval> d = { Interval(0, 4) };
     prg::Path p;
     p.initialize(d);
     KmerNode kn(0, p);
@@ -44,12 +44,13 @@ TEST(KmerNodeTest, assign) {
     EXPECT_EQ(p, kn_prime.path);
 }
 
-TEST(KmerNodeTest, equals) {
+TEST(KmerNodeTest, equals)
+{
 
-    std::deque<Interval> d = {Interval(0, 4)};
+    std::deque<Interval> d = { Interval(0, 4) };
     prg::Path p1, p2;
     p1.initialize(d);
-    d = {Interval(2, 6)};
+    d = { Interval(2, 6) };
     p2.initialize(d);
     KmerNode kn1(0, p1);
     KmerNode kn2(3, p1);
@@ -61,7 +62,7 @@ TEST(KmerNodeTest, equals) {
     EXPECT_EQ(kn2, kn2);
     EXPECT_EQ(kn3, kn3);
     EXPECT_EQ(kn4, kn4);
-    EXPECT_EQ((kn1 == kn2), true); //id doesn't affect ==
+    EXPECT_EQ((kn1 == kn2), true); // id doesn't affect ==
     EXPECT_EQ((kn1 == kn3), false);
     EXPECT_EQ((kn1 == kn4), false);
     EXPECT_EQ((kn2 == kn1), true);
@@ -69,18 +70,18 @@ TEST(KmerNodeTest, equals) {
     EXPECT_EQ((kn2 == kn4), false);
     EXPECT_EQ((kn3 == kn1), false);
     EXPECT_EQ((kn3 == kn2), false);
-    EXPECT_EQ((kn3 == kn4), true); //id doesn't affect ==
+    EXPECT_EQ((kn3 == kn4), true); // id doesn't affect ==
 
     // covg doesn't affect whether equal
     KmerNode kn5(0, p1);
     EXPECT_EQ(kn5, kn5);
     EXPECT_EQ(kn1, kn5);
     EXPECT_EQ(kn5, kn1);
-
 }
 
-TEST(KmerNodeTest, StringStream) {
-    std::deque<Interval> d = {Interval(0, 4)};
+TEST(KmerNodeTest, StringStream)
+{
+    std::deque<Interval> d = { Interval(0, 4) };
     prg::Path p;
     p.initialize(d);
     KmerNode kn(0, p);
@@ -88,5 +89,5 @@ TEST(KmerNodeTest, StringStream) {
     std::ostringstream out;
     out << kn;
 
-    EXPECT_EQ( "0 1{[0, 4)} ", out.str() );
+    EXPECT_EQ("0 1{[0, 4)} ", out.str());
 }

--- a/test/localPRG_test.cpp
+++ b/test/localPRG_test.cpp
@@ -1,28 +1,28 @@
-#include "gtest/gtest.h"
-#include "test_macro.cpp"
-#include "localPRG.h"
-#include "minimizer.h"
-#include "minirecord.h"
-#include "minihit.h"
-#include "interval.h"
-#include "prg/path.h"
-#include "localgraph.h"
-#include "localnode.h"
 #include "index.h"
+#include "interval.h"
 #include "inthash.h"
-#include "pangenome/pannode.h"
-#include "pangenome/panread.h"
-#include "utils.h"
-#include "seq.h"
 #include "kmergraph.h"
 #include "kmernode.h"
-#include <stdint.h>
+#include "localPRG.h"
+#include "localgraph.h"
+#include "localnode.h"
+#include "minihit.h"
+#include "minimizer.h"
+#include "minirecord.h"
+#include "pangenome/pannode.h"
+#include "pangenome/panread.h"
+#include "prg/path.h"
+#include "seq.h"
+#include "test_macro.cpp"
+#include "utils.h"
+#include "gtest/gtest.h"
 #include <iostream>
-
+#include <stdint.h>
 
 using namespace std;
 
-TEST(LocalPRGTest, create) {
+TEST(LocalPRGTest, create)
+{
     LocalPRG l0(0, "empty", "");
     LocalPRG l1(1, "simple", "AGCT");
     LocalPRG l2(2, "varsite", "A 5 GC 6 G 5 T");
@@ -46,7 +46,8 @@ TEST(LocalPRGTest, create) {
     EXPECT_EQ("A 5 G 7 C 8 T 7  6 G 5 T", l3.seq);
 }
 
-TEST(LocalPRGTest, isalphaEmptyString) {
+TEST(LocalPRGTest, isalphaEmptyString)
+{
     LocalPRG l0(0, "empty", "");
     LocalPRG l1(1, "simple", "AGCT");
     LocalPRG l2(2, "varsite", "A 5 GC 6 G 5 T");
@@ -56,13 +57,18 @@ TEST(LocalPRGTest, isalphaEmptyString) {
     bool a1 = l1.isalpha_string("");
     bool a2 = l2.isalpha_string("");
     bool a3 = l3.isalpha_string("");
-    EXPECT_EQ(a0, 1) << "isalpha_string thinks the empty string is not alphabetic for l0";
-    EXPECT_EQ(a1, 1) << "isalpha_string thinks the empty string is not alphabetic for l1";
-    EXPECT_EQ(a2, 1) << "isalpha_string thinks the empty string is not alphabetic for l2";
-    EXPECT_EQ(a3, 1) << "isalpha_string thinks the empty string is not alphabetic for l3";
+    EXPECT_EQ(a0, 1)
+        << "isalpha_string thinks the empty string is not alphabetic for l0";
+    EXPECT_EQ(a1, 1)
+        << "isalpha_string thinks the empty string is not alphabetic for l1";
+    EXPECT_EQ(a2, 1)
+        << "isalpha_string thinks the empty string is not alphabetic for l2";
+    EXPECT_EQ(a3, 1)
+        << "isalpha_string thinks the empty string is not alphabetic for l3";
 }
 
-TEST(LocalPRGTest, isalphaSpaceString) {
+TEST(LocalPRGTest, isalphaSpaceString)
+{
     LocalPRG l0(0, "empty", "");
     LocalPRG l1(1, "simple", "AGCT");
     LocalPRG l2(2, "varsite", "A 5 GC 6 G 5 T");
@@ -72,13 +78,18 @@ TEST(LocalPRGTest, isalphaSpaceString) {
     bool a1 = l1.isalpha_string("AGCT T");
     bool a2 = l2.isalpha_string("AGCT T");
     bool a3 = l3.isalpha_string("AGCT T");
-    EXPECT_EQ(a0, 0) << "isalpha_string thinks a string  containing a space is alphabetic for l0";
-    EXPECT_EQ(a1, 0) << "isalpha_string thinks a string  containing a space is alphabetic for l1";
-    EXPECT_EQ(a2, 0) << "isalpha_string thinks a string  containing a space is alphabetic for l2";
-    EXPECT_EQ(a3, 0) << "isalpha_string thinks a string  containing a space is alphabetic for l3";
+    EXPECT_EQ(a0, 0)
+        << "isalpha_string thinks a string  containing a space is alphabetic for l0";
+    EXPECT_EQ(a1, 0)
+        << "isalpha_string thinks a string  containing a space is alphabetic for l1";
+    EXPECT_EQ(a2, 0)
+        << "isalpha_string thinks a string  containing a space is alphabetic for l2";
+    EXPECT_EQ(a3, 0)
+        << "isalpha_string thinks a string  containing a space is alphabetic for l3";
 }
 
-TEST(LocalPRGTest, isalphaNumberString) {
+TEST(LocalPRGTest, isalphaNumberString)
+{
     LocalPRG l0(0, "empty", "");
     LocalPRG l1(1, "simple", "AGCT");
     LocalPRG l2(2, "varsite", "A 5 GC 6 G 5 T");
@@ -88,20 +99,25 @@ TEST(LocalPRGTest, isalphaNumberString) {
     bool a1 = l1.isalpha_string("AGCT 8 T");
     bool a2 = l2.isalpha_string("AGCT 8 T");
     bool a3 = l3.isalpha_string("AGCT 8 T");
-    EXPECT_EQ(a0, 0) << "isalpha_string thinks a string  containing a number is alphabetic for l0";
-    EXPECT_EQ(a1, 0) << "isalpha_string thinks a string  containing a number is alphabetic for l1";
-    EXPECT_EQ(a2, 0) << "isalpha_string thinks a string  containing a number is alphabetic for l2";
-    EXPECT_EQ(a3, 0) << "isalpha_string thinks a string  containing a number is alphabetic for l3";
+    EXPECT_EQ(a0, 0)
+        << "isalpha_string thinks a string  containing a number is alphabetic for l0";
+    EXPECT_EQ(a1, 0)
+        << "isalpha_string thinks a string  containing a number is alphabetic for l1";
+    EXPECT_EQ(a2, 0)
+        << "isalpha_string thinks a string  containing a number is alphabetic for l2";
+    EXPECT_EQ(a3, 0)
+        << "isalpha_string thinks a string  containing a number is alphabetic for l3";
 }
 
-TEST(LocalPRGTest, string_along_path) {
+TEST(LocalPRGTest, string_along_path)
+{
     LocalPRG l0(0, "empty", "");
     LocalPRG l1(1, "simple", "AGCT");
     LocalPRG l2(2, "varsite", "A 5 GC 6 G 5 T");
     LocalPRG l3(3, "nested varsite", "A 5 G 7 C 8 T 7  6 G 5 T");
 
     // empty interval
-    deque<Interval> d = {Interval(0, 0)};
+    deque<Interval> d = { Interval(0, 0) };
     prg::Path p;
     p.initialize(d);
     EXPECT_EQ("", l0.string_along_path(p));
@@ -110,28 +126,28 @@ TEST(LocalPRGTest, string_along_path) {
     EXPECT_EQ("", l3.string_along_path(p));
 
     // positive length interval
-    d = {Interval(1, 3)};
+    d = { Interval(1, 3) };
     p.initialize(d);
     EXPECT_EQ("GC", l1.string_along_path(p));
     EXPECT_EQ(" 5", l2.string_along_path(p));
     EXPECT_EQ(" 5", l3.string_along_path(p));
 
     // multiple intervals
-    d = {Interval(0, 1), Interval(2, 3)};
+    d = { Interval(0, 1), Interval(2, 3) };
     p.initialize(d);
     EXPECT_EQ("AC", l1.string_along_path(p));
     EXPECT_EQ("A5", l2.string_along_path(p));
     EXPECT_EQ("A5", l3.string_along_path(p));
 
     // including empty interval
-    d = {Interval(0, 1), Interval(2, 2)};
+    d = { Interval(0, 1), Interval(2, 2) };
     p.initialize(d);
     EXPECT_EQ("A", l1.string_along_path(p));
     EXPECT_EQ("A", l2.string_along_path(p));
     EXPECT_EQ("A", l3.string_along_path(p));
 
     // forbidden paths
-    d = {Interval(2, 3), Interval(13, 25)};
+    d = { Interval(2, 3), Interval(13, 25) };
     p.initialize(d);
     EXPECT_DEATH(l1.string_along_path(p), "");
     EXPECT_DEATH(l1.string_along_path(p), "");
@@ -139,35 +155,37 @@ TEST(LocalPRGTest, string_along_path) {
     EXPECT_DEATH(l3.string_along_path(p), "");
 }
 
-TEST(LocalPRGTest, string_along_localpath) {
+TEST(LocalPRGTest, string_along_localpath)
+{
     LocalPRG l0(0, "empty", "");
     LocalPRG l1(1, "simple", "AGCT");
     LocalPRG l2(2, "varsite", "A 5 GC 6 G 5 T");
 
     // empty interval
-    vector<LocalNodePtr> p = {l0.prg.nodes[0]};
+    vector<LocalNodePtr> p = { l0.prg.nodes[0] };
     EXPECT_EQ("", l0.string_along_path(p));
-    p = {l1.prg.nodes[0]};
+    p = { l1.prg.nodes[0] };
     EXPECT_EQ("AGCT", l1.string_along_path(p));
 
     // extract from intervals
-    p = {l2.prg.nodes[0], l2.prg.nodes[1]};
+    p = { l2.prg.nodes[0], l2.prg.nodes[1] };
     EXPECT_EQ("AGC", l2.string_along_path(p));
-    p = {l2.prg.nodes[0], l2.prg.nodes[2], l2.prg.nodes[3]};
+    p = { l2.prg.nodes[0], l2.prg.nodes[2], l2.prg.nodes[3] };
     EXPECT_EQ("AGT", l2.string_along_path(p));
 }
 
-//core function called to test the LocalPRG::nodes_along_path() method in both tests that follow:
-//TEST(LocalPRGTest, nodes_along_path_without_memoization) and
-//TEST(LocalPRGTest, nodes_along_path_with_memoization)
-void nodes_along_path_core_test() {
+// core function called to test the LocalPRG::nodes_along_path() method in both tests
+// that follow: TEST(LocalPRGTest, nodes_along_path_without_memoization) and
+// TEST(LocalPRGTest, nodes_along_path_with_memoization)
+void nodes_along_path_core_test()
+{
     LocalPRG l0(0, "empty", "");
     LocalPRG l1(1, "simple", "AGCT");
     LocalPRG l2(2, "varsite", "A 5 GC 6 G 5 T");
     LocalPRG l3(3, "nested varsite", "A 5 G 7 C 8 T 7  6 G 5 T");
 
     // empty interval expects no nodes along
-    deque<Interval> d = {Interval(0, 0)};
+    deque<Interval> d = { Interval(0, 0) };
     prg::Path p1;
     p1.initialize(d);
     prg::Path p2;
@@ -176,13 +194,13 @@ void nodes_along_path_core_test() {
     p3.initialize(d);
     vector<LocalNodePtr> v;
 
-    //EXPECT_EQ(v, l0.nodes_along_path(p));
+    // EXPECT_EQ(v, l0.nodes_along_path(p));
     EXPECT_EQ(v, l1.nodes_along_path(p1));
     EXPECT_EQ(v, l2.nodes_along_path(p2));
     EXPECT_EQ(v, l3.nodes_along_path(p3));
 
     // positive length interval
-    d = {Interval(1, 3)};
+    d = { Interval(1, 3) };
     p1.initialize(d);
     p2.initialize(d);
     p3.initialize(d);
@@ -193,7 +211,7 @@ void nodes_along_path_core_test() {
     EXPECT_EQ(j, l2.nodes_along_path(p2).size()); // no nodes in this interval
     EXPECT_EQ(j, l3.nodes_along_path(p3).size());
     // different interval
-    d = {Interval(4, 5)};
+    d = { Interval(4, 5) };
     p1.initialize(d);
     p2.initialize(d);
     p3.initialize(d);
@@ -204,7 +222,7 @@ void nodes_along_path_core_test() {
     EXPECT_EQ(j, l3.nodes_along_path(p3)[0]->id);
 
     // multiple intervals
-    d = {Interval(0, 1), Interval(4, 5)};
+    d = { Interval(0, 1), Interval(4, 5) };
     p1.initialize(d);
     p2.initialize(d);
     p3.initialize(d);
@@ -222,7 +240,7 @@ void nodes_along_path_core_test() {
     EXPECT_EQ(j, l3.nodes_along_path(p3)[1]->id);
 
     // including empty interval
-    d = {Interval(12, 13), Interval(16, 16), Interval(23, 24)};
+    d = { Interval(12, 13), Interval(16, 16), Interval(23, 24) };
     p1.initialize(d);
     p2.initialize(d);
     p3.initialize(d);
@@ -236,7 +254,7 @@ void nodes_along_path_core_test() {
     EXPECT_EQ(j, l3.nodes_along_path(p3)[2]->id);
 
     // a path with an empty node at end
-    d = {Interval(12, 13), Interval(16, 16), Interval(23, 23)};
+    d = { Interval(12, 13), Interval(16, 16), Interval(23, 23) };
     p1.initialize(d);
     p2.initialize(d);
     p3.initialize(d);
@@ -250,7 +268,7 @@ void nodes_along_path_core_test() {
     EXPECT_EQ(j, l3.nodes_along_path(p3)[2]->id);
 
     // and a path which ends on a null node
-    d = {Interval(12, 13), Interval(16, 16)};
+    d = { Interval(12, 13), Interval(16, 16) };
     p1.initialize(d);
     p2.initialize(d);
     p3.initialize(d);
@@ -263,7 +281,7 @@ void nodes_along_path_core_test() {
     EXPECT_EQ(j, l3.nodes_along_path(p3)[1]->id);
 
     // and a path that can't really exist still works
-    d = {Interval(12, 13), Interval(19, 20)};
+    d = { Interval(12, 13), Interval(19, 20) };
     p1.initialize(d);
     p2.initialize(d);
     p3.initialize(d);
@@ -275,18 +293,21 @@ void nodes_along_path_core_test() {
     EXPECT_EQ(j, l3.nodes_along_path(p3)[1]->id);
 }
 
-TEST(LocalPRGTest, nodes_along_path_without_memoization) {
+TEST(LocalPRGTest, nodes_along_path_without_memoization)
+{
     LocalPRG::do_path_memoization_in_nodes_along_path_method = false;
     nodes_along_path_core_test();
 }
 
-TEST(LocalPRGTest, nodes_along_path_with_memoization) {
+TEST(LocalPRGTest, nodes_along_path_with_memoization)
+{
     LocalPRG::do_path_memoization_in_nodes_along_path_method = true;
     nodes_along_path_core_test();
     LocalPRG::do_path_memoization_in_nodes_along_path_method = false;
 }
 
-TEST(LocalPRGTest, split_by_siteNoSites) {
+TEST(LocalPRGTest, split_by_siteNoSites)
+{
     LocalPRG l0(0, "empty", "");
     LocalPRG l1(1, "simple", "AGCT");
     LocalPRG l2(2, "varsite", "A 5 GC 6 G 5 T");
@@ -295,57 +316,75 @@ TEST(LocalPRGTest, split_by_siteNoSites) {
     vector<Interval> v0, v1;
     v0.push_back(Interval(0, 0));
     EXPECT_ITERABLE_EQ(vector<Interval>, v0,
-                       l0.split_by_site(Interval(0, 0)));// << "Failed to split empty string with input Interval";
+        l0.split_by_site(
+            Interval(0, 0))); // << "Failed to split empty string with input Interval";
     v1.push_back(Interval(0, 4));
     EXPECT_ITERABLE_EQ(vector<Interval>, v1,
-                       l1.split_by_site(Interval(0, 4)));// << "Failed to split string with input Interval";
+        l1.split_by_site(
+            Interval(0, 4))); // << "Failed to split string with input Interval";
     v1.clear();
     v1.push_back(Interval(0, 2));
     EXPECT_ITERABLE_EQ(vector<Interval>, v1,
-                       l1.split_by_site(Interval(0, 2)));// << "Failed to split string with short input Interval";
+        l1.split_by_site(
+            Interval(0, 2))); // << "Failed to split string with short input Interval";
     v1.clear();
     v1.push_back(Interval(1, 3));
     EXPECT_ITERABLE_EQ(vector<Interval>, v1,
-                       l1.split_by_site(Interval(1, 3)));// << "Failed to split string with middle input Interval";
+        l1.split_by_site(
+            Interval(1, 3))); // << "Failed to split string with middle input Interval";
 }
 
-TEST(LocalPRGTest, split_by_siteSite) {
+TEST(LocalPRGTest, split_by_siteSite)
+{
     LocalPRG l2(2, "varsite", "A 5 GC 6 G 5 T");
 
     vector<Interval> v2;
     v2.push_back(Interval(0, 1));
     l2.next_site = 5;
     EXPECT_ITERABLE_EQ(vector<Interval>, v2,
-                       l2.split_by_site(Interval(0, 1)));// << "Failed to split string in Interval" << Interval(0,1);
+        l2.split_by_site(Interval(
+            0, 1))); // << "Failed to split string in Interval" << Interval(0,1);
     EXPECT_ITERABLE_EQ(vector<Interval>, v2,
-                       l2.split_by_site(Interval(0, 2)));// << "Failed to split string in Interval" << Interval(0,2);
+        l2.split_by_site(Interval(
+            0, 2))); // << "Failed to split string in Interval" << Interval(0,2);
     EXPECT_ITERABLE_EQ(vector<Interval>, v2,
-                       l2.split_by_site(Interval(0, 3)));// << "Failed to split string in Interval" << Interval(0,3);
-    //EXPECT_ITERABLE_EQ( vector< Interval >,v2, l2.split_by_site(Interval(0,4)));// << "Failed to split string in Interval" << Interval(0,4);
+        l2.split_by_site(Interval(
+            0, 3))); // << "Failed to split string in Interval" << Interval(0,3);
+    // EXPECT_ITERABLE_EQ( vector< Interval >,v2, l2.split_by_site(Interval(0,4)));// <<
+    // "Failed to split string in Interval" << Interval(0,4);
     v2.push_back(Interval(4, 6));
     EXPECT_ITERABLE_EQ(vector<Interval>, v2,
-                       l2.split_by_site(Interval(0, 6)));// << "Failed to split string in Interval" << Interval(0,6);
+        l2.split_by_site(Interval(
+            0, 6))); // << "Failed to split string in Interval" << Interval(0,6);
     EXPECT_ITERABLE_EQ(vector<Interval>, v2,
-                       l2.split_by_site(Interval(0, 7)));// << "Failed to split string in Interval" << Interval(0,7);
+        l2.split_by_site(Interval(
+            0, 7))); // << "Failed to split string in Interval" << Interval(0,7);
     EXPECT_ITERABLE_EQ(vector<Interval>, v2,
-                       l2.split_by_site(Interval(0, 8)));// << "Failed to split string in Interval" << Interval(0,8);
+        l2.split_by_site(Interval(
+            0, 8))); // << "Failed to split string in Interval" << Interval(0,8);
     v2.push_back(Interval(9, 10));
     EXPECT_ITERABLE_EQ(vector<Interval>, v2,
-                       l2.split_by_site(Interval(0, 10)));// << "Failed to split string in Interval" << Interval(0,10);
+        l2.split_by_site(Interval(
+            0, 10))); // << "Failed to split string in Interval" << Interval(0,10);
     EXPECT_ITERABLE_EQ(vector<Interval>, v2,
-                       l2.split_by_site(Interval(0, 11)));// << "Failed to split string in Interval" << Interval(0,11);
+        l2.split_by_site(Interval(
+            0, 11))); // << "Failed to split string in Interval" << Interval(0,11);
     EXPECT_ITERABLE_EQ(vector<Interval>, v2,
-                       l2.split_by_site(Interval(0, 12)));// << "Failed to split string in Interval" << Interval(0,12);
+        l2.split_by_site(Interval(
+            0, 12))); // << "Failed to split string in Interval" << Interval(0,12);
     v2.push_back(Interval(13, 14));
     EXPECT_ITERABLE_EQ(vector<Interval>, v2,
-                       l2.split_by_site(Interval(0, 14)));// << "Failed to split string in Interval" << Interval(0,14);
+        l2.split_by_site(Interval(
+            0, 14))); // << "Failed to split string in Interval" << Interval(0,14);
     v2.clear();
     v2.push_back(Interval(5, 6));
-    EXPECT_ITERABLE_EQ(vector<Interval>, v2, l2.split_by_site(
-            Interval(5, 8)));// << "Failed to split string in mid Interval" << Interval(5,8);
+    EXPECT_ITERABLE_EQ(vector<Interval>, v2,
+        l2.split_by_site(Interval(
+            5, 8))); // << "Failed to split string in mid Interval" << Interval(5,8);
 }
 
-TEST(LocalPRGTest, split_by_siteNestedSite) {
+TEST(LocalPRGTest, split_by_siteNestedSite)
+{
     LocalPRG l3(3, "nested varsite", "A 5 G 7 C 8 T 7  6 G 5 T");
     LocalPRG l4(4, "nested varsite start immediately", " 5 G 7 C 8 T 7  6 G 5 ");
 
@@ -353,69 +392,89 @@ TEST(LocalPRGTest, split_by_siteNestedSite) {
     v3.push_back(Interval(0, 1));
     l3.next_site = 5;
     EXPECT_ITERABLE_EQ(vector<Interval>, v3,
-                       l3.split_by_site(Interval(0, 1)));// << "Failed to split string in Interval" << Interval(0,1);
+        l3.split_by_site(Interval(
+            0, 1))); // << "Failed to split string in Interval" << Interval(0,1);
     EXPECT_ITERABLE_EQ(vector<Interval>, v3,
-                       l3.split_by_site(Interval(0, 2)));// << "Failed to split string in Interval" << Interval(0,2);
+        l3.split_by_site(Interval(
+            0, 2))); // << "Failed to split string in Interval" << Interval(0,2);
     EXPECT_ITERABLE_EQ(vector<Interval>, v3,
-                       l3.split_by_site(Interval(0, 3)));// << "Failed to split string in Interval" << Interval(0,3);
-    //EXPECT_ITERABLE_EQ( vector< Interval >,v3, l3.split_by_site(Interval(0,4)));// << "Failed to split string in Interval" << Interval(0,4);
+        l3.split_by_site(Interval(
+            0, 3))); // << "Failed to split string in Interval" << Interval(0,3);
+    // EXPECT_ITERABLE_EQ( vector< Interval >,v3, l3.split_by_site(Interval(0,4)));// <<
+    // "Failed to split string in Interval" << Interval(0,4);
     v3.push_back(Interval(4, 16));
     EXPECT_ITERABLE_EQ(vector<Interval>, v3,
-                       l3.split_by_site(Interval(0, 16)));// << "Failed to split string in Interval" << Interval(0,6);
+        l3.split_by_site(Interval(
+            0, 16))); // << "Failed to split string in Interval" << Interval(0,6);
     EXPECT_ITERABLE_EQ(vector<Interval>, v3,
-                       l3.split_by_site(Interval(0, 17)));// << "Failed to split string in Interval" << Interval(0,7);
+        l3.split_by_site(Interval(
+            0, 17))); // << "Failed to split string in Interval" << Interval(0,7);
     EXPECT_ITERABLE_EQ(vector<Interval>, v3,
-                       l3.split_by_site(Interval(0, 18)));// << "Failed to split string in Interval" << Interval(0,8);
+        l3.split_by_site(Interval(
+            0, 18))); // << "Failed to split string in Interval" << Interval(0,8);
     v3.push_back(Interval(19, 20));
     EXPECT_ITERABLE_EQ(vector<Interval>, v3,
-                       l3.split_by_site(Interval(0, 20)));// << "Failed to split string in Interval" << Interval(0,10);
+        l3.split_by_site(Interval(
+            0, 20))); // << "Failed to split string in Interval" << Interval(0,10);
     EXPECT_ITERABLE_EQ(vector<Interval>, v3,
-                       l3.split_by_site(Interval(0, 21)));// << "Failed to split string in Interval" << Interval(0,11);
+        l3.split_by_site(Interval(
+            0, 21))); // << "Failed to split string in Interval" << Interval(0,11);
     EXPECT_ITERABLE_EQ(vector<Interval>, v3,
-                       l3.split_by_site(Interval(0, 22)));// << "Failed to split string in Interval" << Interval(0,12);
+        l3.split_by_site(Interval(
+            0, 22))); // << "Failed to split string in Interval" << Interval(0,12);
     v3.push_back(Interval(23, 24));
     EXPECT_ITERABLE_EQ(vector<Interval>, v3,
-                       l3.split_by_site(Interval(0, 24)));// << "Failed to split string in Interval" << Interval(0,14);
+        l3.split_by_site(Interval(
+            0, 24))); // << "Failed to split string in Interval" << Interval(0,14);
     l3.next_site = 7;
     v3.clear();
     v3.push_back(Interval(4, 5));
     v3.push_back(Interval(8, 9));
     v3.push_back(Interval(12, 13));
     v3.push_back(Interval(16, 16));
-    EXPECT_ITERABLE_EQ(vector<Interval>, v3, l3.split_by_site(
-            Interval(4, 16)));// << "Failed to split string in mid Interval" << Interval(5,8);
+    EXPECT_ITERABLE_EQ(vector<Interval>, v3,
+        l3.split_by_site(Interval(
+            4, 16))); // << "Failed to split string in mid Interval" << Interval(5,8);
 
     vector<Interval> v4;
     v4.push_back(Interval(0, 0));
     l4.next_site = 5;
     EXPECT_ITERABLE_EQ(vector<Interval>, v4,
-                       l4.split_by_site(Interval(0, 1)));// << "Failed to split string in Interval" << Interval(0,1);
+        l4.split_by_site(Interval(
+            0, 1))); // << "Failed to split string in Interval" << Interval(0,1);
     EXPECT_ITERABLE_EQ(vector<Interval>, v4,
-                       l4.split_by_site(Interval(0, 2)));// << "Failed to split string in Interval" << Interval(0,2);
+        l4.split_by_site(Interval(
+            0, 2))); // << "Failed to split string in Interval" << Interval(0,2);
     v4.push_back(Interval(3, 15));
     EXPECT_ITERABLE_EQ(vector<Interval>, v4,
-                       l4.split_by_site(Interval(0, 15)));// << "Failed to split string in Interval" << Interval(0,6);
+        l4.split_by_site(Interval(
+            0, 15))); // << "Failed to split string in Interval" << Interval(0,6);
     EXPECT_ITERABLE_EQ(vector<Interval>, v4,
-                       l4.split_by_site(Interval(0, 16)));// << "Failed to split string in Interval" << Interval(0,7);
+        l4.split_by_site(Interval(
+            0, 16))); // << "Failed to split string in Interval" << Interval(0,7);
     EXPECT_ITERABLE_EQ(vector<Interval>, v4,
-                       l4.split_by_site(Interval(0, 17)));// << "Failed to split string in Interval" << Interval(0,8);
+        l4.split_by_site(Interval(
+            0, 17))); // << "Failed to split string in Interval" << Interval(0,8);
     v4.push_back(Interval(18, 19));
     EXPECT_ITERABLE_EQ(vector<Interval>, v4,
-                       l4.split_by_site(Interval(0, 19)));// << "Failed to split string in Interval" << Interval(0,10);
+        l4.split_by_site(Interval(
+            0, 19))); // << "Failed to split string in Interval" << Interval(0,10);
     EXPECT_ITERABLE_EQ(vector<Interval>, v4,
-                       l4.split_by_site(Interval(0, 20)));// << "Failed to split string in Interval" << Interval(0,11);
+        l4.split_by_site(Interval(
+            0, 20))); // << "Failed to split string in Interval" << Interval(0,11);
     l4.next_site = 7;
     v4.clear();
     v4.push_back(Interval(0, 4));
     v4.push_back(Interval(7, 8));
     v4.push_back(Interval(11, 12));
     v4.push_back(Interval(15, 22));
-    EXPECT_ITERABLE_EQ(vector<Interval>, v4, l4.split_by_site(
-            Interval(0, 22)));// << "Failed to split string in mid Interval" << Interval(5,8);
-
+    EXPECT_ITERABLE_EQ(vector<Interval>, v4,
+        l4.split_by_site(Interval(
+            0, 22))); // << "Failed to split string in mid Interval" << Interval(5,8);
 }
 
-TEST(LocalPRGTest, build_graph) {
+TEST(LocalPRGTest, build_graph)
+{
     LocalPRG l0(0, "empty", "");
     LocalPRG l1(1, "simple", "AGCT");
     LocalPRG l2(2, "varsite", "A 5 GC 6 G 5 T");
@@ -459,102 +518,119 @@ TEST(LocalPRGTest, build_graph) {
     EXPECT_EQ(lg3, l3.prg);
 }
 
-TEST(LocalPRGTest, shift) {
+TEST(LocalPRGTest, shift)
+{
     LocalPRG l1(1, "simple", "AGCT");
     LocalPRG l2(2, "varsite", "A 5 GC 6 G 5 T");
     LocalPRG l3(3, "nested varsite", "AT 5 G 7 C 8 T 7  6 G 5 T");
-    //LocalPRG l4(4, "much more complex", "TCATTC 5 ACTC 7 TAGTCA 8 TTGTGA 7  6 AACTAG 5 AGCTG");
-    LocalPRG l5(5, "one with lots of null at start and end, and a long stretch in between",
-                " 5  7  9  11 AGTTCTGAAACATTGCGCGTGAGATCTCTG 12 T 11  10 A 9  8 C 7  6 G 5 ");
-    LocalPRG l6(6, "one representing a possible deletion at end", "GATCTCTAG 5 TTATG 6  5 ");
+    // LocalPRG l4(4, "much more complex", "TCATTC 5 ACTC 7 TAGTCA 8 TTGTGA 7  6 AACTAG
+    // 5 AGCTG");
+    LocalPRG l5(5,
+        "one with lots of null at start and end, and a long stretch in between",
+        " 5  7  9  11 AGTTCTGAAACATTGCGCGTGAGATCTCTG 12 T 11  10 A 9  8 C 7  6 G 5 ");
+    LocalPRG l6(
+        6, "one representing a possible deletion at end", "GATCTCTAG 5 TTATG 6  5 ");
 
-    deque<Interval> d = {Interval(0, 3)};
+    deque<Interval> d = { Interval(0, 3) };
     prg::Path p, q;
     p.initialize(d);
-    d = {Interval(1, 4)};
+    d = { Interval(1, 4) };
     q.initialize(d);
     vector<PathPtr> v_exp = { std::make_shared<prg::Path>(q) };
-    bool equal = std::equal(v_exp.begin(), v_exp.end(), l1.shift(p).begin(), ComparePathPtr());
+    bool equal
+        = std::equal(v_exp.begin(), v_exp.end(), l1.shift(p).begin(), ComparePathPtr());
     EXPECT_EQ(equal, true);
     v_exp.clear();
-    equal = std::equal(v_exp.begin(), v_exp.end(), l1.shift(q).begin(), ComparePathPtr());
+    equal
+        = std::equal(v_exp.begin(), v_exp.end(), l1.shift(q).begin(), ComparePathPtr());
     EXPECT_EQ(equal, true);
 
-    d = {Interval(0, 1), Interval(4, 6)};
+    d = { Interval(0, 1), Interval(4, 6) };
     p.initialize(d);
-    d = {Interval(4, 6), Interval(13, 14)};
+    d = { Interval(4, 6), Interval(13, 14) };
     q.initialize(d);
     v_exp = { std::make_shared<prg::Path>(q) };
-    equal = std::equal(v_exp.begin(), v_exp.end(), l2.shift(p).begin(), ComparePathPtr());
+    equal
+        = std::equal(v_exp.begin(), v_exp.end(), l2.shift(p).begin(), ComparePathPtr());
     EXPECT_EQ(equal, true);
     v_exp.clear();
-    equal = std::equal(v_exp.begin(), v_exp.end(), l2.shift(q).begin(), ComparePathPtr());
-    EXPECT_EQ(equal, true);
-
-    v_exp.clear();
-    d = {Interval(0, 2)};
-    p.initialize(d);
-    d = {Interval(1, 2), Interval(5, 6)};
-    q.initialize(d);
-    v_exp.push_back(std::make_shared<prg::Path>(q));
-    d = {Interval(1, 2), Interval(20, 21)};
-    q.initialize(d);
-    v_exp.push_back(std::make_shared<prg::Path>(q));
-    equal = std::equal(v_exp.begin(), v_exp.end(), l3.shift(p).begin(), ComparePathPtr());
+    equal
+        = std::equal(v_exp.begin(), v_exp.end(), l2.shift(q).begin(), ComparePathPtr());
     EXPECT_EQ(equal, true);
 
     v_exp.clear();
-    d = {Interval(1, 2), Interval(5, 6)};
+    d = { Interval(0, 2) };
     p.initialize(d);
-    d = {Interval(5, 6), Interval(9, 10)};
+    d = { Interval(1, 2), Interval(5, 6) };
     q.initialize(d);
     v_exp.push_back(std::make_shared<prg::Path>(q));
-    d = {Interval(5, 6), Interval(13, 14)};
+    d = { Interval(1, 2), Interval(20, 21) };
     q.initialize(d);
     v_exp.push_back(std::make_shared<prg::Path>(q));
-    equal = std::equal(v_exp.begin(), v_exp.end(), l3.shift(p).begin(), ComparePathPtr());
+    equal
+        = std::equal(v_exp.begin(), v_exp.end(), l3.shift(p).begin(), ComparePathPtr());
     EXPECT_EQ(equal, true);
 
     v_exp.clear();
-    d = {Interval(0, 0), Interval(3, 3), Interval(6, 6), Interval(9, 9), Interval(13, 18)};
+    d = { Interval(1, 2), Interval(5, 6) };
     p.initialize(d);
-    d = {Interval(14, 19)};
+    d = { Interval(5, 6), Interval(9, 10) };
     q.initialize(d);
     v_exp.push_back(std::make_shared<prg::Path>(q));
-    equal = std::equal(v_exp.begin(), v_exp.end(), l5.shift(p).begin(), ComparePathPtr());
+    d = { Interval(5, 6), Interval(13, 14) };
+    q.initialize(d);
+    v_exp.push_back(std::make_shared<prg::Path>(q));
+    equal
+        = std::equal(v_exp.begin(), v_exp.end(), l3.shift(p).begin(), ComparePathPtr());
     EXPECT_EQ(equal, true);
 
     v_exp.clear();
-    d = {Interval(3, 8)};
+    d = { Interval(0, 0), Interval(3, 3), Interval(6, 6), Interval(9, 9),
+        Interval(13, 18) };
     p.initialize(d);
-    d = {Interval(4, 9), Interval(20, 20), Interval(23, 23)};
+    d = { Interval(14, 19) };
     q.initialize(d);
     v_exp.push_back(std::make_shared<prg::Path>(q));
-    d = {Interval(4, 9)};
-    q.initialize(d);
-    v_exp.push_back(std::make_shared<prg::Path>(q));
-    equal = std::equal(v_exp.begin(), v_exp.end(), l6.shift(p).begin(), ComparePathPtr());
+    equal
+        = std::equal(v_exp.begin(), v_exp.end(), l5.shift(p).begin(), ComparePathPtr());
     EXPECT_EQ(equal, true);
 
     v_exp.clear();
-    d = {Interval(4, 9)};
+    d = { Interval(3, 8) };
     p.initialize(d);
-    d = {Interval(5, 9), Interval(12, 13)};
+    d = { Interval(4, 9), Interval(20, 20), Interval(23, 23) };
     q.initialize(d);
     v_exp.push_back(std::make_shared<prg::Path>(q));
-    equal = std::equal(v_exp.begin(), v_exp.end(), l6.shift(p).begin(), ComparePathPtr());
+    d = { Interval(4, 9) };
+    q.initialize(d);
+    v_exp.push_back(std::make_shared<prg::Path>(q));
+    equal
+        = std::equal(v_exp.begin(), v_exp.end(), l6.shift(p).begin(), ComparePathPtr());
+    EXPECT_EQ(equal, true);
+
+    v_exp.clear();
+    d = { Interval(4, 9) };
+    p.initialize(d);
+    d = { Interval(5, 9), Interval(12, 13) };
+    q.initialize(d);
+    v_exp.push_back(std::make_shared<prg::Path>(q));
+    equal
+        = std::equal(v_exp.begin(), v_exp.end(), l6.shift(p).begin(), ComparePathPtr());
     EXPECT_EQ(equal, true);
 }
 
-TEST(LocalPRGTest, minimizer_sketch) {
+TEST(LocalPRGTest, minimizer_sketch)
+{
     // note this is a bad test
     LocalPRG l0(0, "empty", "");
     LocalPRG l1(1, "simple", "AGCT");
     LocalPRG l2(2, "varsite", "A 5 GC 6 G 5 T");
     LocalPRG l3(3, "nested varsite", "A 5 G 7 C 8 T 7  6 G 5 T");
-    LocalPRG l4(4, "much more complex", "TCATTC 5 ACTC 7 TAGTCA 8 TTGTGA 7  6 AACTAG 5 AGCTG");
-    LocalPRG l5(5, "one with lots of null at start and end, and a long stretch in between",
-                " 5  7  9  11 AGTTCTGAAACATTGCGCGTGAGATCTCTG 12 T 11  10 A 9  8 C 7  6 G 5 ");
+    LocalPRG l4(
+        4, "much more complex", "TCATTC 5 ACTC 7 TAGTCA 8 TTGTGA 7  6 AACTAG 5 AGCTG");
+    LocalPRG l5(5,
+        "one with lots of null at start and end, and a long stretch in between",
+        " 5  7  9  11 AGTTCTGAAACATTGCGCGTGAGATCTCTG 12 T 11  10 A 9  8 C 7  6 G 5 ");
     LocalPRG l6(2, "too short for w and k", "A 5 GC 6 G 5 T");
 
     auto index = std::make_shared<Index>();
@@ -594,9 +670,9 @@ TEST(LocalPRGTest, minimizer_sketch) {
     EXPECT_EQ(j, index->minhash.size());
     j = 2;
     kh = hash.kmerhash("AGC", 3);
-    EXPECT_EQ(j, index->minhash[min(kh.first, kh.second)]->size()); //AGC
+    EXPECT_EQ(j, index->minhash[min(kh.first, kh.second)]->size()); // AGC
     kh = hash.kmerhash("AGT", 3);
-    EXPECT_EQ(j, index->minhash[min(kh.first, kh.second)]->size()); //AGTx2
+    EXPECT_EQ(j, index->minhash[min(kh.first, kh.second)]->size()); // AGTx2
     j = 1;
     kh = hash.kmerhash("GTT", 3);
     EXPECT_EQ(j, index->minhash[min(kh.first, kh.second)]->size());
@@ -684,13 +760,26 @@ TEST(LocalPRGTest, minimizer_sketch) {
 }
 
 struct MiniPos {
-    bool operator()(Minimizer lhs, Minimizer rhs) {
+    bool operator()(Minimizer lhs, Minimizer rhs)
+    {
         return (lhs.pos_of_kmer_in_read.start) < (rhs.pos_of_kmer_in_read.start);
     }
 };
 
-TEST(LocalPRGTest, minimizer_sketch_SameAsSeqw1) {
-    std::string st = "ATGGCAATCCGAATCTTCGCGATACTTTTCTCCATTTTTTCTCTTGCCACTTTCGCGCATGCGCAAGAAGGCACGCTAGAACGTTCTGACTGGAGGAAGTTTTTCAGCGAATTTCAAGCCAAAGGCACGATAGTTGTGGCAGACGAACGCCAAGCGGATCGTGCCATGTTGGTTTTTGATCCTGTGCGATCGAAGAAACGCTACTCGCCTGCATCGACATTCAAGATACCTCATACACTTTTTGCACTTGATGCAGGCGCTGTTCGTGATGAGTTCCAGATTTTTCGATGGGACGGCGTTAACAGGGGCTTTGCAGGCCACAATCAAGACCAAGATTTGCGATCAGCAATGCGGAATTCTACTGTTTGGGTGTATGAGCTATTTGCAAAGGAAATTGGTGATGACAAAGCTCGGCGCTATTTGAAGAAAATCGACTATGGCAACGCCGATCCTTCGACAAGTAATGGCGATTACTGTATAGAAGGCAGCCTTGCAATCTCGGCGCAGGAGCAAATTGCATTTCTCAGGAAGCTCTATCGTAACGAGCTGCCCTTTCGGGTAGAACATCAGCGCTTGGTCAAGGATCTCATGATTGTGGAAGCCGGTCGCAACTGGATACTGCGTGCAAAGACGGGCTGGGAAGGCCGTATGGGTTGGTGGGTAGGATGGGTTGAGTGGCCGACTGGCTCCGTATTCTTCGCACTGAATATTGATACGCCAAACAGAATGGATGATCTTTTCAAGAGGGAGGCAATCGTGCGGGCAATCCTT";
+TEST(LocalPRGTest, minimizer_sketch_SameAsSeqw1)
+{
+    std::string st
+        = "ATGGCAATCCGAATCTTCGCGATACTTTTCTCCATTTTTTCTCTTGCCACTTTCGCGCATGCGCAAGAAGGCACGC"
+          "TAGAACGTTCTGACTGGAGGAAGTTTTTCAGCGAATTTCAAGCCAAAGGCACGATAGTTGTGGCAGACGAACGCCA"
+          "AGCGGATCGTGCCATGTTGGTTTTTGATCCTGTGCGATCGAAGAAACGCTACTCGCCTGCATCGACATTCAAGATA"
+          "CCTCATACACTTTTTGCACTTGATGCAGGCGCTGTTCGTGATGAGTTCCAGATTTTTCGATGGGACGGCGTTAACA"
+          "GGGGCTTTGCAGGCCACAATCAAGACCAAGATTTGCGATCAGCAATGCGGAATTCTACTGTTTGGGTGTATGAGCT"
+          "ATTTGCAAAGGAAATTGGTGATGACAAAGCTCGGCGCTATTTGAAGAAAATCGACTATGGCAACGCCGATCCTTCG"
+          "ACAAGTAATGGCGATTACTGTATAGAAGGCAGCCTTGCAATCTCGGCGCAGGAGCAAATTGCATTTCTCAGGAAGC"
+          "TCTATCGTAACGAGCTGCCCTTTCGGGTAGAACATCAGCGCTTGGTCAAGGATCTCATGATTGTGGAAGCCGGTCG"
+          "CAACTGGATACTGCGTGCAAAGACGGGCTGGGAAGGCCGTATGGGTTGGTGGGTAGGATGGGTTGAGTGGCCGACT"
+          "GGCTCCGTATTCTTCGCACTGAATATTGATACGCCAAACAGAATGGATGATCTTTTCAAGAGGGAGGCAATCGTGC"
+          "GGGCAATCCTT";
 
     auto index = std::make_shared<Index>();
     LocalPRG l(0, "prg", st);
@@ -710,8 +799,20 @@ TEST(LocalPRGTest, minimizer_sketch_SameAsSeqw1) {
     }
 }
 
-TEST(LocalPRGTest, minimizer_sketch_SameAsSeqw5) {
-    string st = "ATGGCAATCCGAATCTTCGCGATACTTTTCTCCATTTTTTCTCTTGCCACTTTCGCGCATGCGCAAGAAGGCACGCTAGAACGTTCTGACTGGAGGAAGTTTTTCAGCGAATTTCAAGCCAAAGGCACGATAGTTGTGGCAGACGAACGCCAAGCGGATCGTGCCATGTTGGTTTTTGATCCTGTGCGATCGAAGAAACGCTACTCGCCTGCATCGACATTCAAGATACCTCATACACTTTTTGCACTTGATGCAGGCGCTGTTCGTGATGAGTTCCAGATTTTTCGATGGGACGGCGTTAACAGGGGCTTTGCAGGCCACAATCAAGACCAAGATTTGCGATCAGCAATGCGGAATTCTACTGTTTGGGTGTATGAGCTATTTGCAAAGGAAATTGGTGATGACAAAGCTCGGCGCTATTTGAAGAAAATCGACTATGGCAACGCCGATCCTTCGACAAGTAATGGCGATTACTGTATAGAAGGCAGCCTTGCAATCTCGGCGCAGGAGCAAATTGCATTTCTCAGGAAGCTCTATCGTAACGAGCTGCCCTTTCGGGTAGAACATCAGCGCTTGGTCAAGGATCTCATGATTGTGGAAGCCGGTCGCAACTGGATACTGCGTGCAAAGACGGGCTGGGAAGGCCGTATGGGTTGGTGGGTAGGATGGGTTGAGTGGCCGACTGGCTCCGTATTCTTCGCACTGAATATTGATACGCCAAACAGAATGGATGATCTTTTCAAGAGGGAGGCAATCGTGCGGGCAATCCTT";
+TEST(LocalPRGTest, minimizer_sketch_SameAsSeqw5)
+{
+    string st
+        = "ATGGCAATCCGAATCTTCGCGATACTTTTCTCCATTTTTTCTCTTGCCACTTTCGCGCATGCGCAAGAAGGCACGC"
+          "TAGAACGTTCTGACTGGAGGAAGTTTTTCAGCGAATTTCAAGCCAAAGGCACGATAGTTGTGGCAGACGAACGCCA"
+          "AGCGGATCGTGCCATGTTGGTTTTTGATCCTGTGCGATCGAAGAAACGCTACTCGCCTGCATCGACATTCAAGATA"
+          "CCTCATACACTTTTTGCACTTGATGCAGGCGCTGTTCGTGATGAGTTCCAGATTTTTCGATGGGACGGCGTTAACA"
+          "GGGGCTTTGCAGGCCACAATCAAGACCAAGATTTGCGATCAGCAATGCGGAATTCTACTGTTTGGGTGTATGAGCT"
+          "ATTTGCAAAGGAAATTGGTGATGACAAAGCTCGGCGCTATTTGAAGAAAATCGACTATGGCAACGCCGATCCTTCG"
+          "ACAAGTAATGGCGATTACTGTATAGAAGGCAGCCTTGCAATCTCGGCGCAGGAGCAAATTGCATTTCTCAGGAAGC"
+          "TCTATCGTAACGAGCTGCCCTTTCGGGTAGAACATCAGCGCTTGGTCAAGGATCTCATGATTGTGGAAGCCGGTCG"
+          "CAACTGGATACTGCGTGCAAAGACGGGCTGGGAAGGCCGTATGGGTTGGTGGGTAGGATGGGTTGAGTGGCCGACT"
+          "GGCTCCGTATTCTTCGCACTGAATATTGATACGCCAAACAGAATGGATGATCTTTTCAAGAGGGAGGCAATCGTGC"
+          "GGGCAATCCTT";
 
     auto index = std::make_shared<Index>();
     LocalPRG l(0, "prg", st);
@@ -731,8 +832,20 @@ TEST(LocalPRGTest, minimizer_sketch_SameAsSeqw5) {
     }
 }
 
-TEST(LocalPRGTest, minimizer_sketch_SameAsSeqw10) {
-    string st = "ATGGCAATCCGAATCTTCGCGATACTTTTCTCCATTTTTTCTCTTGCCACTTTCGCGCATGCGCAAGAAGGCACGCTAGAACGTTCTGACTGGAGGAAGTTTTTCAGCGAATTTCAAGCCAAAGGCACGATAGTTGTGGCAGACGAACGCCAAGCGGATCGTGCCATGTTGGTTTTTGATCCTGTGCGATCGAAGAAACGCTACTCGCCTGCATCGACATTCAAGATACCTCATACACTTTTTGCACTTGATGCAGGCGCTGTTCGTGATGAGTTCCAGATTTTTCGATGGGACGGCGTTAACAGGGGCTTTGCAGGCCACAATCAAGACCAAGATTTGCGATCAGCAATGCGGAATTCTACTGTTTGGGTGTATGAGCTATTTGCAAAGGAAATTGGTGATGACAAAGCTCGGCGCTATTTGAAGAAAATCGACTATGGCAACGCCGATCCTTCGACAAGTAATGGCGATTACTGTATAGAAGGCAGCCTTGCAATCTCGGCGCAGGAGCAAATTGCATTTCTCAGGAAGCTCTATCGTAACGAGCTGCCCTTTCGGGTAGAACATCAGCGCTTGGTCAAGGATCTCATGATTGTGGAAGCCGGTCGCAACTGGATACTGCGTGCAAAGACGGGCTGGGAAGGCCGTATGGGTTGGTGGGTAGGATGGGTTGAGTGGCCGACTGGCTCCGTATTCTTCGCACTGAATATTGATACGCCAAACAGAATGGATGATCTTTTCAAGAGGGAGGCAATCGTGCGGGCAATCCTT";
+TEST(LocalPRGTest, minimizer_sketch_SameAsSeqw10)
+{
+    string st
+        = "ATGGCAATCCGAATCTTCGCGATACTTTTCTCCATTTTTTCTCTTGCCACTTTCGCGCATGCGCAAGAAGGCACGC"
+          "TAGAACGTTCTGACTGGAGGAAGTTTTTCAGCGAATTTCAAGCCAAAGGCACGATAGTTGTGGCAGACGAACGCCA"
+          "AGCGGATCGTGCCATGTTGGTTTTTGATCCTGTGCGATCGAAGAAACGCTACTCGCCTGCATCGACATTCAAGATA"
+          "CCTCATACACTTTTTGCACTTGATGCAGGCGCTGTTCGTGATGAGTTCCAGATTTTTCGATGGGACGGCGTTAACA"
+          "GGGGCTTTGCAGGCCACAATCAAGACCAAGATTTGCGATCAGCAATGCGGAATTCTACTGTTTGGGTGTATGAGCT"
+          "ATTTGCAAAGGAAATTGGTGATGACAAAGCTCGGCGCTATTTGAAGAAAATCGACTATGGCAACGCCGATCCTTCG"
+          "ACAAGTAATGGCGATTACTGTATAGAAGGCAGCCTTGCAATCTCGGCGCAGGAGCAAATTGCATTTCTCAGGAAGC"
+          "TCTATCGTAACGAGCTGCCCTTTCGGGTAGAACATCAGCGCTTGGTCAAGGATCTCATGATTGTGGAAGCCGGTCG"
+          "CAACTGGATACTGCGTGCAAAGACGGGCTGGGAAGGCCGTATGGGTTGGTGGGTAGGATGGGTTGAGTGGCCGACT"
+          "GGCTCCGTATTCTTCGCACTGAATATTGATACGCCAAACAGAATGGATGATCTTTTCAAGAGGGAGGCAATCGTGC"
+          "GGGCAATCCTT";
 
     auto index = std::make_shared<Index>();
     LocalPRG l(0, "prg", st);
@@ -752,8 +865,20 @@ TEST(LocalPRGTest, minimizer_sketch_SameAsSeqw10) {
     }
 }
 
-TEST(LocalPRGTest, minimizer_sketch_SameAsSeqw15) {
-    string st = "ATGGCAATCCGAATCTTCGCGATACTTTTCTCCATTTTTTCTCTTGCCACTTTCGCGCATGCGCAAGAAGGCACGCTAGAACGTTCTGACTGGAGGAAGTTTTTCAGCGAATTTCAAGCCAAAGGCACGATAGTTGTGGCAGACGAACGCCAAGCGGATCGTGCCATGTTGGTTTTTGATCCTGTGCGATCGAAGAAACGCTACTCGCCTGCATCGACATTCAAGATACCTCATACACTTTTTGCACTTGATGCAGGCGCTGTTCGTGATGAGTTCCAGATTTTTCGATGGGACGGCGTTAACAGGGGCTTTGCAGGCCACAATCAAGACCAAGATTTGCGATCAGCAATGCGGAATTCTACTGTTTGGGTGTATGAGCTATTTGCAAAGGAAATTGGTGATGACAAAGCTCGGCGCTATTTGAAGAAAATCGACTATGGCAACGCCGATCCTTCGACAAGTAATGGCGATTACTGTATAGAAGGCAGCCTTGCAATCTCGGCGCAGGAGCAAATTGCATTTCTCAGGAAGCTCTATCGTAACGAGCTGCCCTTTCGGGTAGAACATCAGCGCTTGGTCAAGGATCTCATGATTGTGGAAGCCGGTCGCAACTGGATACTGCGTGCAAAGACGGGCTGGGAAGGCCGTATGGGTTGGTGGGTAGGATGGGTTGAGTGGCCGACTGGCTCCGTATTCTTCGCACTGAATATTGATACGCCAAACAGAATGGATGATCTTTTCAAGAGGGAGGCAATCGTGCGGGCAATCCTT";
+TEST(LocalPRGTest, minimizer_sketch_SameAsSeqw15)
+{
+    string st
+        = "ATGGCAATCCGAATCTTCGCGATACTTTTCTCCATTTTTTCTCTTGCCACTTTCGCGCATGCGCAAGAAGGCACGC"
+          "TAGAACGTTCTGACTGGAGGAAGTTTTTCAGCGAATTTCAAGCCAAAGGCACGATAGTTGTGGCAGACGAACGCCA"
+          "AGCGGATCGTGCCATGTTGGTTTTTGATCCTGTGCGATCGAAGAAACGCTACTCGCCTGCATCGACATTCAAGATA"
+          "CCTCATACACTTTTTGCACTTGATGCAGGCGCTGTTCGTGATGAGTTCCAGATTTTTCGATGGGACGGCGTTAACA"
+          "GGGGCTTTGCAGGCCACAATCAAGACCAAGATTTGCGATCAGCAATGCGGAATTCTACTGTTTGGGTGTATGAGCT"
+          "ATTTGCAAAGGAAATTGGTGATGACAAAGCTCGGCGCTATTTGAAGAAAATCGACTATGGCAACGCCGATCCTTCG"
+          "ACAAGTAATGGCGATTACTGTATAGAAGGCAGCCTTGCAATCTCGGCGCAGGAGCAAATTGCATTTCTCAGGAAGC"
+          "TCTATCGTAACGAGCTGCCCTTTCGGGTAGAACATCAGCGCTTGGTCAAGGATCTCATGATTGTGGAAGCCGGTCG"
+          "CAACTGGATACTGCGTGCAAAGACGGGCTGGGAAGGCCGTATGGGTTGGTGGGTAGGATGGGTTGAGTGGCCGACT"
+          "GGCTCCGTATTCTTCGCACTGAATATTGATACGCCAAACAGAATGGATGATCTTTTCAAGAGGGAGGCAATCGTGC"
+          "GGGCAATCCTT";
 
     auto index = std::make_shared<Index>();
     LocalPRG l(0, "prg", st);
@@ -773,7 +898,8 @@ TEST(LocalPRGTest, minimizer_sketch_SameAsSeqw15) {
     }
 }
 
-TEST(LocalPRGTest, localnode_path_from_kmernode_path) {
+TEST(LocalPRGTest, localnode_path_from_kmernode_path)
+{
     LocalPRG l3(3, "nested varsite", "A 5 G 7 C 8 T 7  6 G 5 T");
     LocalPRG l4(4, "much more complex", "TC 5 ACTC 7 TAGTCA 8 TTGTGA 7  6 AACTAG 5 AG");
 
@@ -782,27 +908,32 @@ TEST(LocalPRGTest, localnode_path_from_kmernode_path) {
     KmerHash hash;
 
     l3.minimizer_sketch(index, 2, 3);
-    //vector<KmerNodePtr> kmp = {l3.kmer_prg.nodes[0], l3.kmer_prg.nodes[1], l3.kmer_prg.nodes[2], l3.kmer_prg.nodes[4]};
-    vector<KmerNodePtr> kmp = {l3.kmer_prg.nodes[2], l3.kmer_prg.nodes[4]};
+    // vector<KmerNodePtr> kmp = {l3.kmer_prg.nodes[0], l3.kmer_prg.nodes[1],
+    // l3.kmer_prg.nodes[2], l3.kmer_prg.nodes[4]};
+    vector<KmerNodePtr> kmp = { l3.kmer_prg.nodes[2], l3.kmer_prg.nodes[4] };
     vector<LocalNodePtr> lmp = l3.localnode_path_from_kmernode_path(kmp);
-    vector<LocalNodePtr> lmp_exp = {l3.prg.nodes[0], l3.prg.nodes[1], l3.prg.nodes[2], l3.prg.nodes[4],
-                                    l3.prg.nodes[6]};
+    vector<LocalNodePtr> lmp_exp = { l3.prg.nodes[0], l3.prg.nodes[1], l3.prg.nodes[2],
+        l3.prg.nodes[4], l3.prg.nodes[6] };
     EXPECT_ITERABLE_EQ(vector<LocalNodePtr>, lmp_exp, lmp);
     lmp = l3.localnode_path_from_kmernode_path(kmp, 2);
     EXPECT_ITERABLE_EQ(vector<LocalNodePtr>, lmp_exp, lmp);
 
     index->clear();
     l4.minimizer_sketch(index, 3, 3);
-    //kmp = {l4.kmer_prg.nodes[0], l4.kmer_prg.nodes[1], l4.kmer_prg.nodes[3], l4.kmer_prg.nodes[7], l4.kmer_prg.nodes[9], l4.kmer_prg.nodes[11], l4.kmer_prg.nodes[13]};
-    kmp = {l4.kmer_prg.nodes[3], l4.kmer_prg.nodes[7]};
+    // kmp = {l4.kmer_prg.nodes[0], l4.kmer_prg.nodes[1], l4.kmer_prg.nodes[3],
+    // l4.kmer_prg.nodes[7], l4.kmer_prg.nodes[9], l4.kmer_prg.nodes[11],
+    // l4.kmer_prg.nodes[13]};
+    kmp = { l4.kmer_prg.nodes[3], l4.kmer_prg.nodes[7] };
     lmp = l4.localnode_path_from_kmernode_path(kmp, 2);
-    lmp_exp = {l4.prg.nodes[0], l4.prg.nodes[1], l4.prg.nodes[3], l4.prg.nodes[4], l4.prg.nodes[6]};
+    lmp_exp = { l4.prg.nodes[0], l4.prg.nodes[1], l4.prg.nodes[3], l4.prg.nodes[4],
+        l4.prg.nodes[6] };
     EXPECT_ITERABLE_EQ(vector<LocalNodePtr>, lmp_exp, lmp);
     lmp = l4.localnode_path_from_kmernode_path(kmp, 3);
     EXPECT_ITERABLE_EQ(vector<LocalNodePtr>, lmp_exp, lmp);
 }
 
-TEST(LocalPRGTest, kmernode_path_from_localnode_path) {
+TEST(LocalPRGTest, kmernode_path_from_localnode_path)
+{
     LocalPRG l3(3, "nested varsite", "A 5 G 7 C 8 T 7  6 G 5 T");
     LocalPRG l4(4, "much more complex", "TC 5 ACTC 7 TAGTCA 8 TTGTGA 7  6 AACTAG 5 AG");
     LocalPRG l5(5, "nested varsite", "A 5 G 7 C 8 T 7 T 9 CCG 10 CGG 9  6 G 5 TAT");
@@ -811,45 +942,51 @@ TEST(LocalPRGTest, kmernode_path_from_localnode_path) {
     KmerHash hash;
 
     l3.minimizer_sketch(index, 2, 3);
-    vector<LocalNodePtr> lmp = {l3.prg.nodes[0], l3.prg.nodes[1], l3.prg.nodes[2], l3.prg.nodes[4], l3.prg.nodes[6]};
+    vector<LocalNodePtr> lmp = { l3.prg.nodes[0], l3.prg.nodes[1], l3.prg.nodes[2],
+        l3.prg.nodes[4], l3.prg.nodes[6] };
 
     vector<KmerNodePtr> kmp = l3.kmernode_path_from_localnode_path(lmp);
     sort(kmp.begin(), kmp.end());
 
-    vector<KmerNodePtr> kmp_exp = {l3.kmer_prg.nodes[0], l3.kmer_prg.nodes[1], l3.kmer_prg.nodes[2],
-                                   l3.kmer_prg.nodes[4]};
+    vector<KmerNodePtr> kmp_exp = { l3.kmer_prg.nodes[0], l3.kmer_prg.nodes[1],
+        l3.kmer_prg.nodes[2], l3.kmer_prg.nodes[4] };
     sort(kmp_exp.begin(), kmp_exp.end());
     EXPECT_ITERABLE_EQ(vector<KmerNodePtr>, kmp_exp, kmp);
 
     index->clear();
     l4.minimizer_sketch(index, 3, 3);
-    lmp = {l4.prg.nodes[0], l4.prg.nodes[1], l4.prg.nodes[3], l4.prg.nodes[4], l4.prg.nodes[6]};
+    lmp = { l4.prg.nodes[0], l4.prg.nodes[1], l4.prg.nodes[3], l4.prg.nodes[4],
+        l4.prg.nodes[6] };
 
     kmp = l4.kmernode_path_from_localnode_path(lmp);
     sort(kmp.begin(), kmp.end());
 
-    kmp_exp = {l4.kmer_prg.nodes[0], l4.kmer_prg.nodes[1], l4.kmer_prg.nodes[3], l4.kmer_prg.nodes[7],
-               l4.kmer_prg.nodes[9], l4.kmer_prg.nodes[11], l4.kmer_prg.nodes[13]};
+    kmp_exp = { l4.kmer_prg.nodes[0], l4.kmer_prg.nodes[1], l4.kmer_prg.nodes[3],
+        l4.kmer_prg.nodes[7], l4.kmer_prg.nodes[9], l4.kmer_prg.nodes[11],
+        l4.kmer_prg.nodes[13] };
     sort(kmp_exp.begin(), kmp_exp.end());
     EXPECT_ITERABLE_EQ(vector<KmerNodePtr>, kmp_exp, kmp);
 
-    // case where we don't have start and end point in localpath, so need to consider whether kmer overlaps
+    // case where we don't have start and end point in localpath, so need to consider
+    // whether kmer overlaps
     index->clear();
     l5.minimizer_sketch(index, 2, 3);
-    lmp = {l5.prg.nodes[1], l5.prg.nodes[2], l5.prg.nodes[4], l5.prg.nodes[6], l5.prg.nodes[7]};
+    lmp = { l5.prg.nodes[1], l5.prg.nodes[2], l5.prg.nodes[4], l5.prg.nodes[6],
+        l5.prg.nodes[7] };
 
     kmp = l5.kmernode_path_from_localnode_path(lmp);
     sort(kmp.begin(), kmp.end());
 
-    kmp_exp = {l5.kmer_prg.nodes[1], l5.kmer_prg.nodes[2], l5.kmer_prg.nodes[6], l5.kmer_prg.nodes[8],
-               l5.kmer_prg.nodes[10], l5.kmer_prg.nodes[12], l5.kmer_prg.nodes[13]};
+    kmp_exp = { l5.kmer_prg.nodes[1], l5.kmer_prg.nodes[2], l5.kmer_prg.nodes[6],
+        l5.kmer_prg.nodes[8], l5.kmer_prg.nodes[10], l5.kmer_prg.nodes[12],
+        l5.kmer_prg.nodes[13] };
     sort(kmp_exp.begin(), kmp_exp.end());
 
     EXPECT_ITERABLE_EQ(vector<KmerNodePtr>, kmp_exp, kmp);
 }
 
-
-TEST(GetCovgsAlongLocalnodePathTest, emptyPanNodeReturnsEmpty) {
+TEST(GetCovgsAlongLocalnodePathTest, emptyPanNodeReturnsEmpty)
+{
     const auto prg_id { 3 };
     auto local_prg_ptr { std::make_shared<LocalPRG>(prg_id, "test", "") };
     const std::vector<LocalNodePtr> local_node_max_likelihood_path;
@@ -857,125 +994,142 @@ TEST(GetCovgsAlongLocalnodePathTest, emptyPanNodeReturnsEmpty) {
 
     PanNodePtr pangraph_node { std::make_shared<pangenome::Node>(local_prg_ptr) };
 
-    const auto actual {
-            get_covgs_along_localnode_path(pangraph_node, local_node_max_likelihood_path, kmer_node_max_likelihood_path,
-                                           0) };
+    const auto actual { get_covgs_along_localnode_path(pangraph_node,
+        local_node_max_likelihood_path, kmer_node_max_likelihood_path, 0) };
     const std::vector<uint32_t> expected;
 
     EXPECT_EQ(actual, expected);
 }
 
-TEST(GetCovgsAlongLocalnodePathTest, get_covgs_along_localnode_path) {
-    auto l3 { std::make_shared<LocalPRG>(3, "nested varsite", "A 5 G 7 C 8 T 7  6 G 5 T") };
-    auto l4 { std::make_shared<LocalPRG>(4, "much more complex", "TC 5 ACTC 7 TAGTCA 8 TTGTGA 7  6 AACTAG 5 AG") };
+TEST(GetCovgsAlongLocalnodePathTest, get_covgs_along_localnode_path)
+{
+    auto l3 { std::make_shared<LocalPRG>(
+        3, "nested varsite", "A 5 G 7 C 8 T 7  6 G 5 T") };
+    auto l4 { std::make_shared<LocalPRG>(
+        4, "much more complex", "TC 5 ACTC 7 TAGTCA 8 TTGTGA 7  6 AACTAG 5 AG") };
 
     auto index = std::make_shared<Index>();
     KmerHash hash;
 
     l3->minimizer_sketch(index, 2, 3);
-    vector<KmerNodePtr> kmp = {l3->kmer_prg.nodes[2], l3->kmer_prg.nodes[4]};
+    vector<KmerNodePtr> kmp = { l3->kmer_prg.nodes[2], l3->kmer_prg.nodes[4] };
     vector<LocalNodePtr> lmp = l3->localnode_path_from_kmernode_path(kmp, 2);
     shared_ptr<pangenome::Node> pn3(make_shared<pangenome::Node>(l3));
-    for (const auto &n : pn3->kmer_prg_with_coverage.kmer_prg->nodes) {
+    for (const auto& n : pn3->kmer_prg_with_coverage.kmer_prg->nodes) {
         pn3->kmer_prg_with_coverage.increment_covg(n->id, 0, 0);
     }
     vector<uint> covgs = get_covgs_along_localnode_path(pn3, lmp, kmp, 0);
-    vector<uint> covgs_exp = {0, 1, 1, 1};
+    vector<uint> covgs_exp = { 0, 1, 1, 1 };
     EXPECT_ITERABLE_EQ(vector<uint>, covgs_exp, covgs);
 
     index->clear();
     l4->minimizer_sketch(index, 1, 3);
-    kmp = {l4->kmer_prg.nodes[0], l4->kmer_prg.nodes[1], l4->kmer_prg.nodes[3], l4->kmer_prg.nodes[5], l4->kmer_prg.nodes[7],
-           l4->kmer_prg.nodes[9], l4->kmer_prg.nodes[12], l4->kmer_prg.nodes[15], l4->kmer_prg.nodes[18],
-           l4->kmer_prg.nodes[21], l4->kmer_prg.nodes[23], l4->kmer_prg.nodes[25], l4->kmer_prg.nodes[27],
-           l4->kmer_prg.nodes[29]};
+    kmp = { l4->kmer_prg.nodes[0], l4->kmer_prg.nodes[1], l4->kmer_prg.nodes[3],
+        l4->kmer_prg.nodes[5], l4->kmer_prg.nodes[7], l4->kmer_prg.nodes[9],
+        l4->kmer_prg.nodes[12], l4->kmer_prg.nodes[15], l4->kmer_prg.nodes[18],
+        l4->kmer_prg.nodes[21], l4->kmer_prg.nodes[23], l4->kmer_prg.nodes[25],
+        l4->kmer_prg.nodes[27], l4->kmer_prg.nodes[29] };
     lmp = l4->localnode_path_from_kmernode_path(kmp, 1);
     shared_ptr<pangenome::Node> pn4(make_shared<pangenome::Node>(l4));
-    for (const auto &n : pn4->kmer_prg_with_coverage.kmer_prg->nodes) {
+    for (const auto& n : pn4->kmer_prg_with_coverage.kmer_prg->nodes) {
         pn4->kmer_prg_with_coverage.increment_covg(n->id, 0, 0);
     }
     covgs = get_covgs_along_localnode_path(pn4, lmp, kmp, 0);
-    //covgs_exp = {1,2,3,3,3,3,3,3,3,3,3,3,2,1};
-    covgs_exp = {1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1};
+    // covgs_exp = {1,2,3,3,3,3,3,3,3,3,3,3,2,1};
+    covgs_exp = { 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1 };
 
     EXPECT_ITERABLE_EQ(vector<uint>, covgs_exp, covgs);
 
-    kmp = {l4->kmer_prg.nodes[0], l4->kmer_prg.nodes[3], l4->kmer_prg.nodes[5], l4->kmer_prg.nodes[12],
-           l4->kmer_prg.nodes[15], l4->kmer_prg.nodes[18], l4->kmer_prg.nodes[25]};
+    kmp = { l4->kmer_prg.nodes[0], l4->kmer_prg.nodes[3], l4->kmer_prg.nodes[5],
+        l4->kmer_prg.nodes[12], l4->kmer_prg.nodes[15], l4->kmer_prg.nodes[18],
+        l4->kmer_prg.nodes[25] };
     lmp = l4->localnode_path_from_kmernode_path(kmp, 2);
     covgs = get_covgs_along_localnode_path(pn4, lmp, kmp, 0);
-    //covgs_exp = {0,1,2,2,1,1,2,3,2,1,1,1,1,0};
-    covgs_exp = {0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0};
+    // covgs_exp = {0,1,2,2,1,1,2,3,2,1,1,1,1,0};
+    covgs_exp = { 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0 };
 
     EXPECT_ITERABLE_EQ(vector<uint>, covgs_exp, covgs);
 }
 
-
-TEST(LocalPRGTest, write_covgs_to_file) {
-    auto l3 { std::make_shared<LocalPRG>(3, "nested varsite", "A 5 G 7 C 8 T 7  6 G 5 T") };
+TEST(LocalPRGTest, write_covgs_to_file)
+{
+    auto l3 { std::make_shared<LocalPRG>(
+        3, "nested varsite", "A 5 G 7 C 8 T 7  6 G 5 T") };
 
     auto index = std::make_shared<Index>();
     KmerHash hash;
 
     l3->minimizer_sketch(index, 2, 3);
-    vector<KmerNodePtr> kmp = {l3->kmer_prg.nodes[2], l3->kmer_prg.nodes[4]};
+    vector<KmerNodePtr> kmp = { l3->kmer_prg.nodes[2], l3->kmer_prg.nodes[4] };
     vector<LocalNodePtr> lmp = l3->localnode_path_from_kmernode_path(kmp, 2);
     shared_ptr<pangenome::Node> pn3(make_shared<pangenome::Node>(l3));
-    for (const auto &n : pn3->kmer_prg_with_coverage.kmer_prg->nodes) {
+    for (const auto& n : pn3->kmer_prg_with_coverage.kmer_prg->nodes) {
         pn3->kmer_prg_with_coverage.increment_covg(n->id, 0, 0);
     }
     vector<uint> covgs = get_covgs_along_localnode_path(pn3, lmp, kmp, 0);
-    vector<uint> covgs_exp = {0, 1, 1, 1};
+    vector<uint> covgs_exp = { 0, 1, 1, 1 };
     EXPECT_ITERABLE_EQ(vector<uint>, covgs_exp, covgs);
 
     l3->write_covgs_to_file("localPRG_test.covgs", covgs);
 }
 
-TEST(LocalPRGTest, write_path_to_fasta) {
+TEST(LocalPRGTest, write_path_to_fasta)
+{
     LocalPRG l3(3, "nested varsite", "A 5 G 7 C 8 T 7  6 G 5 TAT");
 
     auto index = std::make_shared<Index>();
     l3.minimizer_sketch(index, 1, 3);
 
-    vector<LocalNodePtr> lmp3 = {l3.prg.nodes[0], l3.prg.nodes[1], l3.prg.nodes[3], l3.prg.nodes[4], l3.prg.nodes[6]};
+    vector<LocalNodePtr> lmp3 = { l3.prg.nodes[0], l3.prg.nodes[1], l3.prg.nodes[3],
+        l3.prg.nodes[4], l3.prg.nodes[6] };
     l3.write_path_to_fasta("localPRG_test.maxpath.fa", lmp3, 0.00);
 }
 
-TEST(LocalPRGTest, append_path_to_fasta) {
+TEST(LocalPRGTest, append_path_to_fasta)
+{
     LocalPRG l3(3, "nested varsite", "A 5 G 7 C 8 T 7  6 G 5 TAT");
 
     auto index = std::make_shared<Index>();
     l3.minimizer_sketch(index, 1, 3);
 
-    vector<LocalNodePtr> lmp3 = {l3.prg.nodes[0], l3.prg.nodes[1], l3.prg.nodes[3], l3.prg.nodes[4], l3.prg.nodes[6]};
+    vector<LocalNodePtr> lmp3 = { l3.prg.nodes[0], l3.prg.nodes[1], l3.prg.nodes[3],
+        l3.prg.nodes[4], l3.prg.nodes[6] };
     l3.append_path_to_fasta("localPRG_test.maxpath.fa", lmp3, 0.00);
-
-
 }
 
-TEST(LocalPRGTest, write_aligned_path_to_fasta) {
+TEST(LocalPRGTest, write_aligned_path_to_fasta)
+{
     LocalPRG l3(3, "nested varsite", "A 5 G 7 C 8 T 7  6 G 5 TAT");
 
     auto index = std::make_shared<Index>();
     l3.minimizer_sketch(index, 1, 3);
 
-    vector<LocalNodePtr> lmp3 = {l3.prg.nodes[0], l3.prg.nodes[1], l3.prg.nodes[3], l3.prg.nodes[4], l3.prg.nodes[6]};
+    vector<LocalNodePtr> lmp3 = { l3.prg.nodes[0], l3.prg.nodes[1], l3.prg.nodes[3],
+        l3.prg.nodes[4], l3.prg.nodes[6] };
     l3.write_aligned_path_to_fasta("localPRG_test.alignedpath.fa", lmp3, 0.00);
-
-
 }
 
-TEST(LocalPRGTest, build_vcf) {
+TEST(LocalPRGTest, build_vcf)
+{
     LocalPRG l1(1, "simple", "AGCT");
     LocalPRG l2(2, "varsite", "A 5 GC 6 G 5 T");
     LocalPRG l3(3, "nested varsite", "A 5 G 7 C 8 T 7  6 G 5 TAT");
-    LocalPRG l4(4, "small real PRG", "ATGACAAAACGAAGTGGAAGTAATACGCGCAGGCGGGCTATCAGTCGCCCTGTTCGTCTGACGGCAGAAGAAGACCAGG"
-                                     "AAATCAGAAAAAGGGCTGCTGAATGCGGCAAGACCGTTTC 5 T 6 C 5 GGTTTTTTACGGGCGGCAGCTCTCGGTAAGAAAGTTAA 7 TTCACTGACTGA"
-                                     "TGACCGAGTGCTGAAAGAAGTCATGCGACTGGGGGCGTTG 8 CTCACTGACTGATGATCGGGTACTGAAAGAAGTTATGAGACTGGGGGCGTTA 7 CAGAAA"
-                                     "AAACTCTTTATCGACGGCAAGCGTGTCGGGGACAG 9 A 10 G 9 GAGTATGCGGAGGTGCTGAT 11 A 12 C 11 GCTATTACGGAGTATCACCG 13"
-                                     " G 14 T 13 GCCCTGTTATCCAGGCTTATGGCAGATTAG");
+    LocalPRG l4(4, "small real PRG",
+        "ATGACAAAACGAAGTGGAAGTAATACGCGCAGGCGGGCTATCAGTCGCCCTGTTCGTCTGACGGCAGAAGAAGACCAG"
+        "G"
+        "AAATCAGAAAAAGGGCTGCTGAATGCGGCAAGACCGTTTC 5 T 6 C 5 "
+        "GGTTTTTTACGGGCGGCAGCTCTCGGTAAGAAAGTTAA 7 TTCACTGACTGA"
+        "TGACCGAGTGCTGAAAGAAGTCATGCGACTGGGGGCGTTG 8 "
+        "CTCACTGACTGATGATCGGGTACTGAAAGAAGTTATGAGACTGGGGGCGTTA 7 CAGAAA"
+        "AAACTCTTTATCGACGGCAAGCGTGTCGGGGACAG 9 A 10 G 9 GAGTATGCGGAGGTGCTGAT 11 A 12 C "
+        "11 GCTATTACGGAGTATCACCG 13"
+        " G 14 T 13 GCCCTGTTATCCAGGCTTATGGCAGATTAG");
     LocalPRG l5(5, "another real PRG",
-                "ATGACAAAGGTTACACCGT 5 C 6 T 5 TGACGTGCTACGCCTGTCAGGCCTATTCGACTCCTGCAAT 7 G 8 A 7 TATTGAATTTGCATAGTTTT 9 G 10 A 9 TAGGTCGA 11 G 12 A 11 TAAGGCGTTCACGCCGCATCCGGCGTGAACAAA 13 G 14 T 13 TACTCTTTTT 15  17  19 C 20 T 19 GCACAATCCAA 18 CGCACAAACCAA 17  16  21 CGCACAATCCAA 22  23 CGT 24 CGC 23 ACAAACCA 25 A 26 T 25  21 TATGTGCAAATTATTACTTTTTCCAGAAATCATCGAAAACGG 15 ");
+        "ATGACAAAGGTTACACCGT 5 C 6 T 5 TGACGTGCTACGCCTGTCAGGCCTATTCGACTCCTGCAAT 7 G 8 "
+        "A 7 TATTGAATTTGCATAGTTTT 9 G 10 A 9 TAGGTCGA 11 G 12 A 11 "
+        "TAAGGCGTTCACGCCGCATCCGGCGTGAACAAA 13 G 14 T 13 TACTCTTTTT 15  17  19 C 20 T "
+        "19 GCACAATCCAA 18 CGCACAAACCAA 17  16  21 CGCACAATCCAA 22  23 CGT 24 CGC 23 "
+        "ACAAACCA 25 A 26 T 25  21 TATGTGCAAATTATTACTTTTTCCAGAAATCATCGAAAACGG 15 ");
 
     VCF vcf;
 
@@ -989,18 +1143,18 @@ TEST(LocalPRGTest, build_vcf) {
     j = 1;
     EXPECT_EQ(j, vcf.records.size());
     EXPECT_EQ("varsite", vcf.records[0]->chrom);
-    EXPECT_EQ((uint) 1, vcf.records[0]->pos);
+    EXPECT_EQ((uint)1, vcf.records[0]->pos);
     EXPECT_EQ("GC", vcf.records[0]->ref);
     EXPECT_EQ("G", vcf.records[0]->alt[0]);
     EXPECT_EQ("SVTYPE=INDEL;GRAPHTYPE=SIMPLE", vcf.records[0]->info);
 
     vcf = VCF();
-    vector<LocalNodePtr> lmp = {l2.prg.nodes[0], l2.prg.nodes[2], l2.prg.nodes[3]};
+    vector<LocalNodePtr> lmp = { l2.prg.nodes[0], l2.prg.nodes[2], l2.prg.nodes[3] };
     l2.build_vcf(vcf, lmp);
     j = 1;
     EXPECT_EQ(j, vcf.records.size());
     EXPECT_EQ("varsite", vcf.records[0]->chrom);
-    EXPECT_EQ((uint) 1, vcf.records[0]->pos);
+    EXPECT_EQ((uint)1, vcf.records[0]->pos);
     EXPECT_EQ("G", vcf.records[0]->ref);
     EXPECT_EQ("GC", vcf.records[0]->alt[0]);
     EXPECT_EQ("SVTYPE=INDEL;GRAPHTYPE=SIMPLE", vcf.records[0]->info);
@@ -1011,41 +1165,42 @@ TEST(LocalPRGTest, build_vcf) {
     j = 2;
     EXPECT_EQ(j, vcf.records.size());
     EXPECT_EQ("nested varsite", vcf.records[0]->chrom);
-    EXPECT_EQ((uint) 1, vcf.records[0]->pos);
+    EXPECT_EQ((uint)1, vcf.records[0]->pos);
     EXPECT_EQ("GC", vcf.records[0]->ref);
     EXPECT_EQ("G", vcf.records[0]->alt[0]);
     EXPECT_EQ("SVTYPE=INDEL;GRAPHTYPE=NESTED", vcf.records[0]->info);
-    EXPECT_EQ((uint) 2, vcf.records[1]->pos);
+    EXPECT_EQ((uint)2, vcf.records[1]->pos);
     EXPECT_EQ("C", vcf.records[1]->ref);
     EXPECT_EQ("T", vcf.records[1]->alt[0]);
     EXPECT_EQ("SVTYPE=SNP;GRAPHTYPE=NESTED", vcf.records[1]->info);
 
     vcf = VCF();
-    lmp = {l3.prg.nodes[0], l3.prg.nodes[1], l3.prg.nodes[3], l3.prg.nodes[4], l3.prg.nodes[6]};
+    lmp = { l3.prg.nodes[0], l3.prg.nodes[1], l3.prg.nodes[3], l3.prg.nodes[4],
+        l3.prg.nodes[6] };
     l3.build_vcf(vcf, lmp);
     vcf.sort_records();
     EXPECT_EQ(j, vcf.records.size());
     EXPECT_EQ("nested varsite", vcf.records[0]->chrom);
-    EXPECT_EQ((uint) 1, vcf.records[0]->pos);
+    EXPECT_EQ((uint)1, vcf.records[0]->pos);
     EXPECT_EQ("GT", vcf.records[0]->ref);
     EXPECT_EQ("G", vcf.records[0]->alt[0]);
     EXPECT_EQ("SVTYPE=INDEL;GRAPHTYPE=NESTED", vcf.records[0]->info);
-    EXPECT_EQ((uint) 2, vcf.records[1]->pos);
+    EXPECT_EQ((uint)2, vcf.records[1]->pos);
     EXPECT_EQ("T", vcf.records[1]->ref);
     EXPECT_EQ("C", vcf.records[1]->alt[0]);
     EXPECT_EQ("SVTYPE=SNP;GRAPHTYPE=NESTED", vcf.records[1]->info);
 
     vcf = VCF();
-    lmp = {l3.prg.nodes[0], l3.prg.nodes[5], l3.prg.nodes[6]};
+    lmp = { l3.prg.nodes[0], l3.prg.nodes[5], l3.prg.nodes[6] };
     l3.build_vcf(vcf, lmp);
     vcf.sort_records();
     EXPECT_EQ(j, vcf.records.size());
     EXPECT_EQ("nested varsite", vcf.records[0]->chrom);
-    EXPECT_EQ((uint) 1, vcf.records[0]->pos);
+    EXPECT_EQ((uint)1, vcf.records[0]->pos);
     EXPECT_EQ("G", vcf.records[0]->ref);
     EXPECT_EQ("GC", vcf.records[0]->alt[0]);
     EXPECT_EQ("SVTYPE=INDEL;GRAPHTYPE=SIMPLE", vcf.records[0]->info);
-    EXPECT_EQ((uint) 1, vcf.records[1]->pos);
+    EXPECT_EQ((uint)1, vcf.records[1]->pos);
     EXPECT_EQ("G", vcf.records[1]->ref);
     EXPECT_EQ("GT", vcf.records[1]->alt[0]);
     EXPECT_EQ("SVTYPE=INDEL;GRAPHTYPE=SIMPLE", vcf.records[1]->info);
@@ -1056,60 +1211,65 @@ TEST(LocalPRGTest, build_vcf) {
     j = 5;
     EXPECT_EQ(j, vcf.records.size());
     EXPECT_EQ("small real PRG", vcf.records[0]->chrom);
-    EXPECT_EQ((uint) 119, vcf.records[0]->pos);
+    EXPECT_EQ((uint)119, vcf.records[0]->pos);
     EXPECT_EQ("T", vcf.records[0]->ref);
     EXPECT_EQ("C", vcf.records[0]->alt[0]);
     EXPECT_EQ("SVTYPE=SNP;GRAPHTYPE=SIMPLE", vcf.records[0]->info);
 
-    EXPECT_EQ((uint) 158, vcf.records[1]->pos);
-    EXPECT_EQ("TTCACTGACTGATGACCGAGTGCTGAAAGAAGTCATGCGACTGGGGGCGTTG", vcf.records[1]->ref);
-    EXPECT_EQ("CTCACTGACTGATGATCGGGTACTGAAAGAAGTTATGAGACTGGGGGCGTTA", vcf.records[1]->alt[0]);
+    EXPECT_EQ((uint)158, vcf.records[1]->pos);
+    EXPECT_EQ(
+        "TTCACTGACTGATGACCGAGTGCTGAAAGAAGTCATGCGACTGGGGGCGTTG", vcf.records[1]->ref);
+    EXPECT_EQ(
+        "CTCACTGACTGATGATCGGGTACTGAAAGAAGTTATGAGACTGGGGGCGTTA", vcf.records[1]->alt[0]);
     EXPECT_EQ("SVTYPE=PH_SNPs;GRAPHTYPE=SIMPLE", vcf.records[1]->info);
 
-    EXPECT_EQ((uint) 251, vcf.records[2]->pos);
+    EXPECT_EQ((uint)251, vcf.records[2]->pos);
     EXPECT_EQ("A", vcf.records[2]->ref);
     EXPECT_EQ("G", vcf.records[2]->alt[0]);
     EXPECT_EQ("SVTYPE=SNP;GRAPHTYPE=SIMPLE", vcf.records[2]->info);
 
-    EXPECT_EQ((uint) 272, vcf.records[3]->pos);
+    EXPECT_EQ((uint)272, vcf.records[3]->pos);
     EXPECT_EQ("A", vcf.records[3]->ref);
     EXPECT_EQ("C", vcf.records[3]->alt[0]);
     EXPECT_EQ("SVTYPE=SNP;GRAPHTYPE=SIMPLE", vcf.records[3]->info);
 
-    EXPECT_EQ((uint) 293, vcf.records[4]->pos);
+    EXPECT_EQ((uint)293, vcf.records[4]->pos);
     EXPECT_EQ("G", vcf.records[4]->ref);
     EXPECT_EQ("T", vcf.records[4]->alt[0]);
     EXPECT_EQ("SVTYPE=SNP;GRAPHTYPE=SIMPLE", vcf.records[4]->info);
 
     vcf = VCF();
-    lmp = {l4.prg.nodes[0], l4.prg.nodes[2], l4.prg.nodes[3], l4.prg.nodes[4], l4.prg.nodes[6], l4.prg.nodes[8],
-           l4.prg.nodes[9], l4.prg.nodes[10], l4.prg.nodes[12], l4.prg.nodes[14], l4.prg.nodes[15]};
+    lmp = { l4.prg.nodes[0], l4.prg.nodes[2], l4.prg.nodes[3], l4.prg.nodes[4],
+        l4.prg.nodes[6], l4.prg.nodes[8], l4.prg.nodes[9], l4.prg.nodes[10],
+        l4.prg.nodes[12], l4.prg.nodes[14], l4.prg.nodes[15] };
     l4.build_vcf(vcf, lmp);
     vcf.sort_records();
     j = 5;
     EXPECT_EQ(j, vcf.records.size());
     EXPECT_EQ("small real PRG", vcf.records[0]->chrom);
-    EXPECT_EQ((uint) 119, vcf.records[0]->pos);
+    EXPECT_EQ((uint)119, vcf.records[0]->pos);
     EXPECT_EQ("C", vcf.records[0]->ref);
     EXPECT_EQ("T", vcf.records[0]->alt[0]);
     EXPECT_EQ("SVTYPE=SNP;GRAPHTYPE=SIMPLE", vcf.records[0]->info);
 
-    EXPECT_EQ((uint) 158, vcf.records[1]->pos);
-    EXPECT_EQ("TTCACTGACTGATGACCGAGTGCTGAAAGAAGTCATGCGACTGGGGGCGTTG", vcf.records[1]->ref);
-    EXPECT_EQ("CTCACTGACTGATGATCGGGTACTGAAAGAAGTTATGAGACTGGGGGCGTTA", vcf.records[1]->alt[0]);
+    EXPECT_EQ((uint)158, vcf.records[1]->pos);
+    EXPECT_EQ(
+        "TTCACTGACTGATGACCGAGTGCTGAAAGAAGTCATGCGACTGGGGGCGTTG", vcf.records[1]->ref);
+    EXPECT_EQ(
+        "CTCACTGACTGATGATCGGGTACTGAAAGAAGTTATGAGACTGGGGGCGTTA", vcf.records[1]->alt[0]);
     EXPECT_EQ("SVTYPE=PH_SNPs;GRAPHTYPE=SIMPLE", vcf.records[1]->info);
 
-    EXPECT_EQ((uint) 251, vcf.records[2]->pos);
+    EXPECT_EQ((uint)251, vcf.records[2]->pos);
     EXPECT_EQ("G", vcf.records[2]->ref);
     EXPECT_EQ("A", vcf.records[2]->alt[0]);
     EXPECT_EQ("SVTYPE=SNP;GRAPHTYPE=SIMPLE", vcf.records[2]->info);
 
-    EXPECT_EQ((uint) 272, vcf.records[3]->pos);
+    EXPECT_EQ((uint)272, vcf.records[3]->pos);
     EXPECT_EQ("A", vcf.records[3]->ref);
     EXPECT_EQ("C", vcf.records[3]->alt[0]);
     EXPECT_EQ("SVTYPE=SNP;GRAPHTYPE=SIMPLE", vcf.records[3]->info);
 
-    EXPECT_EQ((uint) 293, vcf.records[4]->pos);
+    EXPECT_EQ((uint)293, vcf.records[4]->pos);
     EXPECT_EQ("T", vcf.records[4]->ref);
     EXPECT_EQ("G", vcf.records[4]->alt[0]);
     EXPECT_EQ("SVTYPE=SNP;GRAPHTYPE=SIMPLE", vcf.records[4]->info);
@@ -1119,8 +1279,46 @@ TEST(LocalPRGTest, build_vcf) {
     vcf.sort_records();
 }
 
-TEST(LocalPRGTest, build_vcf_real) {
-    LocalPRG l1(1, "GC00000008_13", "ATGAAATTAAAAATAGTT 5 G 6 A 5 CGGTGGTTGTAACTGGTTTGTTAGCTGCGAACGTAGC 7 ACACGCT 8 ACACGCC 8 GCACGCT 7 GCCGAAGTC 9 T 10 G 9 ATAACAAGGATGGTAATAAACT 11 C 12 A 11 GACCTTTATGGCAAGGTTACCGCTCTACGTTATTTTACTGATGATAAGCGTGA 13 C 14 A 13 GATGGTGATAAAA 15 C 16 T 16 A 15 TTATGCCCGTCTCGGCTTTAAAGGAGAAACG 17 CAAATCAATGATCAAATGA 19 C 20 T 19 TGGTTTTGGTCACTGGGAATATGATTTTAAAGGCTATAACGATGAAGCCAACGG 21 C 22 T 21 TCGCGCG 23 AC 24 GC 24 GT 23 AACAAGACCCGTCT 25 G 26 A 25 GCCTATGC 27 T 28 A 27 GGTTTAAAAATTAGTGAATTTGGCTCTCTGGACTATGG 29 C 30 T 29 CGTAACTACGGTGTCGGCTATGACATTGGTTCATGGAC 31 CT 32 CG 32 TG 31 ATATGTTGCCAGAATTTGGTGGCGATACCTGGAGTCAGAAAGATGTCTTCATGACATACCGTAC 33 C 34 T 34 A 33 ACCGGTGT 35 G 36 A 35 GCAACCTATCGCAACTACGATTTCTT 37 C 38 T 37 GGCTTAATTGAAGG 39 T 40 G 39 CTGAACTTTGCCGCGCAATATCAAGGCAAAAATGAACG 41 C 42 T 41 ACTGACAA 43 TGGT 44 CAGT 44 TGGC 43 CATCTTTATGGTGCTGACTA 45  47 C 48 T 47 ACGCGTGCCAA 49 C 50 T 49  46 CACGCGCGCCAAC 45 GGTGACGGTTTCGGTATCTCCTCAACTTATGTTTATGATGGCTTTGGTATCGG 51 TGCGGTA 52 AGCGGTG 52 TGCGGTG 51 TATACCAAATCCGATCGGACAA 53 ATGCA 54 TTGCA 54 ATGCG 53 CAGGAAAGAGCCGCTGCTAATCCTCTCAATGCCTCCGGTAAGAATGCAGAACTGTGGGC 55 C 56 T 55 ACAGGTATAAA 57 G 58 A 57 TATGATGCCAACAACAT 59 C 60 T 59 TACTTTGCAGCTAATTACGCTGAAACATTAAACATGACCACCTATGG 61 C 62 G 61 GATGGTTATAT 63 CTCT 64 CTCG 64 TTCT 63 AACAAAGCACAAAGTTTTGAAGT 65 AGTGACA 66 AGTGGCA 66 GGTGGCG 65 CAATATCAATTCGACTTCGGCTTGC 67 GCCCA 68 ACCCC 68 GCCCC 67 TCACTCGCTTACCTGAAATCGAAAGGCA 69 T 70 G 69 AGATCTGGGCCGCTACGGCGA 71  73 C 74 T 73 CAGGACATGATTGAGTATATCGACGTTGGTGCGACGTATTTCTTCAACAAAAATATGTCGACCTATGTTGATTATAAAATCAACCTGATTGATGAAAGCGACTTTACCCGTGCCGTAGATATTCGCAC 75 CGATAACATCGTCGC 77 AACGGGT 78 AACGGGC 78 TACGGGC 78 AACGGGA 77 ATTACCTATCAGTTC 76 GGCTTTGTTGAATAAATCGAACTTTTGC 75  72 AGTTAACGGCATCAACAATGATCCACTTGCCCAAATGCAGTACTGGACTGCAGTAAGAAATATAATTGATGACACTAATGAAGTGACCATTGAATTATCTTATAACCTGGCAATCACAAATATCGATACCAGCGATGAACATCTTGTAGAAGTAAGCGAGAATTCCGAAGGAAATCATATAAAAGACAATGACTCAATGTCTATTCGTTATAGATCAAAATATTATTCCAGAGAGTACGCTTTAATAGAAGAAGAAACAATATTTTCTGACGCAGAACTAAAAGCCATTCTGCCTATGCATCGCATGTACGGGGTTGGTGACTATAAGTCAAATTCCTCTTCTCTACCCTCACACTCGGGGCTAAAGGACCCAACGGGCACACCCGTCTGTTATTATATTCATAATGAGGATAAACCTTCCTTAGGTTTTGGTCCAATATCCAATAATTGGTTAAGCCAATCCTTTACAACAGAGTTA 71  18  18 CAAATCAATG 79 T 80 A 79 TCAAATG 81 CTTG 82 ATTA 82 ATTG 81 GTTTTGGTCAC 83 T 84 A 83 GGGAATATGATTTTAAAGGCTATAACGATGAAGCCAAC 85 GGCTCGC 86 GGCTCGT 86 TGCTCGC 86 GGTTCGC 85 GCGGCAA 87  89 CAATCTC 90 GAATCTC 89  88 GAATCTCTTATTGAGT 87  17 ");
+TEST(LocalPRGTest, build_vcf_real)
+{
+    LocalPRG l1(1, "GC00000008_13",
+        "ATGAAATTAAAAATAGTT 5 G 6 A 5 CGGTGGTTGTAACTGGTTTGTTAGCTGCGAACGTAGC 7 ACACGCT "
+        "8 ACACGCC 8 GCACGCT 7 GCCGAAGTC 9 T 10 G 9 ATAACAAGGATGGTAATAAACT 11 C 12 A "
+        "11 GACCTTTATGGCAAGGTTACCGCTCTACGTTATTTTACTGATGATAAGCGTGA 13 C 14 A 13 "
+        "GATGGTGATAAAA 15 C 16 T 16 A 15 TTATGCCCGTCTCGGCTTTAAAGGAGAAACG 17 "
+        "CAAATCAATGATCAAATGA 19 C 20 T 19 "
+        "TGGTTTTGGTCACTGGGAATATGATTTTAAAGGCTATAACGATGAAGCCAACGG 21 C 22 T 21 TCGCGCG "
+        "23 AC 24 GC 24 GT 23 AACAAGACCCGTCT 25 G 26 A 25 GCCTATGC 27 T 28 A 27 "
+        "GGTTTAAAAATTAGTGAATTTGGCTCTCTGGACTATGG 29 C 30 T 29 "
+        "CGTAACTACGGTGTCGGCTATGACATTGGTTCATGGAC 31 CT 32 CG 32 TG 31 "
+        "ATATGTTGCCAGAATTTGGTGGCGATACCTGGAGTCAGAAAGATGTCTTCATGACATACCGTAC 33 C 34 T 34 "
+        "A 33 ACCGGTGT 35 G 36 A 35 GCAACCTATCGCAACTACGATTTCTT 37 C 38 T 37 "
+        "GGCTTAATTGAAGG 39 T 40 G 39 CTGAACTTTGCCGCGCAATATCAAGGCAAAAATGAACG 41 C 42 T "
+        "41 ACTGACAA 43 TGGT 44 CAGT 44 TGGC 43 CATCTTTATGGTGCTGACTA 45  47 C 48 T 47 "
+        "ACGCGTGCCAA 49 C 50 T 49  46 CACGCGCGCCAAC 45 "
+        "GGTGACGGTTTCGGTATCTCCTCAACTTATGTTTATGATGGCTTTGGTATCGG 51 TGCGGTA 52 AGCGGTG "
+        "52 TGCGGTG 51 TATACCAAATCCGATCGGACAA 53 ATGCA 54 TTGCA 54 ATGCG 53 "
+        "CAGGAAAGAGCCGCTGCTAATCCTCTCAATGCCTCCGGTAAGAATGCAGAACTGTGGGC 55 C 56 T 55 "
+        "ACAGGTATAAA 57 G 58 A 57 TATGATGCCAACAACAT 59 C 60 T 59 "
+        "TACTTTGCAGCTAATTACGCTGAAACATTAAACATGACCACCTATGG 61 C 62 G 61 GATGGTTATAT 63 "
+        "CTCT 64 CTCG 64 TTCT 63 AACAAAGCACAAAGTTTTGAAGT 65 AGTGACA 66 AGTGGCA 66 "
+        "GGTGGCG 65 CAATATCAATTCGACTTCGGCTTGC 67 GCCCA 68 ACCCC 68 GCCCC 67 "
+        "TCACTCGCTTACCTGAAATCGAAAGGCA 69 T 70 G 69 AGATCTGGGCCGCTACGGCGA 71  73 C 74 T "
+        "73 "
+        "CAGGACATGATTGAGTATATCGACGTTGGTGCGACGTATTTCTTCAACAAAAATATGTCGACCTATGTTGATTATAAA"
+        "ATCAACCTGATTGATGAAAGCGACTTTACCCGTGCCGTAGATATTCGCAC 75 CGATAACATCGTCGC 77 "
+        "AACGGGT 78 AACGGGC 78 TACGGGC 78 AACGGGA 77 ATTACCTATCAGTTC 76 "
+        "GGCTTTGTTGAATAAATCGAACTTTTGC 75  72 "
+        "AGTTAACGGCATCAACAATGATCCACTTGCCCAAATGCAGTACTGGACTGCAGTAAGAAATATAATTGATGACACTAA"
+        "TGAAGTGACCATTGAATTATCTTATAACCTGGCAATCACAAATATCGATACCAGCGATGAACATCTTGTAGAAGTAAG"
+        "CGAGAATTCCGAAGGAAATCATATAAAAGACAATGACTCAATGTCTATTCGTTATAGATCAAAATATTATTCCAGAGA"
+        "GTACGCTTTAATAGAAGAAGAAACAATATTTTCTGACGCAGAACTAAAAGCCATTCTGCCTATGCATCGCATGTACGG"
+        "GGTTGGTGACTATAAGTCAAATTCCTCTTCTCTACCCTCACACTCGGGGCTAAAGGACCCAACGGGCACACCCGTCTG"
+        "TTATTATATTCATAATGAGGATAAACCTTCCTTAGGTTTTGGTCCAATATCCAATAATTGGTTAAGCCAATCCTTTAC"
+        "AACAGAGTTA 71  18  18 CAAATCAATG 79 T 80 A 79 TCAAATG 81 CTTG 82 ATTA 82 ATTG "
+        "81 GTTTTGGTCAC 83 T 84 A 83 GGGAATATGATTTTAAAGGCTATAACGATGAAGCCAAC 85 GGCTCGC "
+        "86 GGCTCGT 86 TGCTCGC 86 GGTTCGC 85 GCGGCAA 87  89 CAATCTC 90 GAATCTC 89  88 "
+        "GAATCTCTTATTGAGT 87  17 ");
 
     VCF vcf;
     auto ref_path = l1.prg.top_path();
@@ -1130,105 +1328,118 @@ TEST(LocalPRGTest, build_vcf_real) {
     vcf.correct_dot_alleles(ref_seq, "GC00000008_13");
 }
 
-TEST(LocalPRGTest, add_sample_gt_to_vcf) {
+TEST(LocalPRGTest, add_sample_gt_to_vcf)
+{
     LocalPRG l1(1, "simple", "AGCT");
     LocalPRG l2(2, "varsite", "A 5 GC 6 G 5 T");
     LocalPRG l3(3, "nested varsite", "A 5 G 7 C 8 T 7  6 G 5 TAT");
-    LocalPRG l4(4, "small real PRG", "ATGACAAAACGAAGTGGAAGTAATACGCGCAGGCGGGCTATCAGTCGCCCTGTTCGTCTGACGGCAGAAGAAGACCAGG"
-                                     "AAATCAGAAAAAGGGCTGCTGAATGCGGCAAGACCGTTTC 5 T 6 C 5 GGTTTTTTACGGGCGGCAGCTCTCGGTAAGAAAGTTAA 7 TTCACTGACTGA"
-                                     "TGACCGAGTGCTGAAAGAAGTCATGCGACTGGGGGCGTTG 8 CTCACTGACTGATGATCGGGTACTGAAAGAAGTTATGAGACTGGGGGCGTTA 7 CAGAAA"
-                                     "AAACTCTTTATCGACGGCAAGCGTGTCGGGGACAG 9 A 10 G 9 GAGTATGCGGAGGTGCTGAT 11 A 12 C 11 GCTATTACGGAGTATCACCG 13"
-                                     " G 14 T 13 GCCCTGTTATCCAGGCTTATGGCAGATTAG");
-    LocalPRG l5(5, "another real PRG", " 5 ATGCTTATTGGCTATGT 7  9 ACGCGTA 10 TCGCGTA 10 ACGTGTG 9 TCAACAAATGACCAGAACA"
-                                       "C 11 A 12 C 11  8 ACGCGTATCAACAAATGATCAGAACACA 7 GATCTACAACGTAATGCG 6 AAGT 5 ");
+    LocalPRG l4(4, "small real PRG",
+        "ATGACAAAACGAAGTGGAAGTAATACGCGCAGGCGGGCTATCAGTCGCCCTGTTCGTCTGACGGCAGAAGAAGACCAG"
+        "G"
+        "AAATCAGAAAAAGGGCTGCTGAATGCGGCAAGACCGTTTC 5 T 6 C 5 "
+        "GGTTTTTTACGGGCGGCAGCTCTCGGTAAGAAAGTTAA 7 TTCACTGACTGA"
+        "TGACCGAGTGCTGAAAGAAGTCATGCGACTGGGGGCGTTG 8 "
+        "CTCACTGACTGATGATCGGGTACTGAAAGAAGTTATGAGACTGGGGGCGTTA 7 CAGAAA"
+        "AAACTCTTTATCGACGGCAAGCGTGTCGGGGACAG 9 A 10 G 9 GAGTATGCGGAGGTGCTGAT 11 A 12 C "
+        "11 GCTATTACGGAGTATCACCG 13"
+        " G 14 T 13 GCCCTGTTATCCAGGCTTATGGCAGATTAG");
+    LocalPRG l5(5, "another real PRG",
+        " 5 ATGCTTATTGGCTATGT 7  9 ACGCGTA 10 TCGCGTA 10 ACGTGTG 9 TCAACAAATGACCAGAACA"
+        "C 11 A 12 C 11  8 ACGCGTATCAACAAATGATCAGAACACA 7 GATCTACAACGTAATGCG 6 AAGT "
+        "5 ");
 
     VCF vcf;
 
-    vector<LocalNodePtr> lmp1 = {l1.prg.nodes[0]};
+    vector<LocalNodePtr> lmp1 = { l1.prg.nodes[0] };
     l1.build_vcf(vcf, l1.prg.top_path());
     l1.add_sample_gt_to_vcf(vcf, l1.prg.top_path(), lmp1, "sample");
     uint j = 1;
     EXPECT_EQ(j, vcf.samples.size());
 
     vcf = VCF();
-    vector<LocalNodePtr> lmp2 = {l2.prg.nodes[0], l2.prg.nodes[2], l2.prg.nodes[3]};
+    vector<LocalNodePtr> lmp2 = { l2.prg.nodes[0], l2.prg.nodes[2], l2.prg.nodes[3] };
     l2.build_vcf(vcf, l2.prg.top_path());
     l2.add_sample_gt_to_vcf(vcf, l2.prg.top_path(), lmp2, "sample");
     j = 1;
     EXPECT_EQ(j, vcf.samples.size());
     EXPECT_EQ(j, vcf.records[0]->samples.size());
-    EXPECT_EQ((uint16_t) 1, vcf.records[0]->samples[0]["GT"][0]);
+    EXPECT_EQ((uint16_t)1, vcf.records[0]->samples[0]["GT"][0]);
 
     vcf = VCF();
-    vector<LocalNodePtr> lmp3 = {l3.prg.nodes[0], l3.prg.nodes[1], l3.prg.nodes[3], l3.prg.nodes[4], l3.prg.nodes[6]};
+    vector<LocalNodePtr> lmp3 = { l3.prg.nodes[0], l3.prg.nodes[1], l3.prg.nodes[3],
+        l3.prg.nodes[4], l3.prg.nodes[6] };
     l3.build_vcf(vcf, l3.prg.top_path());
     vcf.sort_records();
     l3.add_sample_gt_to_vcf(vcf, l3.prg.top_path(), lmp3, "sample");
     EXPECT_EQ(j, vcf.samples.size());
     EXPECT_EQ(j, vcf.records[0]->samples.size());
-    EXPECT_EQ((uint16_t) 1, vcf.records[1]->samples[0]["GT"][0]);
+    EXPECT_EQ((uint16_t)1, vcf.records[1]->samples[0]["GT"][0]);
 
     vcf = VCF();
-    vector<LocalNodePtr> lmp4 = {l4.prg.nodes[0], l4.prg.nodes[1], l4.prg.nodes[3], l4.prg.nodes[5], l4.prg.nodes[6],
-                                 l4.prg.nodes[8], l4.prg.nodes[9], l4.prg.nodes[10], l4.prg.nodes[12], l4.prg.nodes[13],
-                                 l4.prg.nodes[15]};
+    vector<LocalNodePtr> lmp4 = { l4.prg.nodes[0], l4.prg.nodes[1], l4.prg.nodes[3],
+        l4.prg.nodes[5], l4.prg.nodes[6], l4.prg.nodes[8], l4.prg.nodes[9],
+        l4.prg.nodes[10], l4.prg.nodes[12], l4.prg.nodes[13], l4.prg.nodes[15] };
     l4.build_vcf(vcf, l4.prg.top_path());
     vcf.sort_records();
     l4.add_sample_gt_to_vcf(vcf, l4.prg.top_path(), lmp4, "sample");
     EXPECT_EQ(j, vcf.samples.size());
     EXPECT_EQ(j, vcf.records[0]->samples.size());
-    EXPECT_EQ((uint16_t) 0, vcf.records[0]->samples[0]["GT"][0]);
+    EXPECT_EQ((uint16_t)0, vcf.records[0]->samples[0]["GT"][0]);
     EXPECT_EQ(j, vcf.records[1]->samples.size());
-    EXPECT_EQ((uint16_t) 1, vcf.records[1]->samples[0]["GT"][0]);
+    EXPECT_EQ((uint16_t)1, vcf.records[1]->samples[0]["GT"][0]);
     EXPECT_EQ(j, vcf.records[2]->samples.size());
-    EXPECT_EQ((uint16_t) 1, vcf.records[2]->samples[0]["GT"][0]);
+    EXPECT_EQ((uint16_t)1, vcf.records[2]->samples[0]["GT"][0]);
     EXPECT_EQ(j, vcf.records[3]->samples.size());
-    EXPECT_EQ((uint16_t) 0, vcf.records[3]->samples[0]["GT"][0]);
+    EXPECT_EQ((uint16_t)0, vcf.records[3]->samples[0]["GT"][0]);
     EXPECT_EQ(j, vcf.records[4]->samples.size());
-    EXPECT_EQ((uint16_t) 0, vcf.records[4]->samples[0]["GT"][0]);
+    EXPECT_EQ((uint16_t)0, vcf.records[4]->samples[0]["GT"][0]);
 
     vcf = VCF();
-    vector<LocalNodePtr> lmp5 = {l5.prg.nodes[0], l5.prg.nodes[1], l5.prg.nodes[10], l5.prg.nodes[11],
-                                 l5.prg.nodes[13]};
+    vector<LocalNodePtr> lmp5 = { l5.prg.nodes[0], l5.prg.nodes[1], l5.prg.nodes[10],
+        l5.prg.nodes[11], l5.prg.nodes[13] };
     l5.build_vcf(vcf, l5.prg.top_path());
     vcf.sort_records();
     l5.add_sample_gt_to_vcf(vcf, l5.prg.top_path(), lmp5, "sample");
     EXPECT_EQ(j, vcf.samples.size());
-    EXPECT_EQ((uint) 5, vcf.records.size());
+    EXPECT_EQ((uint)5, vcf.records.size());
     EXPECT_EQ(j, vcf.records[0]->samples.size());
-    EXPECT_TRUE(vcf.records[0]->samples[0].find("GT") == vcf.records[0]->samples[0].end());
+    EXPECT_TRUE(
+        vcf.records[0]->samples[0].find("GT") == vcf.records[0]->samples[0].end());
     EXPECT_EQ(j, vcf.records[1]->samples.size());
-    EXPECT_TRUE(vcf.records[1]->samples[0].find("GT") == vcf.records[1]->samples[0].end());
+    EXPECT_TRUE(
+        vcf.records[1]->samples[0].find("GT") == vcf.records[1]->samples[0].end());
     EXPECT_EQ(j, vcf.records[2]->samples.size());
-    EXPECT_TRUE(vcf.records[2]->samples[0].find("GT") == vcf.records[2]->samples[0].end());
+    EXPECT_TRUE(
+        vcf.records[2]->samples[0].find("GT") == vcf.records[2]->samples[0].end());
     EXPECT_EQ(j, vcf.records[3]->samples.size());
-    EXPECT_EQ((uint16_t) 1, vcf.records[3]->samples[0]["GT"][0]);
+    EXPECT_EQ((uint16_t)1, vcf.records[3]->samples[0]["GT"][0]);
     EXPECT_EQ(j, vcf.records[4]->samples.size());
-    EXPECT_TRUE(vcf.records[4]->samples[0].find("GT") == vcf.records[4]->samples[0].end());
+    EXPECT_TRUE(
+        vcf.records[4]->samples[0].find("GT") == vcf.records[4]->samples[0].end());
 
     // add the ref path
     l5.add_sample_gt_to_vcf(vcf, l5.prg.top_path(), l5.prg.top_path(), "sample2");
-    EXPECT_EQ((uint) 2, vcf.samples.size());
-    EXPECT_EQ((uint) 5, vcf.records.size());
-    EXPECT_EQ((uint) 2, vcf.records[0]->samples.size());
-    EXPECT_EQ((uint16_t) 0, vcf.records[0]->samples[1]["GT"][0]);
-    EXPECT_EQ((uint) 2, vcf.records[1]->samples.size());
-    EXPECT_EQ((uint16_t) 0, vcf.records[1]->samples[1]["GT"][0]);
-    EXPECT_EQ((uint) 2, vcf.records[2]->samples.size());
-    EXPECT_EQ((uint16_t) 0, vcf.records[2]->samples[1]["GT"][0]);
-    EXPECT_EQ((uint) 2, vcf.records[3]->samples.size());
-    EXPECT_EQ((uint16_t) 0, vcf.records[3]->samples[1]["GT"][0]);
-    EXPECT_EQ((uint) 2, vcf.records[4]->samples.size());
-    EXPECT_EQ((uint16_t) 0, vcf.records[4]->samples[1]["GT"][0]);
-
+    EXPECT_EQ((uint)2, vcf.samples.size());
+    EXPECT_EQ((uint)5, vcf.records.size());
+    EXPECT_EQ((uint)2, vcf.records[0]->samples.size());
+    EXPECT_EQ((uint16_t)0, vcf.records[0]->samples[1]["GT"][0]);
+    EXPECT_EQ((uint)2, vcf.records[1]->samples.size());
+    EXPECT_EQ((uint16_t)0, vcf.records[1]->samples[1]["GT"][0]);
+    EXPECT_EQ((uint)2, vcf.records[2]->samples.size());
+    EXPECT_EQ((uint16_t)0, vcf.records[2]->samples[1]["GT"][0]);
+    EXPECT_EQ((uint)2, vcf.records[3]->samples.size());
+    EXPECT_EQ((uint16_t)0, vcf.records[3]->samples[1]["GT"][0]);
+    EXPECT_EQ((uint)2, vcf.records[4]->samples.size());
+    EXPECT_EQ((uint16_t)0, vcf.records[4]->samples[1]["GT"][0]);
 }
 
-TEST(LocalPRGTest, moreupdateVCF) {
+TEST(LocalPRGTest, moreupdateVCF)
+{
     // load PRGs from file
     std::vector<std::shared_ptr<LocalPRG>> prgs;
     read_prg_file(prgs, "../../test/test_cases/updatevcf_test.fa");
 
-    EXPECT_EQ((uint) 3, prgs.size());
+    EXPECT_EQ((uint)3, prgs.size());
 
     VCF vcf;
 
@@ -1237,30 +1448,34 @@ TEST(LocalPRGTest, moreupdateVCF) {
     prgs[2]->build_vcf(vcf, prgs[2]->prg.top_path());
     vcf.sort_records();
 
-    vector<LocalNodePtr> lmp1 = {prgs[1]->prg.nodes[0], prgs[1]->prg.nodes[11], prgs[1]->prg.nodes[12],
-                                 prgs[1]->prg.nodes[17], prgs[1]->prg.nodes[65], prgs[1]->prg.nodes[67]};
+    vector<LocalNodePtr> lmp1
+        = { prgs[1]->prg.nodes[0], prgs[1]->prg.nodes[11], prgs[1]->prg.nodes[12],
+              prgs[1]->prg.nodes[17], prgs[1]->prg.nodes[65], prgs[1]->prg.nodes[67] };
     prgs[1]->add_sample_gt_to_vcf(vcf, prgs[1]->prg.top_path(), lmp1, "sample");
 
-    vector<LocalNodePtr> lmp2 = {prgs[2]->prg.nodes[0], prgs[2]->prg.nodes[1], prgs[2]->prg.nodes[3],
-                                 prgs[2]->prg.nodes[4], prgs[2]->prg.nodes[6], prgs[2]->prg.nodes[7],
-                                 prgs[2]->prg.nodes[9], prgs[2]->prg.nodes[10], prgs[2]->prg.nodes[11],
-                                 prgs[2]->prg.nodes[13], prgs[2]->prg.nodes[14], prgs[2]->prg.nodes[16],
-                                 prgs[2]->prg.nodes[17], prgs[2]->prg.nodes[19], prgs[2]->prg.nodes[44],
-                                 prgs[2]->prg.nodes[45], prgs[2]->prg.nodes[47], prgs[2]->prg.nodes[118],
-                                 prgs[2]->prg.nodes[119], prgs[2]->prg.nodes[121], prgs[2]->prg.nodes[123],
-                                 prgs[2]->prg.nodes[125], prgs[2]->prg.nodes[126], prgs[2]->prg.nodes[130],
-                                 prgs[2]->prg.nodes[131], prgs[2]->prg.nodes[133], prgs[2]->prg.nodes[135],
-                                 prgs[2]->prg.nodes[141], prgs[2]->prg.nodes[142], prgs[2]->prg.nodes[144],
-                                 prgs[2]->prg.nodes[145], prgs[2]->prg.nodes[160]};
+    vector<LocalNodePtr> lmp2 = { prgs[2]->prg.nodes[0], prgs[2]->prg.nodes[1],
+        prgs[2]->prg.nodes[3], prgs[2]->prg.nodes[4], prgs[2]->prg.nodes[6],
+        prgs[2]->prg.nodes[7], prgs[2]->prg.nodes[9], prgs[2]->prg.nodes[10],
+        prgs[2]->prg.nodes[11], prgs[2]->prg.nodes[13], prgs[2]->prg.nodes[14],
+        prgs[2]->prg.nodes[16], prgs[2]->prg.nodes[17], prgs[2]->prg.nodes[19],
+        prgs[2]->prg.nodes[44], prgs[2]->prg.nodes[45], prgs[2]->prg.nodes[47],
+        prgs[2]->prg.nodes[118], prgs[2]->prg.nodes[119], prgs[2]->prg.nodes[121],
+        prgs[2]->prg.nodes[123], prgs[2]->prg.nodes[125], prgs[2]->prg.nodes[126],
+        prgs[2]->prg.nodes[130], prgs[2]->prg.nodes[131], prgs[2]->prg.nodes[133],
+        prgs[2]->prg.nodes[135], prgs[2]->prg.nodes[141], prgs[2]->prg.nodes[142],
+        prgs[2]->prg.nodes[144], prgs[2]->prg.nodes[145], prgs[2]->prg.nodes[160] };
     prgs[2]->add_sample_gt_to_vcf(vcf, prgs[2]->prg.top_path(), lmp2, "sample");
 }
 
-TEST(LocalPRGTest, find_alt_path) {
+TEST(LocalPRGTest, find_alt_path)
+{
     LocalPRG l3(3, "nested varsite", "A 5 G 7 C 8 T 7  6 G 5 TAT 9 T 10  9 ATG");
 
-    vector<LocalNodePtr> top = {l3.prg.nodes[0], l3.prg.nodes[1], l3.prg.nodes[2], l3.prg.nodes[4], l3.prg.nodes[6]};
-    vector<LocalNodePtr> middle = {l3.prg.nodes[0], l3.prg.nodes[1], l3.prg.nodes[3], l3.prg.nodes[4], l3.prg.nodes[6]};
-    vector<LocalNodePtr> bottom = {l3.prg.nodes[0], l3.prg.nodes[5], l3.prg.nodes[6]};
+    vector<LocalNodePtr> top = { l3.prg.nodes[0], l3.prg.nodes[1], l3.prg.nodes[2],
+        l3.prg.nodes[4], l3.prg.nodes[6] };
+    vector<LocalNodePtr> middle = { l3.prg.nodes[0], l3.prg.nodes[1], l3.prg.nodes[3],
+        l3.prg.nodes[4], l3.prg.nodes[6] };
+    vector<LocalNodePtr> bottom = { l3.prg.nodes[0], l3.prg.nodes[5], l3.prg.nodes[6] };
 
     vector<LocalNodePtr> alt_path = l3.find_alt_path(top, 2, "C", "T");
     EXPECT_ITERABLE_EQ(vector<LocalNodePtr>, middle, alt_path);
@@ -1281,10 +1496,10 @@ TEST(LocalPRGTest, find_alt_path) {
     EXPECT_ITERABLE_EQ(vector<LocalNodePtr>, top, alt_path);
 
     // and now for the one where the alt or ref is "."
-    top = {l3.prg.nodes[0], l3.prg.nodes[1], l3.prg.nodes[2], l3.prg.nodes[4], l3.prg.nodes[6], l3.prg.nodes[7],
-           l3.prg.nodes[9]};
-    bottom = {l3.prg.nodes[0], l3.prg.nodes[1], l3.prg.nodes[2], l3.prg.nodes[4], l3.prg.nodes[6], l3.prg.nodes[8],
-              l3.prg.nodes[9]};
+    top = { l3.prg.nodes[0], l3.prg.nodes[1], l3.prg.nodes[2], l3.prg.nodes[4],
+        l3.prg.nodes[6], l3.prg.nodes[7], l3.prg.nodes[9] };
+    bottom = { l3.prg.nodes[0], l3.prg.nodes[1], l3.prg.nodes[2], l3.prg.nodes[4],
+        l3.prg.nodes[6], l3.prg.nodes[8], l3.prg.nodes[9] };
     alt_path = l3.find_alt_path(top, 6, "T", ".");
     EXPECT_ITERABLE_EQ(vector<LocalNodePtr>, bottom, alt_path);
 
@@ -1293,8 +1508,9 @@ TEST(LocalPRGTest, find_alt_path) {
 
     // if the site is at the start and alt is "."
     LocalPRG l3_(3, "nested varsite", " 5 G 7 C 8 T 7  6  5 TAT 9 T 10  9 ");
-    top = {l3_.prg.nodes[0], l3_.prg.nodes[1], l3_.prg.nodes[2], l3_.prg.nodes[4], l3_.prg.nodes[6]};
-    bottom = {l3_.prg.nodes[0], l3_.prg.nodes[5], l3_.prg.nodes[6]};
+    top = { l3_.prg.nodes[0], l3_.prg.nodes[1], l3_.prg.nodes[2], l3_.prg.nodes[4],
+        l3_.prg.nodes[6] };
+    bottom = { l3_.prg.nodes[0], l3_.prg.nodes[5], l3_.prg.nodes[6] };
 
     alt_path = l3_.find_alt_path(top, 0, "GC", ".");
     EXPECT_ITERABLE_EQ(vector<LocalNodePtr>, bottom, alt_path);
@@ -1303,178 +1519,214 @@ TEST(LocalPRGTest, find_alt_path) {
     EXPECT_ITERABLE_EQ(vector<LocalNodePtr>, top, alt_path);
 
     // if the site at the end has ref/alt as "."
-    top = {l3_.prg.nodes[0], l3_.prg.nodes[1], l3_.prg.nodes[2], l3_.prg.nodes[4],
-           l3_.prg.nodes[6], l3_.prg.nodes[7], l3_.prg.nodes[9]};
-    bottom = {l3_.prg.nodes[0], l3_.prg.nodes[1], l3_.prg.nodes[2], l3_.prg.nodes[4],
-              l3_.prg.nodes[6], l3_.prg.nodes[8], l3_.prg.nodes[9]};
+    top = { l3_.prg.nodes[0], l3_.prg.nodes[1], l3_.prg.nodes[2], l3_.prg.nodes[4],
+        l3_.prg.nodes[6], l3_.prg.nodes[7], l3_.prg.nodes[9] };
+    bottom = { l3_.prg.nodes[0], l3_.prg.nodes[1], l3_.prg.nodes[2], l3_.prg.nodes[4],
+        l3_.prg.nodes[6], l3_.prg.nodes[8], l3_.prg.nodes[9] };
 
     alt_path = l3_.find_alt_path(top, 5, "T", ".");
     EXPECT_ITERABLE_EQ(vector<LocalNodePtr>, bottom, alt_path);
 
     alt_path = l3_.find_alt_path(bottom, 5, ".", "T");
     EXPECT_ITERABLE_EQ(vector<LocalNodePtr>, top, alt_path);
-
 }
 
 class LocalPRGMock : public LocalPRG {
 public:
-    LocalPRGMock() : LocalPRG(0, "", "") {}
+    LocalPRGMock()
+        : LocalPRG(0, "", "")
+    {
+    }
 };
 
-
-class LocalPRGTest___get_number_of_bases_in_local_path_before_a_given_position___Fixture : public ::testing::Test {
+class LocalPRGTest___get_number_of_bases_in_local_path_before_a_given_position___Fixture
+    : public ::testing::Test {
 protected:
     class LocalPRGMockExposesTestedMethod : public LocalPRGMock {
     public:
-        virtual uint32_t
-        get_number_of_bases_in_local_path_before_a_given_position(const std::vector<LocalNodePtr> &local_path,
-                                                                  uint32_t position) const {
-            return LocalPRGMock::get_number_of_bases_in_local_path_before_a_given_position(local_path, position);
+        virtual uint32_t get_number_of_bases_in_local_path_before_a_given_position(
+            const std::vector<LocalNodePtr>& local_path, uint32_t position) const
+        {
+            return LocalPRGMock::
+                get_number_of_bases_in_local_path_before_a_given_position(
+                    local_path, position);
         }
     };
 
-
-    void SetUp() override {
-        local_path_with_two_intervals.push_back(std::make_shared<LocalNode>("", Interval(10, 20), 0));
-        local_path_with_two_intervals.push_back(std::make_shared<LocalNode>("", Interval(35, 45), 1));
+    void SetUp() override
+    {
+        local_path_with_two_intervals.push_back(
+            std::make_shared<LocalNode>("", Interval(10, 20), 0));
+        local_path_with_two_intervals.push_back(
+            std::make_shared<LocalNode>("", Interval(35, 45), 1));
     }
 
-    void TearDown() override {
-    }
+    void TearDown() override {}
 
     LocalPRGMockExposesTestedMethod local_prg_mock;
     std::vector<LocalNodePtr> empty_local_path;
     std::vector<LocalNodePtr> local_path_with_two_intervals;
 };
 
-
-TEST_F(LocalPRGTest___get_number_of_bases_in_local_path_before_a_given_position___Fixture,
-       empty_local_path___returns_0) {
+TEST_F(
+    LocalPRGTest___get_number_of_bases_in_local_path_before_a_given_position___Fixture,
+    empty_local_path___returns_0)
+{
     uint32_t position = 30;
 
-    uint32_t actual = local_prg_mock.get_number_of_bases_in_local_path_before_a_given_position(empty_local_path,
-                                                                                               position);
+    uint32_t actual
+        = local_prg_mock.get_number_of_bases_in_local_path_before_a_given_position(
+            empty_local_path, position);
 
     uint32_t expected = 0;
     ASSERT_EQ(actual, expected);
 }
 
-TEST_F(LocalPRGTest___get_number_of_bases_in_local_path_before_a_given_position___Fixture,
-       local_path_with_two_intervals___position_just_before_first_interval___returns_0) {
+TEST_F(
+    LocalPRGTest___get_number_of_bases_in_local_path_before_a_given_position___Fixture,
+    local_path_with_two_intervals___position_just_before_first_interval___returns_0)
+{
     uint32_t position = 9;
 
-    uint32_t actual = local_prg_mock.get_number_of_bases_in_local_path_before_a_given_position(
+    uint32_t actual
+        = local_prg_mock.get_number_of_bases_in_local_path_before_a_given_position(
             local_path_with_two_intervals, position);
 
     uint32_t expected = 0;
     ASSERT_EQ(actual, expected);
 }
 
-TEST_F(LocalPRGTest___get_number_of_bases_in_local_path_before_a_given_position___Fixture,
-       local_path_with_two_intervals___position_at_the_start_of_first_interval___returns_0) {
+TEST_F(
+    LocalPRGTest___get_number_of_bases_in_local_path_before_a_given_position___Fixture,
+    local_path_with_two_intervals___position_at_the_start_of_first_interval___returns_0)
+{
     uint32_t position = 10;
 
-    uint32_t actual = local_prg_mock.get_number_of_bases_in_local_path_before_a_given_position(
+    uint32_t actual
+        = local_prg_mock.get_number_of_bases_in_local_path_before_a_given_position(
             local_path_with_two_intervals, position);
 
     uint32_t expected = 0;
     ASSERT_EQ(actual, expected);
 }
 
-TEST_F(LocalPRGTest___get_number_of_bases_in_local_path_before_a_given_position___Fixture,
-       local_path_with_two_intervals___position_just_after_the_start_of_first_interval___returns_1) {
+TEST_F(
+    LocalPRGTest___get_number_of_bases_in_local_path_before_a_given_position___Fixture,
+    local_path_with_two_intervals___position_just_after_the_start_of_first_interval___returns_1)
+{
     uint32_t position = 11;
 
-    uint32_t actual = local_prg_mock.get_number_of_bases_in_local_path_before_a_given_position(
+    uint32_t actual
+        = local_prg_mock.get_number_of_bases_in_local_path_before_a_given_position(
             local_path_with_two_intervals, position);
 
     uint32_t expected = 1;
     ASSERT_EQ(actual, expected);
 }
 
-TEST_F(LocalPRGTest___get_number_of_bases_in_local_path_before_a_given_position___Fixture,
-       local_path_with_two_intervals___position_just_before_the_end_of_first_interval___returns_8) {
+TEST_F(
+    LocalPRGTest___get_number_of_bases_in_local_path_before_a_given_position___Fixture,
+    local_path_with_two_intervals___position_just_before_the_end_of_first_interval___returns_8)
+{
     uint32_t position = 18;
 
-    uint32_t actual = local_prg_mock.get_number_of_bases_in_local_path_before_a_given_position(
+    uint32_t actual
+        = local_prg_mock.get_number_of_bases_in_local_path_before_a_given_position(
             local_path_with_two_intervals, position);
 
     uint32_t expected = 8;
     ASSERT_EQ(actual, expected);
 }
 
-TEST_F(LocalPRGTest___get_number_of_bases_in_local_path_before_a_given_position___Fixture,
-       local_path_with_two_intervals___position_at_the_end_of_first_interval___returns_9) {
+TEST_F(
+    LocalPRGTest___get_number_of_bases_in_local_path_before_a_given_position___Fixture,
+    local_path_with_two_intervals___position_at_the_end_of_first_interval___returns_9)
+{
     uint32_t position = 19;
 
-    uint32_t actual = local_prg_mock.get_number_of_bases_in_local_path_before_a_given_position(
+    uint32_t actual
+        = local_prg_mock.get_number_of_bases_in_local_path_before_a_given_position(
             local_path_with_two_intervals, position);
 
     uint32_t expected = 9;
     ASSERT_EQ(actual, expected);
 }
 
-TEST_F(LocalPRGTest___get_number_of_bases_in_local_path_before_a_given_position___Fixture,
-       local_path_with_two_intervals___position_just_after_the_end_of_first_interval___returns_10) {
+TEST_F(
+    LocalPRGTest___get_number_of_bases_in_local_path_before_a_given_position___Fixture,
+    local_path_with_two_intervals___position_just_after_the_end_of_first_interval___returns_10)
+{
     uint32_t position = 20;
 
-    uint32_t actual = local_prg_mock.get_number_of_bases_in_local_path_before_a_given_position(
+    uint32_t actual
+        = local_prg_mock.get_number_of_bases_in_local_path_before_a_given_position(
             local_path_with_two_intervals, position);
 
     uint32_t expected = 10;
     ASSERT_EQ(actual, expected);
 }
 
-
-TEST_F(LocalPRGTest___get_number_of_bases_in_local_path_before_a_given_position___Fixture,
-       local_path_with_two_intervals___position_between_intervals___returns_10) {
+TEST_F(
+    LocalPRGTest___get_number_of_bases_in_local_path_before_a_given_position___Fixture,
+    local_path_with_two_intervals___position_between_intervals___returns_10)
+{
     uint32_t position = 30;
 
-    uint32_t actual = local_prg_mock.get_number_of_bases_in_local_path_before_a_given_position(
+    uint32_t actual
+        = local_prg_mock.get_number_of_bases_in_local_path_before_a_given_position(
             local_path_with_two_intervals, position);
 
     uint32_t expected = 10;
     ASSERT_EQ(actual, expected);
 }
 
-TEST_F(LocalPRGTest___get_number_of_bases_in_local_path_before_a_given_position___Fixture,
-       local_path_with_two_intervals___position_at_the_start_of_second_interval___returns_10) {
+TEST_F(
+    LocalPRGTest___get_number_of_bases_in_local_path_before_a_given_position___Fixture,
+    local_path_with_two_intervals___position_at_the_start_of_second_interval___returns_10)
+{
     uint32_t position = 35;
 
-    uint32_t actual = local_prg_mock.get_number_of_bases_in_local_path_before_a_given_position(
+    uint32_t actual
+        = local_prg_mock.get_number_of_bases_in_local_path_before_a_given_position(
             local_path_with_two_intervals, position);
 
     uint32_t expected = 10;
     ASSERT_EQ(actual, expected);
 }
 
-TEST_F(LocalPRGTest___get_number_of_bases_in_local_path_before_a_given_position___Fixture,
-       local_path_with_two_intervals___position_just_after_the_start_of_second_interval___returns_11) {
+TEST_F(
+    LocalPRGTest___get_number_of_bases_in_local_path_before_a_given_position___Fixture,
+    local_path_with_two_intervals___position_just_after_the_start_of_second_interval___returns_11)
+{
     uint32_t position = 36;
 
-    uint32_t actual = local_prg_mock.get_number_of_bases_in_local_path_before_a_given_position(
+    uint32_t actual
+        = local_prg_mock.get_number_of_bases_in_local_path_before_a_given_position(
             local_path_with_two_intervals, position);
 
     uint32_t expected = 11;
     ASSERT_EQ(actual, expected);
 }
 
-
-class LocalPRGTest___get_number_of_bases_that_are_exclusively_in_the_previous_kmer_node___Fixture
-        : public ::testing::Test {
+class
+    LocalPRGTest___get_number_of_bases_that_are_exclusively_in_the_previous_kmer_node___Fixture
+    : public ::testing::Test {
 protected:
     class LocalPRGMockExposesTestedMethod : public LocalPRGMock {
     public:
         virtual uint32_t
-        get_number_of_bases_that_are_exclusively_in_the_previous_kmer_node(const KmerNodePtr &previous_kmer_node,
-                                                                           const KmerNodePtr &current_kmer_node) const {
-            return LocalPRGMock::get_number_of_bases_that_are_exclusively_in_the_previous_kmer_node(previous_kmer_node,
-                                                                                                    current_kmer_node);
+        get_number_of_bases_that_are_exclusively_in_the_previous_kmer_node(
+            const KmerNodePtr& previous_kmer_node,
+            const KmerNodePtr& current_kmer_node) const
+        {
+            return LocalPRGMock::
+                get_number_of_bases_that_are_exclusively_in_the_previous_kmer_node(
+                    previous_kmer_node, current_kmer_node);
         }
     };
 
-
-    void SetUp() override {
+    void SetUp() override
+    {
         {
             prg::Path path_from_3_to_30;
             path_from_3_to_30.push_back(Interval(3, 7));
@@ -1514,7 +1766,6 @@ protected:
             kmer_node_from_15_to_50 = std::make_shared<KmerNode>(2, path_from_15_to_50);
         }
 
-
         {
             prg::Path path_from_40_to_50;
             path_from_40_to_50.push_back(Interval(40, 50));
@@ -1522,8 +1773,7 @@ protected:
         }
     }
 
-    void TearDown() override {
-    }
+    void TearDown() override {}
 
     LocalPRGMockExposesTestedMethod local_prg_mock;
     KmerNodePtr kmer_node_from_3_to_30;
@@ -1535,84 +1785,104 @@ protected:
     KmerNodePtr kmer_node_from_40_to_50;
 };
 
-
-TEST_F(LocalPRGTest___get_number_of_bases_that_are_exclusively_in_the_previous_kmer_node___Fixture,
-       previous_node_exactly_at_the_start_of_current_node___returns_0) {
+TEST_F(
+    LocalPRGTest___get_number_of_bases_that_are_exclusively_in_the_previous_kmer_node___Fixture,
+    previous_node_exactly_at_the_start_of_current_node___returns_0)
+{
     KmerNodePtr previous_node = kmer_node_from_3_to_30;
     KmerNodePtr current_node = kmer_node_from_3_to_50;
 
-    uint32_t actual = local_prg_mock.get_number_of_bases_that_are_exclusively_in_the_previous_kmer_node(previous_node,
-                                                                                                        current_node);
+    uint32_t actual
+        = local_prg_mock
+              .get_number_of_bases_that_are_exclusively_in_the_previous_kmer_node(
+                  previous_node, current_node);
 
     uint32_t expected = 0;
     ASSERT_EQ(actual, expected);
 }
 
-TEST_F(LocalPRGTest___get_number_of_bases_that_are_exclusively_in_the_previous_kmer_node___Fixture,
-       previous_node_just_before_the_start_of_current_node___returns_1) {
+TEST_F(
+    LocalPRGTest___get_number_of_bases_that_are_exclusively_in_the_previous_kmer_node___Fixture,
+    previous_node_just_before_the_start_of_current_node___returns_1)
+{
     KmerNodePtr previous_node = kmer_node_from_3_to_30;
     KmerNodePtr current_node = kmer_node_from_4_to_50;
 
-    uint32_t actual = local_prg_mock.get_number_of_bases_that_are_exclusively_in_the_previous_kmer_node(previous_node,
-                                                                                                        current_node);
+    uint32_t actual
+        = local_prg_mock
+              .get_number_of_bases_that_are_exclusively_in_the_previous_kmer_node(
+                  previous_node, current_node);
 
     uint32_t expected = 1;
     ASSERT_EQ(actual, expected);
 }
 
-TEST_F(LocalPRGTest___get_number_of_bases_that_are_exclusively_in_the_previous_kmer_node___Fixture,
-       current_node_right_at_the_end_of_first_interval_of_previous_node___returns_4) {
+TEST_F(
+    LocalPRGTest___get_number_of_bases_that_are_exclusively_in_the_previous_kmer_node___Fixture,
+    current_node_right_at_the_end_of_first_interval_of_previous_node___returns_4)
+{
     KmerNodePtr previous_node = kmer_node_from_3_to_30;
     KmerNodePtr current_node = kmer_node_from_7_to_50;
 
-    uint32_t actual = local_prg_mock.get_number_of_bases_that_are_exclusively_in_the_previous_kmer_node(previous_node,
-                                                                                                        current_node);
+    uint32_t actual
+        = local_prg_mock
+              .get_number_of_bases_that_are_exclusively_in_the_previous_kmer_node(
+                  previous_node, current_node);
 
     uint32_t expected = 4;
     ASSERT_EQ(actual, expected);
 }
 
-TEST_F(LocalPRGTest___get_number_of_bases_that_are_exclusively_in_the_previous_kmer_node___Fixture,
-       current_node_between_the_first_and_second_interval_of_previous_node___returns_4) {
+TEST_F(
+    LocalPRGTest___get_number_of_bases_that_are_exclusively_in_the_previous_kmer_node___Fixture,
+    current_node_between_the_first_and_second_interval_of_previous_node___returns_4)
+{
     KmerNodePtr previous_node = kmer_node_from_3_to_30;
     KmerNodePtr current_node = kmer_node_from_10_to_50;
 
-    uint32_t actual = local_prg_mock.get_number_of_bases_that_are_exclusively_in_the_previous_kmer_node(previous_node,
-                                                                                                        current_node);
+    uint32_t actual
+        = local_prg_mock
+              .get_number_of_bases_that_are_exclusively_in_the_previous_kmer_node(
+                  previous_node, current_node);
 
     uint32_t expected = 4;
     ASSERT_EQ(actual, expected);
 }
 
-
-TEST_F(LocalPRGTest___get_number_of_bases_that_are_exclusively_in_the_previous_kmer_node___Fixture,
-       current_node_inside_second_interval_of_previous_node___returns_7) {
+TEST_F(
+    LocalPRGTest___get_number_of_bases_that_are_exclusively_in_the_previous_kmer_node___Fixture,
+    current_node_inside_second_interval_of_previous_node___returns_7)
+{
     KmerNodePtr previous_node = kmer_node_from_3_to_30;
     KmerNodePtr current_node = kmer_node_from_15_to_50;
 
-    uint32_t actual = local_prg_mock.get_number_of_bases_that_are_exclusively_in_the_previous_kmer_node(previous_node,
-                                                                                                        current_node);
+    uint32_t actual
+        = local_prg_mock
+              .get_number_of_bases_that_are_exclusively_in_the_previous_kmer_node(
+                  previous_node, current_node);
 
     uint32_t expected = 7;
     ASSERT_EQ(actual, expected);
 }
 
-
-TEST_F(LocalPRGTest___get_number_of_bases_that_are_exclusively_in_the_previous_kmer_node___Fixture,
-       current_node_after_previous_node___returns_22) {
+TEST_F(
+    LocalPRGTest___get_number_of_bases_that_are_exclusively_in_the_previous_kmer_node___Fixture,
+    current_node_after_previous_node___returns_22)
+{
     KmerNodePtr previous_node = kmer_node_from_3_to_30;
     KmerNodePtr current_node = kmer_node_from_40_to_50;
 
-    uint32_t actual = local_prg_mock.get_number_of_bases_that_are_exclusively_in_the_previous_kmer_node(previous_node,
-                                                                                                        current_node);
+    uint32_t actual
+        = local_prg_mock
+              .get_number_of_bases_that_are_exclusively_in_the_previous_kmer_node(
+                  previous_node, current_node);
 
     uint32_t expected = 22;
     ASSERT_EQ(actual, expected);
 }
 
-
-
-TEST(LocalPRGTest, get_forward_and_reverse_kmer_coverages_in_range) {
+TEST(LocalPRGTest, get_forward_and_reverse_kmer_coverages_in_range)
+{
     auto index = std::make_shared<Index>();
     LocalPRG l3(3, "nested varsite", "A 5 G 7 C 8 T 7  6 G 5 TAT");
     l3.minimizer_sketch(index, 1, 3);
@@ -1628,86 +1898,86 @@ TEST(LocalPRGTest, get_forward_and_reverse_kmer_coverages_in_range) {
     kg.set_covg(8, 6, 1, 0);
 
     vector<LocalNodePtr> lmp = {};
-    vector<KmerNodePtr> kmp = {
-            l3.kmer_prg.nodes[0],
-            l3.kmer_prg.nodes[2],
-            l3.kmer_prg.nodes[5],
-            l3.kmer_prg.nodes[8],
-            l3.kmer_prg.nodes[10],
-            l3.kmer_prg.nodes[11]
-    };
+    vector<KmerNodePtr> kmp
+        = { l3.kmer_prg.nodes[0], l3.kmer_prg.nodes[2], l3.kmer_prg.nodes[5],
+              l3.kmer_prg.nodes[8], l3.kmer_prg.nodes[10], l3.kmer_prg.nodes[11] };
     vector<uint32_t> fwd, rev, exp_fwd, exp_rev;
 
-    std::tie(fwd, rev) = l3.get_forward_and_reverse_kmer_coverages_in_range(kg, kmp, lmp, 0, 0, 0);
+    std::tie(fwd, rev)
+        = l3.get_forward_and_reverse_kmer_coverages_in_range(kg, kmp, lmp, 0, 0, 0);
     EXPECT_TRUE(fwd.empty());
     EXPECT_TRUE(rev.empty());
 
-    std::tie(fwd, rev) = l3.get_forward_and_reverse_kmer_coverages_in_range(kg, kmp, lmp, 0, 1, 0);
-    exp_fwd = {4};
-    exp_rev = {3};
+    std::tie(fwd, rev)
+        = l3.get_forward_and_reverse_kmer_coverages_in_range(kg, kmp, lmp, 0, 1, 0);
+    exp_fwd = { 4 };
+    exp_rev = { 3 };
     EXPECT_ITERABLE_EQ(vector<uint32_t>, exp_fwd, fwd);
     EXPECT_ITERABLE_EQ(vector<uint32_t>, exp_rev, rev);
 
-    std::tie(fwd, rev) = l3.get_forward_and_reverse_kmer_coverages_in_range(kg, kmp, lmp, 0, 2, 0);
-    exp_fwd = {4, 4};
-    exp_rev = {3, 5};
+    std::tie(fwd, rev)
+        = l3.get_forward_and_reverse_kmer_coverages_in_range(kg, kmp, lmp, 0, 2, 0);
+    exp_fwd = { 4, 4 };
+    exp_rev = { 3, 5 };
     EXPECT_ITERABLE_EQ(vector<uint32_t>, exp_fwd, fwd);
     EXPECT_ITERABLE_EQ(vector<uint32_t>, exp_rev, rev);
 
-    std::tie(fwd, rev) = l3.get_forward_and_reverse_kmer_coverages_in_range(kg, kmp, lmp, 0, 3, 0);
-    exp_fwd = {4, 4, 4};
-    exp_rev = {3, 5, 6};
+    std::tie(fwd, rev)
+        = l3.get_forward_and_reverse_kmer_coverages_in_range(kg, kmp, lmp, 0, 3, 0);
+    exp_fwd = { 4, 4, 4 };
+    exp_rev = { 3, 5, 6 };
     EXPECT_ITERABLE_EQ(vector<uint32_t>, exp_fwd, fwd);
     EXPECT_ITERABLE_EQ(vector<uint32_t>, exp_rev, rev);
 
-    std::tie(fwd, rev) = l3.get_forward_and_reverse_kmer_coverages_in_range(kg, kmp, lmp, 1, 2, 0);
-    exp_fwd = {4, 4};
-    exp_rev = {3, 5};
+    std::tie(fwd, rev)
+        = l3.get_forward_and_reverse_kmer_coverages_in_range(kg, kmp, lmp, 1, 2, 0);
+    exp_fwd = { 4, 4 };
+    exp_rev = { 3, 5 };
     EXPECT_ITERABLE_EQ(vector<uint32_t>, exp_fwd, fwd);
     EXPECT_ITERABLE_EQ(vector<uint32_t>, exp_rev, rev);
 }
 
-TEST(LocalPRGTest, add_sample_covgs_to_vcf) {
+TEST(LocalPRGTest, add_sample_covgs_to_vcf)
+{
     uint32_t min_kmer_covgs = 0;
     auto index = std::make_shared<Index>();
-    vector<string> short_formats = {"GT"};
-    vector<string> formats = {"GT", "MEAN_FWD_COVG", "MEAN_REV_COVG",
-                              "MED_FWD_COVG", "MED_REV_COVG",
-                              "SUM_FWD_COVG", "SUM_REV_COVG", "GAPS"};
+    vector<string> short_formats = { "GT" };
+    vector<string> formats = { "GT", "MEAN_FWD_COVG", "MEAN_REV_COVG", "MED_FWD_COVG",
+        "MED_REV_COVG", "SUM_FWD_COVG", "SUM_REV_COVG", "GAPS" };
 
     LocalPRG l3(3, "nested varsite", "A 5 G 7 C 8 T 7  6 G 5 TAT");
     l3.minimizer_sketch(index, 1, 3);
 
     VCF vcf;
 
-    vector<LocalNodePtr> lmp3 = {l3.prg.nodes[0], l3.prg.nodes[1], l3.prg.nodes[3], l3.prg.nodes[4], l3.prg.nodes[6]};
+    vector<LocalNodePtr> lmp3 = { l3.prg.nodes[0], l3.prg.nodes[1], l3.prg.nodes[3],
+        l3.prg.nodes[4], l3.prg.nodes[6] };
     l3.build_vcf(vcf, l3.prg.top_path());
     vcf.sort_records();
     l3.add_sample_gt_to_vcf(vcf, l3.prg.top_path(), lmp3, "sample");
-    EXPECT_EQ((uint) 1, vcf.samples.size());
-    EXPECT_EQ((uint) 1, vcf.records[0]->samples.size());
+    EXPECT_EQ((uint)1, vcf.samples.size());
+    EXPECT_EQ((uint)1, vcf.records[0]->samples.size());
     EXPECT_ITERABLE_EQ(vector<string>, short_formats, vcf.records[0]->format);
-    EXPECT_EQ((uint16_t) 1, vcf.records[1]->samples[0]["GT"][0]);
+    EXPECT_EQ((uint16_t)1, vcf.records[1]->samples[0]["GT"][0]);
 
     KmerGraphWithCoverage kg(&l3.kmer_prg);
-    l3.add_sample_covgs_to_vcf(vcf, kg, l3.prg.top_path(), min_kmer_covgs, "sample",
-                               0);
-    EXPECT_EQ((uint) 1, vcf.samples.size());
-    EXPECT_EQ((uint) 1, vcf.records[0]->samples.size());
+    l3.add_sample_covgs_to_vcf(vcf, kg, l3.prg.top_path(), min_kmer_covgs, "sample", 0);
+    EXPECT_EQ((uint)1, vcf.samples.size());
+    EXPECT_EQ((uint)1, vcf.records[0]->samples.size());
     EXPECT_ITERABLE_EQ(vector<string>, formats, vcf.records[0]->format);
-    EXPECT_EQ((uint16_t) 1, vcf.records[1]->samples[0]["GT"][0]);
-    EXPECT_EQ((uint16_t) 0, vcf.records[1]->samples[0]["MEAN_FWD_COVG"][0]);
-    EXPECT_EQ((uint16_t) 0, vcf.records[1]->samples[0]["MEAN_REV_COVG"][0]);
-    EXPECT_EQ((uint16_t) 0, vcf.records[1]->samples[0]["MEAN_FWD_COVG"][1]);
-    EXPECT_EQ((uint16_t) 0, vcf.records[1]->samples[0]["MEAN_REV_COVG"][1]);
-    EXPECT_EQ((uint16_t) 0, vcf.records[1]->samples[0]["MED_FWD_COVG"][0]);
-    EXPECT_EQ((uint16_t) 0, vcf.records[1]->samples[0]["MED_REV_COVG"][0]);
-    EXPECT_EQ((uint16_t) 0, vcf.records[1]->samples[0]["MED_FWD_COVG"][1]);
-    EXPECT_EQ((uint16_t) 0, vcf.records[1]->samples[0]["MED_REV_COVG"][1]);
-    EXPECT_EQ((uint16_t) 0, vcf.records[1]->samples[0]["SUM_FWD_COVG"][0]);
-    EXPECT_EQ((uint16_t) 0, vcf.records[1]->samples[0]["SUM_REV_COVG"][0]);
-    EXPECT_EQ((uint16_t) 0, vcf.records[1]->samples[0]["SUM_FWD_COVG"][1]);
-    EXPECT_EQ((uint16_t) 0, vcf.records[1]->samples[0]["SUM_REV_COVG"][1]);
+    EXPECT_EQ((uint16_t)1, vcf.records[1]->samples[0]["GT"][0]);
+    EXPECT_EQ((uint16_t)0, vcf.records[1]->samples[0]["MEAN_FWD_COVG"][0]);
+    EXPECT_EQ((uint16_t)0, vcf.records[1]->samples[0]["MEAN_REV_COVG"][0]);
+    EXPECT_EQ((uint16_t)0, vcf.records[1]->samples[0]["MEAN_FWD_COVG"][1]);
+    EXPECT_EQ((uint16_t)0, vcf.records[1]->samples[0]["MEAN_REV_COVG"][1]);
+    EXPECT_EQ((uint16_t)0, vcf.records[1]->samples[0]["MED_FWD_COVG"][0]);
+    EXPECT_EQ((uint16_t)0, vcf.records[1]->samples[0]["MED_REV_COVG"][0]);
+    EXPECT_EQ((uint16_t)0, vcf.records[1]->samples[0]["MED_FWD_COVG"][1]);
+    EXPECT_EQ((uint16_t)0, vcf.records[1]->samples[0]["MED_REV_COVG"][1]);
+    EXPECT_EQ((uint16_t)0, vcf.records[1]->samples[0]["SUM_FWD_COVG"][0]);
+    EXPECT_EQ((uint16_t)0, vcf.records[1]->samples[0]["SUM_REV_COVG"][0]);
+    EXPECT_EQ((uint16_t)0, vcf.records[1]->samples[0]["SUM_FWD_COVG"][1]);
+    EXPECT_EQ((uint16_t)0, vcf.records[1]->samples[0]["SUM_REV_COVG"][1]);
 
     // ref
     kg.set_covg(1, 1, 0, 0);
@@ -1726,25 +1996,26 @@ TEST(LocalPRGTest, add_sample_covgs_to_vcf) {
     kg.set_covg(8, 5, 1, 0);
 
     l3.add_sample_covgs_to_vcf(vcf, kg, l3.prg.top_path(), min_kmer_covgs, "sample", 0);
-    EXPECT_EQ((uint) 1, vcf.samples.size());
-    EXPECT_EQ((uint) 1, vcf.records[0]->samples.size());
+    EXPECT_EQ((uint)1, vcf.samples.size());
+    EXPECT_EQ((uint)1, vcf.records[0]->samples.size());
     EXPECT_ITERABLE_EQ(vector<string>, formats, vcf.records[0]->format);
-    EXPECT_EQ((uint16_t) 1, vcf.records[1]->samples[0]["GT"][0]);
-    EXPECT_EQ((uint16_t) 1, vcf.records[1]->samples[0]["MEAN_FWD_COVG"][0]);
-    EXPECT_EQ((uint16_t) 0, vcf.records[1]->samples[0]["MEAN_REV_COVG"][0]);
-    EXPECT_EQ((uint16_t) 5, vcf.records[1]->samples[0]["MEAN_FWD_COVG"][1]);
-    EXPECT_EQ((uint16_t) 6, vcf.records[1]->samples[0]["MEAN_REV_COVG"][1]);
-    EXPECT_EQ((uint16_t) 1, vcf.records[1]->samples[0]["MED_FWD_COVG"][0]);
-    EXPECT_EQ((uint16_t) 0, vcf.records[1]->samples[0]["MED_REV_COVG"][0]);
-    EXPECT_EQ((uint16_t) 5, vcf.records[1]->samples[0]["MED_FWD_COVG"][1]);
-    EXPECT_EQ((uint16_t) 5, vcf.records[1]->samples[0]["MED_REV_COVG"][1]);
-    EXPECT_EQ((uint16_t) 3, vcf.records[1]->samples[0]["SUM_FWD_COVG"][0]);
-    EXPECT_EQ((uint16_t) 0, vcf.records[1]->samples[0]["SUM_REV_COVG"][0]);
-    EXPECT_EQ((uint16_t) 15, vcf.records[1]->samples[0]["SUM_FWD_COVG"][1]);
-    EXPECT_EQ((uint16_t) 18, vcf.records[1]->samples[0]["SUM_REV_COVG"][1]);
+    EXPECT_EQ((uint16_t)1, vcf.records[1]->samples[0]["GT"][0]);
+    EXPECT_EQ((uint16_t)1, vcf.records[1]->samples[0]["MEAN_FWD_COVG"][0]);
+    EXPECT_EQ((uint16_t)0, vcf.records[1]->samples[0]["MEAN_REV_COVG"][0]);
+    EXPECT_EQ((uint16_t)5, vcf.records[1]->samples[0]["MEAN_FWD_COVG"][1]);
+    EXPECT_EQ((uint16_t)6, vcf.records[1]->samples[0]["MEAN_REV_COVG"][1]);
+    EXPECT_EQ((uint16_t)1, vcf.records[1]->samples[0]["MED_FWD_COVG"][0]);
+    EXPECT_EQ((uint16_t)0, vcf.records[1]->samples[0]["MED_REV_COVG"][0]);
+    EXPECT_EQ((uint16_t)5, vcf.records[1]->samples[0]["MED_FWD_COVG"][1]);
+    EXPECT_EQ((uint16_t)5, vcf.records[1]->samples[0]["MED_REV_COVG"][1]);
+    EXPECT_EQ((uint16_t)3, vcf.records[1]->samples[0]["SUM_FWD_COVG"][0]);
+    EXPECT_EQ((uint16_t)0, vcf.records[1]->samples[0]["SUM_REV_COVG"][0]);
+    EXPECT_EQ((uint16_t)15, vcf.records[1]->samples[0]["SUM_FWD_COVG"][1]);
+    EXPECT_EQ((uint16_t)18, vcf.records[1]->samples[0]["SUM_REV_COVG"][1]);
 }
 
-TEST(LocalPRGTest, add_consensus_path_to_fastaq_bin) {
+TEST(LocalPRGTest, add_consensus_path_to_fastaq_bin)
+{
     auto index = std::make_shared<Index>();
 
     auto l3 { std::make_shared<LocalPRG>(3, "three", "A 5 G 7 C 8 T 7  6 G 5 TAT") };
@@ -1770,9 +2041,11 @@ TEST(LocalPRGTest, add_consensus_path_to_fastaq_bin) {
     vector<LocalNodePtr> lmp;
 
     uint32_t max_num_kmers_to_average = 100;
-    l3->add_consensus_path_to_fastaq(fq, pn3, kmp, lmp, 1, true, 8, max_num_kmers_to_average, 0);
+    l3->add_consensus_path_to_fastaq(
+        fq, pn3, kmp, lmp, 1, true, 8, max_num_kmers_to_average, 0);
     EXPECT_EQ("AGTTAT", l3->string_along_path(lmp));
-    bool added_to_fq = find(fq.names.begin(), fq.names.end(), "three") != fq.names.end();
+    bool added_to_fq
+        = find(fq.names.begin(), fq.names.end(), "three") != fq.names.end();
     EXPECT_TRUE(added_to_fq);
     bool added_to_seqs = fq.sequences.find("three") != fq.sequences.end();
     EXPECT_TRUE(added_to_seqs);
@@ -1782,16 +2055,16 @@ TEST(LocalPRGTest, add_consensus_path_to_fastaq_bin) {
     EXPECT_TRUE(added_to_headers);
     EXPECT_EQ("AGTTAT", fq.sequences["three"]);
     EXPECT_EQ(fq.scores["three"], "DDD\?\?!");
-
 }
 
-TEST(LocalPRGTest, add_consensus_path_to_fastaq_nbin) {
+TEST(LocalPRGTest, add_consensus_path_to_fastaq_nbin)
+{
     auto index = std::make_shared<Index>();
     auto l3 { std::make_shared<LocalPRG>(3, "three", "A 5 G 7 C 8 T 7  6 G 5 TAT") };
     l3->minimizer_sketch(index, 1, 3);
 
     shared_ptr<pangenome::Node> pn3(make_shared<pangenome::Node>(l3));
-    pn3->kmer_prg_with_coverage.set_covg(2 ,4, 0, 0);
+    pn3->kmer_prg_with_coverage.set_covg(2, 4, 0, 0);
     pn3->kmer_prg_with_coverage.set_covg(2, 3, 1, 0);
     pn3->kmer_prg_with_coverage.set_covg(5, 5, 0, 0);
     pn3->kmer_prg_with_coverage.set_covg(7, 2, 0, 0);
@@ -1807,18 +2080,20 @@ TEST(LocalPRGTest, add_consensus_path_to_fastaq_nbin) {
     vector<LocalNodePtr> lmp;
 
     uint32_t max_num_kmers_to_average = 100;
-    l3->add_consensus_path_to_fastaq(fq, pn3, kmp, lmp, 1, false, 8, max_num_kmers_to_average, 0);
+    l3->add_consensus_path_to_fastaq(
+        fq, pn3, kmp, lmp, 1, false, 8, max_num_kmers_to_average, 0);
 
     EXPECT_NE(kmp.size(), 0);
-    std::vector<uint32_t> expected = {2, 5, 8, 10};
+    std::vector<uint32_t> expected = { 2, 5, 8, 10 };
     std::vector<uint32_t> result = {};
-    for (const auto &kmer_node_ptr: kmp)
+    for (const auto& kmer_node_ptr : kmp)
         result.push_back(kmer_node_ptr->id);
 
-    EXPECT_ITERABLE_EQ(std::vector<uint32_t>, expected , result);
+    EXPECT_ITERABLE_EQ(std::vector<uint32_t>, expected, result);
 
     EXPECT_EQ("AGTTAT", l3->string_along_path(lmp));
-    bool added_to_fq = find(fq.names.begin(), fq.names.end(), "three") != fq.names.end();
+    bool added_to_fq
+        = find(fq.names.begin(), fq.names.end(), "three") != fq.names.end();
     EXPECT_TRUE(added_to_fq);
     bool added_to_seqs = fq.sequences.find("three") != fq.sequences.end();
     EXPECT_TRUE(added_to_seqs);
@@ -1830,49 +2105,280 @@ TEST(LocalPRGTest, add_consensus_path_to_fastaq_nbin) {
     EXPECT_EQ(fq.scores["three"], "DDD\?\?!");
 }
 
-TEST(LocalPRGTest, get_valid_vcf_reference_real_example) {
+TEST(LocalPRGTest, get_valid_vcf_reference_real_example)
+{
     auto index = std::make_shared<Index>(Index());
 
-    LocalPRG l(3, "GC00003042", " 5  7  9 ATGTTAGTTAGTAAAAGCAACGGATTTAACGCTAGCGCA 11 G 12 T 11 TTTTGGGTAGTGGAAGTTATAATGAAAATAAATCTTCTAAACAC 10 ATGTTAATTAATAAAAGCAACGGATTTAACGCTAGCGCAGTTTGGGGTAGTGGAAGTTATAATGAAAATAAATCTTCTAAACAC 10  9 ATGGAGCTACTAGCTCATAGTATT 13 T 14 G 13 TAAAATTAATTTGTAAGGAAGCTGCATCAGAGACGTATCGCGGTGCTCTTGAAA 15 CTTTACAAAAAATGAT 16 TTTTACAAAAAATAAT 16 CTTTACAAAAAATGAC 15 GTCTGAATGTATATATCA 17 AGAAGGCAACGCC 18 TGAAGGCAACGCC 17  8  19 ATGTTAGTTAGTAAAAACAACGAATTTAACACTAGCTCATTTATAGATAGTGGAAATTGTAATGAAAGAAAATCTTCTGAATCC 20  19 ATGGAGCTACTAGCTTATAGTATTATAAATTTAATTTGTAAGAAAGCTGCCTCAGGGACGTATCGCGGTGCTCTTGAAACTTTACAAAAAATGATGTCTGAATGTATATATCATGAAGGCAACGCC 8 ATGTTAGTTAGTAAAAGCAACGAAATTAACACTAGCACATTTATAAATAGTGGAA 21 A 22 G 21 TTGTAATGAAAGAAAATCTTCTAAATCCATGGAGTTACTAGCTTATAGTATTATAAAATTAATTTGTAAAGAAGCTGCCTCAGGGACGTATAACGGTGCTCTTGAAATTTTACAAAAAATGATGTCTGAATGTAAATATCATGAAGGCAATGCT 7 TTTGTCATTATGGGAG 23  25 CT 26 TT 26 CC 25 GGAGAACAATTAAAACGTATTAAATATGA 27 AGTTGGTGAAAATAACTTAAAGGTATTCAACGT 29 A 30 G 29 CACTTTAATAATAATCACGAGTTAGTTAGTTC 28 TGCTAATGAAAATAAATTAAAAGTATACAACGTACACTTTGATAATAATCAAGAGTTAGTTGCTGA 27 TGGTGAGCCTGACGTA 31  33 ATATGTTTAAGCAAGCAGGTCTGGGAAAATCTTCTCATTAAACTAAAGCTGGAAAA 35 C 36 T 35 AATGAAAATGTGTTTTCTGAAACTAAAAAATTATCGAATAAAAATAATG 37 CCGATCAGTTTTTTGAATGCGCTAA 39 AAGAAATGAA 40 GAGAAATGAA 39  38 ACGATCAGTTTTTTGAATGCGCTAAAAGAAATGAACAGAACCTTTTGATAATA 38 CCGATCAGTTTTTT 37  34 GTATTTTTAAAAAAACGGTGTGGGAAGACCTTCTCGTTAAAC 33  32 ATATGTTTAAGCAAGCAGGTCTGGGAAAATCTTCTCATTAAACTAAAGCTGGAAAACAATGAAAATGTGTTTTCTGAAACTAAAAAATTATCGAATAAAAATAATGACGATCAGTTTTTTGAATGCGCTAAAAGAAATGAACAGAACCTTTTCGATAATATAAGAAAAAGTGATTTTCATGTTGGTTTACTTAAGCCAAGTAGTACGCGTAGTGTTATTTTAGAAACGCCGCCAAATGTCTGTATGGAATCACGTAATTCATATGAAAAAAA 41 A 42 TAGA 41  31  24 CTGGGGAACAATTAAAACGTATTAAATATGATGTTGATGAAAATAACTTAAAGGTATTCAACGTACACTTTGATAATAATGAAGTGTTAGTTACTGATGGTGAGCCTGACGTAGTATGTTTAAGCAAGCAGGTCTGGGAAAATCTTCTCATTAAATTAAAACCGGAGATCAAGGAAAATGTGGCTTCTGAAGTTCATAAATCAGCGAATAAAGGTGAGATTGAGCAATTAGTTGAATGGTCTAAAAGAAATGAACAAACCCTTTTCGATAAT 43 A 44 G 43 TAATAAAAAGTGATTTTCATGTTGGTTCACTTAAGCCAGGTAGTATGAATGGTGTTATTTTAGAAATGCCACCAAATGTCTGTATGGAACCACGTAATTCATATGAAAACAAAATAGATGAGGTTTCATCTTTGTCAGAGTCAGAGGAACACCCCATAGATATTCAAAAAATAACAGATGCGTTTGTGAAGGAGTTCAAGGGGATATTATTTGATAAAAATGGAAG 45 A 46 G 45 TCTTCAGAGCTTCTGTTTAATTTTTATGAATGTTGCTATACGTTTTTACCAAGAGCGCAGCCTCAAGATAAAATCGATAGCTATAATTCAGCACTGCAAGCTTTTTCCATCTTTTGTTCATCTACGTTGACACATAATAATGTAGGCTTTGATTTCAAATTATTTCCAGAAGTCAAGCTGTCTGGAGAACATCTTGAAACGGTATTCAAATACAAAAATGGCGATGATGTCCGGGAGATAGCCAAAATTAACATTACTCTCCAAAAAGAAGAGGGTGGCTTATATAATCTACGTGGATTGGATTTTAAGGGATGCTTCTTTTCTGGACAGAACTTCAGTAACTATGATATTCAATATGTGAACTGGGGAATGTCATTGTTTGATGTTGATACTCCGTGTATTTTTAATACGCCTGCTAACCATGAGAGTTATGAAAAATCATTAAAACCTGTAAGCGAAAACGGTTTAAATGGAGTCTTATCTGATCGTAATAAAAAAATAAAAATGATCACGGGTGTGGCACCATTCGATGATATTTTATTTATGGATGATGACTTTGATGATAACTCCCCTGAGGATGCTCCCATTGAGAATAGTCCTGTTGTGAATAGTCCTCTTGTA 24 CTGGAAAACAA 23  6  47 ATGTTAGTTAGTAAAAGCAACGAAATTAACACTAGCACATTTATAAATAGTGGAA 49 G 50 A 49 TTGTAATGAAAGAAAATC 51 T 52 C 51 TCTAAATCCATGGAGTTACTAGCTTATAGTATTATAAAATTAATTTGTAAAGAAGCTGCCTCAGGGACGTATAACGGTGCTCTTGAAATTTTACAAAAAATGATGTCTGAATGTAAA 53 T 54 C 53 ATCATGAAGGCAATGC 55 T 56 C 55 TTTGTCATTATGGGAGCCGGAGAACAATTAAAACGTATTAAATATGATGCTAATGAAAATAAATTAAAAGTATACAACGTACACTTTGATAATAATCAAGAGTTAGTTGCTGATGGTGAGCCTGACGTAGTATTTTTAAAAAAAACGGTGTGGGAAGA 57 CCTTCTCG 58 TCTTCTCA 57  48 GTGTGGGAAGACCTTCTCG 47 TTAAACTAAAGCTGGAGAACAAAGAAAATGCGGTTTCTGAAA 59 TTAACC 60 CTGACA 59 TGTCATCTAATAAAAATAATGTTGATCAGTTTATTGAATGCGCTAAGAGAAATGAACAGACCCTATTCGGCAATATAAGAAAAAGTGATTTTCA 61 T 62 C 61 GTTGCTTCACTTCAGCCAGGTAGAACGCGTAGTGTTATTTCAGAAACGCCGCCAAATGACTGTATGGAATCACATAATTTATATGAAAACCACACAGATA 63 C 64 A 63 GGTTTCAACTGTAACTAAAAATTCTCAGCAAGTTAAAGGTCACTATGG 65 A 66 G 65 GATAAGTTGAAAGAAATGCAGTT 67 G 68 T 67 TTCCTCAACCAGATGAGCAATGCACTTCAACAGGATTCATCTTTGTTAGAGTCAAAGGAACACACCATAGATATTCAAGAAAAAACGAATAAGTTTGTGCAGCATTTTCAGCGGGTATTATTTGATAAAAATGGAAGGTCATCAGAGTTTCTACTTAATTTTTATGAGTGTTGCTATAAGTTTTTACCAAGAGCGCAGCCTCAAGATAAAATCGATAGCTATAATTCAGCACTGCAAGCTTTTTCCATCTTTTGTTCATCTACGTTGA 69 C 70 T 69 ACATAATAATGTAGGGTTTAATTTCAAATTATTTCCAGAAGTCAAG 71 C 72 T 71 TGTCTGGAGGAGAGCTTGAAACGGTATTCAAATACAAAAATGG 73 T 74 C 73 AATTTTGTCTGGGAGATAGCCAGAATTAAAATT 75 A 76 G 75 CTCTCCCAAAAGAAGAGGGT 77 G 78 A 77 GTTTATATAATTTACGTGGATTGGATTTTAAGGGATGCTTCTTTTCTGGACAGAACTTCAGTAACTATGATATTCAATATGTGAACTGGGGAACGTCATTGTTTGAT 79  81 CTTGATACTCCA 82 CTTGATACTCCG 81 TGTATTTTTAATGCGCCTGCTTACAACAAGAGTAATGAAAAATCATTA 83 G 84 A 83 AACGCGTCAGCGAAAACGGTTTAAGTGGAGTCTTGTCTGATCGTAATAA 85 A 86 T 85  80 GTTGATACTCCGTGTATTTTTAATGTGCCTGATGACAATAAGAGTTATGATAAATTATTAAAATCCGTCAGCGAAAATGGTTTAAATGGAGTCTTGACTGATCGTAATAAT 79 AAAATAAAACTAATCACGGG 87 T 88 C 87 GTGGCACCATTCGATG 89 ATATTTTATT 90 GTATTTCATC 89 TATGGATGATGACTTTGATGATA 91  93 ACTCCCCTGATGATGG 94 GTTCTTCTGAGGATGA 93 TCCCGTTGAGAATAGTCCTGTTGTGAATAGTCCCCTTGTA 92 GTTCCTCTGAGGAAAATTCCCCTGAGGATAGTCCCATTGAGAATCGTCCCCTTGTA 91  6  95  97 ATGGAATCACGTAATTCATATGAAAACAAAATAGATGAGATTTCATCTTTGTCAGAGTCAAAGGAACACCCCATAGATATTCAAGAAAAAAAAGATG 99 CGTTT 100 TGTTT 99  98  98 ATGGAATCACGTAATTCATATGAAAACAAAATAGATGAGATTTCATCTTTGTCAGAGTTAAAGGAACACCCCATAGATATTCAAGAAAAAAAAGATGCGTTT 98 ATGGAATCACGTAATTCATATAAAAACAAAATAGATGAGATTTCATCTTTGTCAGAGTCAAAGGAACACCCCATAGATATTCAAGAAAAAAAAGATGCGTTT 97 GTGAATGAGTTCAAGGGGGTATTATTTGATAA 101 AAATAC 102 GAATAC 102 AAATAT 101  96  103 ATGTTAGTTAGTAAAAACAACGAATTTAACACTAGCTCATTTATAGATAGTGGAAATTGTAATGAAAGAAAATCTTCTGAATCCATGGAGCTACTAGCTTATAGTATTATAAATTTAATTTGTAAGAAAGCTGCCTCAGGGACGTATCGCGGTGCTCTTGAAACTTTACAAAAAATG 104  103 ATGTCTGAATGTATATATCA 105 T 106 A 105 GAAGGCAACGCCTTTGTCATTATGGGAG 107 T 108 C 107 TGGAGAACAATTAAAACGTATTAAATATGAAGTTGGTGAAAATAACTTAAAGGTATTCAACGTACACTTTAATAATAATCACGAGTTAGTTAGTTCTGGTGAGCCTGACGTAATATGTTTAAGCAAGCAGGTCTGGGAAAATCTTCTCATTAAACTAAAGCTGGAAAACAATGAAAATGTGTTTTCTGAAACTAAAAAATTATCGAATAAAAATAATG 109 A 110 C 109 CGATCAGTTTTTTGAATGCGCTAAAAGAAATGAACAGAACCTTTTCGATAATATAAGAAAAAGTGATTTTCATGTTGGTTTACTTAAGCCAAGTAGTACGCGTAGTGTTATTTTAGAAACGCCGCCAAATGTCTGTATGGAATCACGTAATTCATATGAAAACAAAATAGATGAGATTTCATCTTTGTCAGAGTCAAAGGAACACCCCATAGATATTCAAGAAAAAAAAGATGCGTTTGTGAATGAGTTCAAGGGGGTATTATTTGATAAAAATAC 96 ATGTTAGTTAGTAAAAGCAACGAAATTAACACTAGCACATTTATAAATAGTGGAAGTTGTAATGAAAGAAAATCTTCTAAATCCATGGAGTTACTAGCTTATAGTATTATAAAATTAATTTGTAAGGAAGCTGCCTCAGGGACGTATAACGGTGCTCTTGAAATTTTACAAAAAATGATGTCTGAATGTAAATATCATGAAAGCAATGCTTTTGTCATTATGGGAGCCGGAGAACAATTAAAACGTATTAAATATGATGTTAATGAAGATAAATTAAAAGTATACAACGTACACTTTGATAATAATCAAGAGTTAGTTGCTGATGGTGAGCCTGACGTAGTATTTTTAAAAAAAACGGTGTGGGAAGACCTTCTCGTTAAACTAAAGCTGGAGAACAAAGAAAATGCGGTTTCTGAAGTTCATAAATCAGCGAATAAAGGTGAGGTCGAGCAATTAGTTGAATGTTCTGAAAGAAATGAAAAGAGGCTTCTTGATAATATAAATAAAAACACTACTATCTATAATATTTACAACAACCAACGAGCAACAAACATTACTACATCTGTATCTGAACCACCTGCACAAGGTAAAAGTAATGATGTAGATAAATTAAAACAAACGCAGTTTATCAACGCTAGTCAATTTGATATTAATGAGCTTCAGCAGAGTTCTGCTTTTTTAGCGTCAAAATATCACACCATAGATATTCAAGAAAAAACAGATGCGTTTGTGAAGAAGTTCAAGGGGATATTATTTGATAAAAATGG 95 AAGGTCTTCAGAGCTTCT 111 G 112 T 111 TTTAATTTTTATGAGTGTTGCTATAAGTTTTTACCAAGAGC 113  115 T 116 G 115 CAGCCTCAAGATAAAAT 117 CGAT 118 TGAA 117  114 TCAGCCACAAGATAAAATCGAT 113 AGCTATAATTCAGCACTGCAAGCTTTTTCCAT 119 TTTTTGTTCATCTACGTTGACACATAATAATATAGGCTTTGATTTCAAATTATTTCCT 120 CTTTCGTTCATCTACTTTGAATAATAATGATGTAGGGTTTAATTTCAAATTATTCCCA 119 GAAGTCAAGCTGTCTGGA 121 G 122 A 121 AACATCTTGAAACGGTATTCAAATACAAAAATGGCGATGATGTCCGGGAGATAGCCAAAATTAACATTACTCTCCAAAAAGAAGAGGGTGGTTTATATAATTTACGTGGATTGGATTTTAAGGG 123 GT 124 AT 124 GG 123 GCTTCTTTTCTGGACAGAACTTCAGTA 125 A 126 T 125 CTATGATATTCAATATGTGAACTGGGGAACGTCATTGTTTGAT 127 GTTGATAC 128 CTTGATAC 128 GTTGATAT 127 TCCGTGTATTTTTAATGCGCCTGCTTACAACAAGAGTAATGAAAAATCATTA 129 AAACCTGTG 130 GAACGCGTC 129 AGCGAAAACGGTTTAAGTGGAGT 131 ATTGA 132 CTTGT 132 CTTGA 131 CTGATCGTAATAATAAAATAAAACTCATCACGGGCGTGGCACCATTCGATGATATTTTATTTATGGATGATGACTTTGATGATAGTTC 133 CTCTGAGGATG 134 CTCTGAGGATA 134 TTCTGAGGATG 133 ATCCCGTTGAGAATAGTCCTGTTGTGACTAGTCCC 135 G 136 C 135 TTGTATCAAGTTCTAAAAGCAGTTTTCAA 6  137  139  140 ATGTTAGTTAGTAAAAGCAACGAACTTAACACTAGCGCATTTTTTGCTAGCAGGAATTATAATGGAAACAATTCTTCCAACCCCATGGAGCTACTAGCTCATAGCATTATAAAATTAATTTGTAAGGAAGCTGCCTCAGCGACGTATTGCGGTGCTCTTGAAACTTTACAAAAAATGATGTCTGAATGTATATATCAAGAAGGCAACGCCTTTGTCATTATGGGAGCTGGAGAACAATTAAAACGTATTAAATATGATGTTGATGAAAATAACTTAAAGGTATTCAACGTACACTTTGATAATAATGAAGTGTTAGTTACTGATGGTGAGCCTGACGTAGTATGTTTAAGCAAGCAGGTCTGGGAAAATCTTCTCATTAAATTAAAACCGGAGATTAAAGAAAATGTGTTTTCTGAAAATAACAAATTATCGAGAGAAAATAATGTTGATCAGTATGTTCAATCCGCTAAAAGAAATGAACAGGCCCTTTTCGATAATATAATAAAAAGTGATTTTCATGTTGCTTCACTTCAGCCAGGTAGAACACGTAGTGTTATTTCAGAAACGCCGCCAAATGACTGTATGGAAGCACGTAATTCATATGAAAACCAAATAGATGAGATTTCATCT 139 TTGTCAGAGTCAAAGGAACACCCCATAGATATTCAAGAAAAAA 141 A 142 C 141 AGATGCGTTTGTGAATGAGTTCA 143 A 144 G 143  138 ATGTTAGTTAGTAAAAG 145 C 146 A 145 AACGGATTTAACGCTAGCGCAGTTTTGGGTAGTGGAAGTTATAATGAAAATAAATCTTCTAAACACATGGAGCTACTAGCTCATAGTATTTTAAAATTAATTTGTAAG 147 G 148 A 147 AAGCTGCATCAGAGACGTATCGCGGTGCTCTTGAAACTTTACAAAAAATGATGTCTGAATGT 149 A 150 G 149 TATATCAAGAAGGCAACGCCTTTGTCATTATGGGAGCTGGAGAACAATTAAAACGTATTAAATATGAAGTTGGTGAAAATAACTTAAAGGTATTCAACGTACACTTTAATAATAATCACGAGTTAGTTAGTTCTGGTGAGCCTGACGTAATATGTTTAAGCAAGCAGGTCTGGGAAAATCTTCTCATTAAACTAAAGCTGGAAAACAATGAAAATGTGTTTTCTGAAACTAAAAAA 151 T 152 C 151 TATCGAATAAAAATAATGCCGATCAGTTTTTTGAATGCGCTAA 153 GAGAAATGAACAGACCCTA 154 AAGAAATGAACAGAACCTT 153 TTCGATAATATAAGAAAAAGTGATTTTCATGTTGGTT 155 CACTTAAGCCAG 156 TACTTAAGCCAA 155 GTAGTACGCGTAGTGTTATTTTAGAAACGCCGCCAAATGTCTGTATGGAATCACGTAATTCATATGAAAACAAAATAGATGAGATTTCATCTTTGTCAGAGTCAAAGGAACACCCCATAGATATTCAAGAAAAAA 157 CAGATGCATTTGTGAAGAAGTTCAA 158 AAGATGCGTTTGTGAATGAGTTCAA 157  138 GTGAATGAGTTCAA 138 ATGTTAGTTAGTAAAAGCAACGGATTTAACGCTAGCGCAGTTTTGGGTAGTGGAAGTTATAATGAAAATAAATCTTCTAAACACATGGAGCTACTAGCTCATAGTATTGTAAAATTAATTTGTAAGGAAGCTGCATCAGAGACGTATCGCGGTGCTCTTGAAATTTTACAAAAAATAATGTCTGAATGTATATATCATGAAGGCAACGCCTTTGTCATTATGGGAGCTGGAGAACAATTAAAACGTATTAAATATGATGTTGATGAAAATAACTTAAAGGTATTCAACGTACACTTTGATAATAATGAAGTGTTAGTTACTGATGGTGAGCCTGACGTAGTATGTTTAAGCAAGCAGGTCTGGGAAAATCTTCTCATTAAATTAAAACCGGAGATCAAGGAAAATGCGGCTTCTGAAGTTCATAAATCAGCGAATAAAGGTGAGATTGAGCAATTAGTTGAATGCTCTAAAAGAAATGAACAGACCCTTTTCGATAATATAAGAAAAAGTGATTTTCATGTTGGTTCACTTAAGCCAGGTAGTATGAATAGTGTTATTTTAGAAATGCCACCAAATGTCTGTATGGAACCACGTAATCCATATGAAAACAAAATAGATGAGGTTTCATCTTTGTCAGAGCCAAAGGAACACACCATAGATATTCAAGAAAAAACAGATGCGTTTGTGAATGAGTTCAA 137 GGGGATATTATTTGAT 159 AAAAATGG 160 AAAAATAC 160 CAAAATGG 160 AAAAATAG 159 AAGGTCTTCAGAGTTTCT 161  163 AC 164 GT 163 TTAATTTTTATGAATGTTGCTAT 165 GA 166 GT 166 AA 165  162 ATTTAATTTTTATGAGTGTTGCTATAA 161 GTTTTTACCAAGAGC 167 GCAGCCTCAGGATAAAAT 169 CGAA 170 TGAA 169  168 TCAGCCTCAAGATAAAATCGAT 167 AGCTATAATTCAGCACTGCAAGCTTT 171 CTCCATC 172 TTCCATT 172 TTCCATC 171 TTTTGTTCATCTACGTTGA 173  175 T 176 C 175 ACATAATAATATAGGCTTTG 174 CACATAATGGTGTAGGGTTTA 173 ATTTCAAATTATTTCC 177 AGAAGTCAAACTGTGTGGGG 179 AAA 180 GAA 180 AAC 179  178  181 AGAAGTCAAGCTGTCTGGAGAAC 182 TGAAGTCAAACTGTCTGGAGAAC 181  177 ATCTTGAAACGGTATTCAAATA 183 T 184 C 183 AAAAATGGCGATGATGTCCGGGAGATAGCCAAAATTAACATT 185  187 A 188 G 187 CTCTCCAAAAAGAAGAGGATGGTTTATATAATTTAG 186 ATCCTACCAAAAGGAGAGGGTGATTTATATAATTTGG 186 ACTCTCCAAAAAGAAGA 189 GGGTGGATTATATAATCTAC 190  191 A 192 G 191 GGTGGTTTATATAATTTAC 189  185 GTGGATTGGATTTTAAGGG 193 A 194 G 193 TGCTTCTTTTCTGGACAGAACTTCAGTAACTATGATATTCAATATGTGAACTGGGG 195 A 196 T 195 ACGTCATTGTTTGAT 197  199 CTTGATACTCCG 200 GTTGATACTCCG 200 CTTGATACTCCA 199 TGTATTTTTAATGCGCCTGCTTACAACAAGAGTAATG 201  203 A 204 G 203 AAAATCATTAAAACCTGTG 202 AAAAATCATTAGAACGCGTC 201  198 GTTGATACTCCGTGTATTTTTAATACGCCTGCTAACCATGAGAGTTATGAAAAATCATTAAAACCTGTA 197 AGCGAAAACGGTTTAA 205  207 GTGGAGTC 208 GTGGAGTA 207 TTGACTGATCGTAATAATAAAATAAAACTCATCACGGGC 206  209 ATGGAGTCTTA 210 GTGGAGTCTTG 209 TCTGATCGTAATAAAAAAATAAAA 211 ATGATCACGGGT 212 CTAATCACGGGT 211  205 GTGGCACCATTCGATGATATTTTATTTATGGATGATGACTTTGATGATA 213 GTTCCTCTGAGGATGATCCCG 214 ACTCCCCTGAGGATG 215 CTCCCA 216 GTCCCG 215  213 TTGAGAATAGTCCTGTTGTGA 217 CTAGTCCCGTTGTATCAAGTTCTAAAAGCAGTTTTCAA 218 ATAGTCCCCTTGTA 217  6 ATGTTAGTTAGTAAAAG 219 TAATGGCCATAACGTTAATACAGTTTTGGGTAGTAGAAGTTGTAATGAAAACAATTCTTCCAACCCCATGGG 220 CAACGGATTTAACGCTAGCGCAGTTTTGGGTAGTGGAAGTTATAATGAAAATAAATCTTCTAAACACATGGA 219 GCTACTAGCTCATAGTATT 221 G 222 T 221 TAAAATTAATTTGTAAGGAAGCTGCATCAGAGACGTATCGCGGTGCTCTTGAAACTTTACAAAAAATGATGTCTGAATGTATATATCA 223 T 224 A 223 GAAGGCAACGCCTTTGTCATTATGGGA 225 TCTGGAGTG 226 GCTGGAGAA 226 TCTGGAGAG 225 CAATTAAAACGTATTAAATATGATGTTGATGAAAATAACTTAAAAGTATTCAACGTATACTTTGATAATAATGAAGAGTTAGTTACTGATGGTGAGCCTGACGTAGTATGTTTAAGCAAGCAGGTCTGGGAAGATCTTCTCATTAAACTAAAGCTGGAGAACAAAGAAAATGCGGTTTCTGAAACTGACCTGTCATCGAATGAAAATAATGTTGATCATTTTTTTCAATCCGCTAAGAGAGATGAACAGACCCTATTCGGCAATATAAGAAAAAGTGAGTTTCATGTTGATTCATTAAAGCCAGGTAGTACGCGTAGTGTTATTTTAGAAACGCAACCAAATGTCTCTATGGAACCACATAATTTATATGACAACCAAATAGATAAGGTTTCACCTGTAACTAAAAACTCTCAGCAAGTTAAAGGCCACTATGGAGATAAATTGAAAGAAATGCAGATGTTCCTTAACCAGATGAGCAATGCACTTCAACAGGCTCCATCTTTGTCAGAGTCAAAGGAACACACCATAGATATTCAAAAAATAACGGATGCCTTTGTGAAGGAGTTCCGGGGGATATTATTTGATAAAAATGGAAATTCATCAGAACGTTTATTCAATTTTTATGAGTGCTGCTATATATTTTTACCAAGAGCGCAGCCTCAAGATAAAATCGAAAGCTATAATTCAGCGCTGCAAGCTTTTTCCATCTTCCGTTCATCTACTTTGAATAATAATGATGTAGGGTTTAATTTCAAATTATTCCCAGAAGTCAAGCTGTCTGGTGAAAATCTTGAAACGGTATTCAAATACAAAAAAGGAAGTTTTGTCCGGGAGATAGCCAGAATTAACATTACTCTCCAAAAAGAAGAGGATGGTTTATATAATTTAGGTGGATTGGATTTTAAGGGATGCTTCTTTTCTGGACAGAACTTCAGTAACTATGATATTCAATATGTGAACTGGGGAACGTCATTGTTTGATCTTGATACTCCGTGTATTTTTAATGCGCCTGCTTACAACAAGAGTAATGAAAAATCATTAAAACCTGTGAGCGAAAACGGTTTAAGTGGAGTCTTGACTGATCGTAATAATAAAATAAAACTCATCACGGGCGTGGCACCATTCGATGATATTTTATTTATGGATGATGACTTTGATGATAGTTCCTCTGAGGATGATCCCGTTGAGAATAGTCCTGTTGTGACTAGTCCCGTTGTATCAAGTTCTAAAAGCAGTTTTCAA 5 ");
-    string bad = "ATGTTAGTTAGTAAAAGCAACGGATTTAACGCTAGCGCAGTTTTGGGTAGTGGAAGTTATAATGAAAATAAATCTTCTAAACACATGGAGCTACTAGCTCATAGTATTTTAAAATTAATTTGTAAGGAAGCTGCATCAGAGACGTATCGCGGTGCTCTTGAAACTTTACAAAAAATGATGTCTGAATGTATATATCAAGAAGGCAACGCCTTTGTCATTATGGGAGCTGGAGAACAATTAAAACGTATTAAATATGAAGTTGGTGAAAATAACTTAAAGGTATTCAACGTACACTTTAATAATAATCACGAGTTAGTTAGTTCTGGTGAGCCTGACGTAATATGTTTAAGCAAGCAGGTCTGGGAAAATCTTCTCATTAAACTAAAGCTGGAAAACAATGAAAATGTGTTTTCTGAAACTAAAAAATTATCGAATAAAAATAATGCCGATCAGTTTTTTGAATGCGCTAAAAGAAATGAA";
+    LocalPRG l(3, "GC00003042",
+        " 5  7  9 ATGTTAGTTAGTAAAAGCAACGGATTTAACGCTAGCGCA 11 G 12 T 11 "
+        "TTTTGGGTAGTGGAAGTTATAATGAAAATAAATCTTCTAAACAC 10 "
+        "ATGTTAATTAATAAAAGCAACGGATTTAACGCTAGCGCAGTTTGGGGTAGTGGAAGTTATAATGAAAATAAATCTTCT"
+        "AAACAC 10  9 ATGGAGCTACTAGCTCATAGTATT 13 T 14 G 13 "
+        "TAAAATTAATTTGTAAGGAAGCTGCATCAGAGACGTATCGCGGTGCTCTTGAAA 15 CTTTACAAAAAATGAT 16 "
+        "TTTTACAAAAAATAAT 16 CTTTACAAAAAATGAC 15 GTCTGAATGTATATATCA 17 AGAAGGCAACGCC "
+        "18 TGAAGGCAACGCC 17  8  19 "
+        "ATGTTAGTTAGTAAAAACAACGAATTTAACACTAGCTCATTTATAGATAGTGGAAATTGTAATGAAAGAAAATCTTCT"
+        "GAATCC 20  19 "
+        "ATGGAGCTACTAGCTTATAGTATTATAAATTTAATTTGTAAGAAAGCTGCCTCAGGGACGTATCGCGGTGCTCTTGAA"
+        "ACTTTACAAAAAATGATGTCTGAATGTATATATCATGAAGGCAACGCC 8 "
+        "ATGTTAGTTAGTAAAAGCAACGAAATTAACACTAGCACATTTATAAATAGTGGAA 21 A 22 G 21 "
+        "TTGTAATGAAAGAAAATCTTCTAAATCCATGGAGTTACTAGCTTATAGTATTATAAAATTAATTTGTAAAGAAGCTGC"
+        "CTCAGGGACGTATAACGGTGCTCTTGAAATTTTACAAAAAATGATGTCTGAATGTAAATATCATGAAGGCAATGCT "
+        "7 TTTGTCATTATGGGAG 23  25 CT 26 TT 26 CC 25 GGAGAACAATTAAAACGTATTAAATATGA 27 "
+        "AGTTGGTGAAAATAACTTAAAGGTATTCAACGT 29 A 30 G 29 "
+        "CACTTTAATAATAATCACGAGTTAGTTAGTTC 28 "
+        "TGCTAATGAAAATAAATTAAAAGTATACAACGTACACTTTGATAATAATCAAGAGTTAGTTGCTGA 27 "
+        "TGGTGAGCCTGACGTA 31  33 "
+        "ATATGTTTAAGCAAGCAGGTCTGGGAAAATCTTCTCATTAAACTAAAGCTGGAAAA 35 C 36 T 35 "
+        "AATGAAAATGTGTTTTCTGAAACTAAAAAATTATCGAATAAAAATAATG 37 "
+        "CCGATCAGTTTTTTGAATGCGCTAA 39 AAGAAATGAA 40 GAGAAATGAA 39  38 "
+        "ACGATCAGTTTTTTGAATGCGCTAAAAGAAATGAACAGAACCTTTTGATAATA 38 CCGATCAGTTTTTT 37  "
+        "34 GTATTTTTAAAAAAACGGTGTGGGAAGACCTTCTCGTTAAAC 33  32 "
+        "ATATGTTTAAGCAAGCAGGTCTGGGAAAATCTTCTCATTAAACTAAAGCTGGAAAACAATGAAAATGTGTTTTCTGAA"
+        "ACTAAAAAATTATCGAATAAAAATAATGACGATCAGTTTTTTGAATGCGCTAAAAGAAATGAACAGAACCTTTTCGAT"
+        "AATATAAGAAAAAGTGATTTTCATGTTGGTTTACTTAAGCCAAGTAGTACGCGTAGTGTTATTTTAGAAACGCCGCCA"
+        "AATGTCTGTATGGAATCACGTAATTCATATGAAAAAAA 41 A 42 TAGA 41  31  24 "
+        "CTGGGGAACAATTAAAACGTATTAAATATGATGTTGATGAAAATAACTTAAAGGTATTCAACGTACACTTTGATAATA"
+        "ATGAAGTGTTAGTTACTGATGGTGAGCCTGACGTAGTATGTTTAAGCAAGCAGGTCTGGGAAAATCTTCTCATTAAAT"
+        "TAAAACCGGAGATCAAGGAAAATGTGGCTTCTGAAGTTCATAAATCAGCGAATAAAGGTGAGATTGAGCAATTAGTTG"
+        "AATGGTCTAAAAGAAATGAACAAACCCTTTTCGATAAT 43 A 44 G 43 "
+        "TAATAAAAAGTGATTTTCATGTTGGTTCACTTAAGCCAGGTAGTATGAATGGTGTTATTTTAGAAATGCCACCAAATG"
+        "TCTGTATGGAACCACGTAATTCATATGAAAACAAAATAGATGAGGTTTCATCTTTGTCAGAGTCAGAGGAACACCCCA"
+        "TAGATATTCAAAAAATAACAGATGCGTTTGTGAAGGAGTTCAAGGGGATATTATTTGATAAAAATGGAAG 45 A "
+        "46 G 45 "
+        "TCTTCAGAGCTTCTGTTTAATTTTTATGAATGTTGCTATACGTTTTTACCAAGAGCGCAGCCTCAAGATAAAATCGAT"
+        "AGCTATAATTCAGCACTGCAAGCTTTTTCCATCTTTTGTTCATCTACGTTGACACATAATAATGTAGGCTTTGATTTC"
+        "AAATTATTTCCAGAAGTCAAGCTGTCTGGAGAACATCTTGAAACGGTATTCAAATACAAAAATGGCGATGATGTCCGG"
+        "GAGATAGCCAAAATTAACATTACTCTCCAAAAAGAAGAGGGTGGCTTATATAATCTACGTGGATTGGATTTTAAGGGA"
+        "TGCTTCTTTTCTGGACAGAACTTCAGTAACTATGATATTCAATATGTGAACTGGGGAATGTCATTGTTTGATGTTGAT"
+        "ACTCCGTGTATTTTTAATACGCCTGCTAACCATGAGAGTTATGAAAAATCATTAAAACCTGTAAGCGAAAACGGTTTA"
+        "AATGGAGTCTTATCTGATCGTAATAAAAAAATAAAAATGATCACGGGTGTGGCACCATTCGATGATATTTTATTTATG"
+        "GATGATGACTTTGATGATAACTCCCCTGAGGATGCTCCCATTGAGAATAGTCCTGTTGTGAATAGTCCTCTTGTA "
+        "24 CTGGAAAACAA 23  6  47 "
+        "ATGTTAGTTAGTAAAAGCAACGAAATTAACACTAGCACATTTATAAATAGTGGAA 49 G 50 A 49 "
+        "TTGTAATGAAAGAAAATC 51 T 52 C 51 "
+        "TCTAAATCCATGGAGTTACTAGCTTATAGTATTATAAAATTAATTTGTAAAGAAGCTGCCTCAGGGACGTATAACGGT"
+        "GCTCTTGAAATTTTACAAAAAATGATGTCTGAATGTAAA 53 T 54 C 53 ATCATGAAGGCAATGC 55 T 56 "
+        "C 55 "
+        "TTTGTCATTATGGGAGCCGGAGAACAATTAAAACGTATTAAATATGATGCTAATGAAAATAAATTAAAAGTATACAAC"
+        "GTACACTTTGATAATAATCAAGAGTTAGTTGCTGATGGTGAGCCTGACGTAGTATTTTTAAAAAAAACGGTGTGGGAA"
+        "GA 57 CCTTCTCG 58 TCTTCTCA 57  48 GTGTGGGAAGACCTTCTCG 47 "
+        "TTAAACTAAAGCTGGAGAACAAAGAAAATGCGGTTTCTGAAA 59 TTAACC 60 CTGACA 59 "
+        "TGTCATCTAATAAAAATAATGTTGATCAGTTTATTGAATGCGCTAAGAGAAATGAACAGACCCTATTCGGCAATATAA"
+        "GAAAAAGTGATTTTCA 61 T 62 C 61 "
+        "GTTGCTTCACTTCAGCCAGGTAGAACGCGTAGTGTTATTTCAGAAACGCCGCCAAATGACTGTATGGAATCACATAAT"
+        "TTATATGAAAACCACACAGATA 63 C 64 A 63 "
+        "GGTTTCAACTGTAACTAAAAATTCTCAGCAAGTTAAAGGTCACTATGG 65 A 66 G 65 "
+        "GATAAGTTGAAAGAAATGCAGTT 67 G 68 T 67 "
+        "TTCCTCAACCAGATGAGCAATGCACTTCAACAGGATTCATCTTTGTTAGAGTCAAAGGAACACACCATAGATATTCAA"
+        "GAAAAAACGAATAAGTTTGTGCAGCATTTTCAGCGGGTATTATTTGATAAAAATGGAAGGTCATCAGAGTTTCTACTT"
+        "AATTTTTATGAGTGTTGCTATAAGTTTTTACCAAGAGCGCAGCCTCAAGATAAAATCGATAGCTATAATTCAGCACTG"
+        "CAAGCTTTTTCCATCTTTTGTTCATCTACGTTGA 69 C 70 T 69 "
+        "ACATAATAATGTAGGGTTTAATTTCAAATTATTTCCAGAAGTCAAG 71 C 72 T 71 "
+        "TGTCTGGAGGAGAGCTTGAAACGGTATTCAAATACAAAAATGG 73 T 74 C 73 "
+        "AATTTTGTCTGGGAGATAGCCAGAATTAAAATT 75 A 76 G 75 CTCTCCCAAAAGAAGAGGGT 77 G 78 A "
+        "77 "
+        "GTTTATATAATTTACGTGGATTGGATTTTAAGGGATGCTTCTTTTCTGGACAGAACTTCAGTAACTATGATATTCAAT"
+        "ATGTGAACTGGGGAACGTCATTGTTTGAT 79  81 CTTGATACTCCA 82 CTTGATACTCCG 81 "
+        "TGTATTTTTAATGCGCCTGCTTACAACAAGAGTAATGAAAAATCATTA 83 G 84 A 83 "
+        "AACGCGTCAGCGAAAACGGTTTAAGTGGAGTCTTGTCTGATCGTAATAA 85 A 86 T 85  80 "
+        "GTTGATACTCCGTGTATTTTTAATGTGCCTGATGACAATAAGAGTTATGATAAATTATTAAAATCCGTCAGCGAAAAT"
+        "GGTTTAAATGGAGTCTTGACTGATCGTAATAAT 79 AAAATAAAACTAATCACGGG 87 T 88 C 87 "
+        "GTGGCACCATTCGATG 89 ATATTTTATT 90 GTATTTCATC 89 TATGGATGATGACTTTGATGATA 91  "
+        "93 ACTCCCCTGATGATGG 94 GTTCTTCTGAGGATGA 93 "
+        "TCCCGTTGAGAATAGTCCTGTTGTGAATAGTCCCCTTGTA 92 "
+        "GTTCCTCTGAGGAAAATTCCCCTGAGGATAGTCCCATTGAGAATCGTCCCCTTGTA 91  6  95  97 "
+        "ATGGAATCACGTAATTCATATGAAAACAAAATAGATGAGATTTCATCTTTGTCAGAGTCAAAGGAACACCCCATAGAT"
+        "ATTCAAGAAAAAAAAGATG 99 CGTTT 100 TGTTT 99  98  98 "
+        "ATGGAATCACGTAATTCATATGAAAACAAAATAGATGAGATTTCATCTTTGTCAGAGTTAAAGGAACACCCCATAGAT"
+        "ATTCAAGAAAAAAAAGATGCGTTT 98 "
+        "ATGGAATCACGTAATTCATATAAAAACAAAATAGATGAGATTTCATCTTTGTCAGAGTCAAAGGAACACCCCATAGAT"
+        "ATTCAAGAAAAAAAAGATGCGTTT 97 GTGAATGAGTTCAAGGGGGTATTATTTGATAA 101 AAATAC 102 "
+        "GAATAC 102 AAATAT 101  96  103 "
+        "ATGTTAGTTAGTAAAAACAACGAATTTAACACTAGCTCATTTATAGATAGTGGAAATTGTAATGAAAGAAAATCTTCT"
+        "GAATCCATGGAGCTACTAGCTTATAGTATTATAAATTTAATTTGTAAGAAAGCTGCCTCAGGGACGTATCGCGGTGCT"
+        "CTTGAAACTTTACAAAAAATG 104  103 ATGTCTGAATGTATATATCA 105 T 106 A 105 "
+        "GAAGGCAACGCCTTTGTCATTATGGGAG 107 T 108 C 107 "
+        "TGGAGAACAATTAAAACGTATTAAATATGAAGTTGGTGAAAATAACTTAAAGGTATTCAACGTACACTTTAATAATAA"
+        "TCACGAGTTAGTTAGTTCTGGTGAGCCTGACGTAATATGTTTAAGCAAGCAGGTCTGGGAAAATCTTCTCATTAAACT"
+        "AAAGCTGGAAAACAATGAAAATGTGTTTTCTGAAACTAAAAAATTATCGAATAAAAATAATG 109 A 110 C "
+        "109 "
+        "CGATCAGTTTTTTGAATGCGCTAAAAGAAATGAACAGAACCTTTTCGATAATATAAGAAAAAGTGATTTTCATGTTGG"
+        "TTTACTTAAGCCAAGTAGTACGCGTAGTGTTATTTTAGAAACGCCGCCAAATGTCTGTATGGAATCACGTAATTCATA"
+        "TGAAAACAAAATAGATGAGATTTCATCTTTGTCAGAGTCAAAGGAACACCCCATAGATATTCAAGAAAAAAAAGATGC"
+        "GTTTGTGAATGAGTTCAAGGGGGTATTATTTGATAAAAATAC 96 "
+        "ATGTTAGTTAGTAAAAGCAACGAAATTAACACTAGCACATTTATAAATAGTGGAAGTTGTAATGAAAGAAAATCTTCT"
+        "AAATCCATGGAGTTACTAGCTTATAGTATTATAAAATTAATTTGTAAGGAAGCTGCCTCAGGGACGTATAACGGTGCT"
+        "CTTGAAATTTTACAAAAAATGATGTCTGAATGTAAATATCATGAAAGCAATGCTTTTGTCATTATGGGAGCCGGAGAA"
+        "CAATTAAAACGTATTAAATATGATGTTAATGAAGATAAATTAAAAGTATACAACGTACACTTTGATAATAATCAAGAG"
+        "TTAGTTGCTGATGGTGAGCCTGACGTAGTATTTTTAAAAAAAACGGTGTGGGAAGACCTTCTCGTTAAACTAAAGCTG"
+        "GAGAACAAAGAAAATGCGGTTTCTGAAGTTCATAAATCAGCGAATAAAGGTGAGGTCGAGCAATTAGTTGAATGTTCT"
+        "GAAAGAAATGAAAAGAGGCTTCTTGATAATATAAATAAAAACACTACTATCTATAATATTTACAACAACCAACGAGCA"
+        "ACAAACATTACTACATCTGTATCTGAACCACCTGCACAAGGTAAAAGTAATGATGTAGATAAATTAAAACAAACGCAG"
+        "TTTATCAACGCTAGTCAATTTGATATTAATGAGCTTCAGCAGAGTTCTGCTTTTTTAGCGTCAAAATATCACACCATA"
+        "GATATTCAAGAAAAAACAGATGCGTTTGTGAAGAAGTTCAAGGGGATATTATTTGATAAAAATGG 95 "
+        "AAGGTCTTCAGAGCTTCT 111 G 112 T 111 TTTAATTTTTATGAGTGTTGCTATAAGTTTTTACCAAGAGC "
+        "113  115 T 116 G 115 CAGCCTCAAGATAAAAT 117 CGAT 118 TGAA 117  114 "
+        "TCAGCCACAAGATAAAATCGAT 113 AGCTATAATTCAGCACTGCAAGCTTTTTCCAT 119 "
+        "TTTTTGTTCATCTACGTTGACACATAATAATATAGGCTTTGATTTCAAATTATTTCCT 120 "
+        "CTTTCGTTCATCTACTTTGAATAATAATGATGTAGGGTTTAATTTCAAATTATTCCCA 119 "
+        "GAAGTCAAGCTGTCTGGA 121 G 122 A 121 "
+        "AACATCTTGAAACGGTATTCAAATACAAAAATGGCGATGATGTCCGGGAGATAGCCAAAATTAACATTACTCTCCAAA"
+        "AAGAAGAGGGTGGTTTATATAATTTACGTGGATTGGATTTTAAGGG 123 GT 124 AT 124 GG 123 "
+        "GCTTCTTTTCTGGACAGAACTTCAGTA 125 A 126 T 125 "
+        "CTATGATATTCAATATGTGAACTGGGGAACGTCATTGTTTGAT 127 GTTGATAC 128 CTTGATAC 128 "
+        "GTTGATAT 127 TCCGTGTATTTTTAATGCGCCTGCTTACAACAAGAGTAATGAAAAATCATTA 129 "
+        "AAACCTGTG 130 GAACGCGTC 129 AGCGAAAACGGTTTAAGTGGAGT 131 ATTGA 132 CTTGT 132 "
+        "CTTGA 131 "
+        "CTGATCGTAATAATAAAATAAAACTCATCACGGGCGTGGCACCATTCGATGATATTTTATTTATGGATGATGACTTTG"
+        "ATGATAGTTC 133 CTCTGAGGATG 134 CTCTGAGGATA 134 TTCTGAGGATG 133 "
+        "ATCCCGTTGAGAATAGTCCTGTTGTGACTAGTCCC 135 G 136 C 135 "
+        "TTGTATCAAGTTCTAAAAGCAGTTTTCAA 6  137  139  140 "
+        "ATGTTAGTTAGTAAAAGCAACGAACTTAACACTAGCGCATTTTTTGCTAGCAGGAATTATAATGGAAACAATTCTTCC"
+        "AACCCCATGGAGCTACTAGCTCATAGCATTATAAAATTAATTTGTAAGGAAGCTGCCTCAGCGACGTATTGCGGTGCT"
+        "CTTGAAACTTTACAAAAAATGATGTCTGAATGTATATATCAAGAAGGCAACGCCTTTGTCATTATGGGAGCTGGAGAA"
+        "CAATTAAAACGTATTAAATATGATGTTGATGAAAATAACTTAAAGGTATTCAACGTACACTTTGATAATAATGAAGTG"
+        "TTAGTTACTGATGGTGAGCCTGACGTAGTATGTTTAAGCAAGCAGGTCTGGGAAAATCTTCTCATTAAATTAAAACCG"
+        "GAGATTAAAGAAAATGTGTTTTCTGAAAATAACAAATTATCGAGAGAAAATAATGTTGATCAGTATGTTCAATCCGCT"
+        "AAAAGAAATGAACAGGCCCTTTTCGATAATATAATAAAAAGTGATTTTCATGTTGCTTCACTTCAGCCAGGTAGAACA"
+        "CGTAGTGTTATTTCAGAAACGCCGCCAAATGACTGTATGGAAGCACGTAATTCATATGAAAACCAAATAGATGAGATT"
+        "TCATCT 139 TTGTCAGAGTCAAAGGAACACCCCATAGATATTCAAGAAAAAA 141 A 142 C 141 "
+        "AGATGCGTTTGTGAATGAGTTCA 143 A 144 G 143  138 ATGTTAGTTAGTAAAAG 145 C 146 A "
+        "145 "
+        "AACGGATTTAACGCTAGCGCAGTTTTGGGTAGTGGAAGTTATAATGAAAATAAATCTTCTAAACACATGGAGCTACTA"
+        "GCTCATAGTATTTTAAAATTAATTTGTAAG 147 G 148 A 147 "
+        "AAGCTGCATCAGAGACGTATCGCGGTGCTCTTGAAACTTTACAAAAAATGATGTCTGAATGT 149 A 150 G "
+        "149 "
+        "TATATCAAGAAGGCAACGCCTTTGTCATTATGGGAGCTGGAGAACAATTAAAACGTATTAAATATGAAGTTGGTGAAA"
+        "ATAACTTAAAGGTATTCAACGTACACTTTAATAATAATCACGAGTTAGTTAGTTCTGGTGAGCCTGACGTAATATGTT"
+        "TAAGCAAGCAGGTCTGGGAAAATCTTCTCATTAAACTAAAGCTGGAAAACAATGAAAATGTGTTTTCTGAAACTAAAA"
+        "AA 151 T 152 C 151 TATCGAATAAAAATAATGCCGATCAGTTTTTTGAATGCGCTAA 153 "
+        "GAGAAATGAACAGACCCTA 154 AAGAAATGAACAGAACCTT 153 "
+        "TTCGATAATATAAGAAAAAGTGATTTTCATGTTGGTT 155 CACTTAAGCCAG 156 TACTTAAGCCAA 155 "
+        "GTAGTACGCGTAGTGTTATTTTAGAAACGCCGCCAAATGTCTGTATGGAATCACGTAATTCATATGAAAACAAAATAG"
+        "ATGAGATTTCATCTTTGTCAGAGTCAAAGGAACACCCCATAGATATTCAAGAAAAAA 157 "
+        "CAGATGCATTTGTGAAGAAGTTCAA 158 AAGATGCGTTTGTGAATGAGTTCAA 157  138 "
+        "GTGAATGAGTTCAA 138 "
+        "ATGTTAGTTAGTAAAAGCAACGGATTTAACGCTAGCGCAGTTTTGGGTAGTGGAAGTTATAATGAAAATAAATCTTCT"
+        "AAACACATGGAGCTACTAGCTCATAGTATTGTAAAATTAATTTGTAAGGAAGCTGCATCAGAGACGTATCGCGGTGCT"
+        "CTTGAAATTTTACAAAAAATAATGTCTGAATGTATATATCATGAAGGCAACGCCTTTGTCATTATGGGAGCTGGAGAA"
+        "CAATTAAAACGTATTAAATATGATGTTGATGAAAATAACTTAAAGGTATTCAACGTACACTTTGATAATAATGAAGTG"
+        "TTAGTTACTGATGGTGAGCCTGACGTAGTATGTTTAAGCAAGCAGGTCTGGGAAAATCTTCTCATTAAATTAAAACCG"
+        "GAGATCAAGGAAAATGCGGCTTCTGAAGTTCATAAATCAGCGAATAAAGGTGAGATTGAGCAATTAGTTGAATGCTCT"
+        "AAAAGAAATGAACAGACCCTTTTCGATAATATAAGAAAAAGTGATTTTCATGTTGGTTCACTTAAGCCAGGTAGTATG"
+        "AATAGTGTTATTTTAGAAATGCCACCAAATGTCTGTATGGAACCACGTAATCCATATGAAAACAAAATAGATGAGGTT"
+        "TCATCTTTGTCAGAGCCAAAGGAACACACCATAGATATTCAAGAAAAAACAGATGCGTTTGTGAATGAGTTCAA "
+        "137 GGGGATATTATTTGAT 159 AAAAATGG 160 AAAAATAC 160 CAAAATGG 160 AAAAATAG 159 "
+        "AAGGTCTTCAGAGTTTCT 161  163 AC 164 GT 163 TTAATTTTTATGAATGTTGCTAT 165 GA 166 "
+        "GT 166 AA 165  162 ATTTAATTTTTATGAGTGTTGCTATAA 161 GTTTTTACCAAGAGC 167 "
+        "GCAGCCTCAGGATAAAAT 169 CGAA 170 TGAA 169  168 TCAGCCTCAAGATAAAATCGAT 167 "
+        "AGCTATAATTCAGCACTGCAAGCTTT 171 CTCCATC 172 TTCCATT 172 TTCCATC 171 "
+        "TTTTGTTCATCTACGTTGA 173  175 T 176 C 175 ACATAATAATATAGGCTTTG 174 "
+        "CACATAATGGTGTAGGGTTTA 173 ATTTCAAATTATTTCC 177 AGAAGTCAAACTGTGTGGGG 179 AAA "
+        "180 GAA 180 AAC 179  178  181 AGAAGTCAAGCTGTCTGGAGAAC 182 "
+        "TGAAGTCAAACTGTCTGGAGAAC 181  177 ATCTTGAAACGGTATTCAAATA 183 T 184 C 183 "
+        "AAAAATGGCGATGATGTCCGGGAGATAGCCAAAATTAACATT 185  187 A 188 G 187 "
+        "CTCTCCAAAAAGAAGAGGATGGTTTATATAATTTAG 186 "
+        "ATCCTACCAAAAGGAGAGGGTGATTTATATAATTTGG 186 ACTCTCCAAAAAGAAGA 189 "
+        "GGGTGGATTATATAATCTAC 190  191 A 192 G 191 GGTGGTTTATATAATTTAC 189  185 "
+        "GTGGATTGGATTTTAAGGG 193 A 194 G 193 "
+        "TGCTTCTTTTCTGGACAGAACTTCAGTAACTATGATATTCAATATGTGAACTGGGG 195 A 196 T 195 "
+        "ACGTCATTGTTTGAT 197  199 CTTGATACTCCG 200 GTTGATACTCCG 200 CTTGATACTCCA 199 "
+        "TGTATTTTTAATGCGCCTGCTTACAACAAGAGTAATG 201  203 A 204 G 203 "
+        "AAAATCATTAAAACCTGTG 202 AAAAATCATTAGAACGCGTC 201  198 "
+        "GTTGATACTCCGTGTATTTTTAATACGCCTGCTAACCATGAGAGTTATGAAAAATCATTAAAACCTGTA 197 "
+        "AGCGAAAACGGTTTAA 205  207 GTGGAGTC 208 GTGGAGTA 207 "
+        "TTGACTGATCGTAATAATAAAATAAAACTCATCACGGGC 206  209 ATGGAGTCTTA 210 GTGGAGTCTTG "
+        "209 TCTGATCGTAATAAAAAAATAAAA 211 ATGATCACGGGT 212 CTAATCACGGGT 211  205 "
+        "GTGGCACCATTCGATGATATTTTATTTATGGATGATGACTTTGATGATA 213 GTTCCTCTGAGGATGATCCCG "
+        "214 ACTCCCCTGAGGATG 215 CTCCCA 216 GTCCCG 215  213 TTGAGAATAGTCCTGTTGTGA 217 "
+        "CTAGTCCCGTTGTATCAAGTTCTAAAAGCAGTTTTCAA 218 ATAGTCCCCTTGTA 217  6 "
+        "ATGTTAGTTAGTAAAAG 219 "
+        "TAATGGCCATAACGTTAATACAGTTTTGGGTAGTAGAAGTTGTAATGAAAACAATTCTTCCAACCCCATGGG 220 "
+        "CAACGGATTTAACGCTAGCGCAGTTTTGGGTAGTGGAAGTTATAATGAAAATAAATCTTCTAAACACATGGA 219 "
+        "GCTACTAGCTCATAGTATT 221 G 222 T 221 "
+        "TAAAATTAATTTGTAAGGAAGCTGCATCAGAGACGTATCGCGGTGCTCTTGAAACTTTACAAAAAATGATGTCTGAAT"
+        "GTATATATCA 223 T 224 A 223 GAAGGCAACGCCTTTGTCATTATGGGA 225 TCTGGAGTG 226 "
+        "GCTGGAGAA 226 TCTGGAGAG 225 "
+        "CAATTAAAACGTATTAAATATGATGTTGATGAAAATAACTTAAAAGTATTCAACGTATACTTTGATAATAATGAAGAG"
+        "TTAGTTACTGATGGTGAGCCTGACGTAGTATGTTTAAGCAAGCAGGTCTGGGAAGATCTTCTCATTAAACTAAAGCTG"
+        "GAGAACAAAGAAAATGCGGTTTCTGAAACTGACCTGTCATCGAATGAAAATAATGTTGATCATTTTTTTCAATCCGCT"
+        "AAGAGAGATGAACAGACCCTATTCGGCAATATAAGAAAAAGTGAGTTTCATGTTGATTCATTAAAGCCAGGTAGTACG"
+        "CGTAGTGTTATTTTAGAAACGCAACCAAATGTCTCTATGGAACCACATAATTTATATGACAACCAAATAGATAAGGTT"
+        "TCACCTGTAACTAAAAACTCTCAGCAAGTTAAAGGCCACTATGGAGATAAATTGAAAGAAATGCAGATGTTCCTTAAC"
+        "CAGATGAGCAATGCACTTCAACAGGCTCCATCTTTGTCAGAGTCAAAGGAACACACCATAGATATTCAAAAAATAACG"
+        "GATGCCTTTGTGAAGGAGTTCCGGGGGATATTATTTGATAAAAATGGAAATTCATCAGAACGTTTATTCAATTTTTAT"
+        "GAGTGCTGCTATATATTTTTACCAAGAGCGCAGCCTCAAGATAAAATCGAAAGCTATAATTCAGCGCTGCAAGCTTTT"
+        "TCCATCTTCCGTTCATCTACTTTGAATAATAATGATGTAGGGTTTAATTTCAAATTATTCCCAGAAGTCAAGCTGTCT"
+        "GGTGAAAATCTTGAAACGGTATTCAAATACAAAAAAGGAAGTTTTGTCCGGGAGATAGCCAGAATTAACATTACTCTC"
+        "CAAAAAGAAGAGGATGGTTTATATAATTTAGGTGGATTGGATTTTAAGGGATGCTTCTTTTCTGGACAGAACTTCAGT"
+        "AACTATGATATTCAATATGTGAACTGGGGAACGTCATTGTTTGATCTTGATACTCCGTGTATTTTTAATGCGCCTGCT"
+        "TACAACAAGAGTAATGAAAAATCATTAAAACCTGTGAGCGAAAACGGTTTAAGTGGAGTCTTGACTGATCGTAATAAT"
+        "AAAATAAAACTCATCACGGGCGTGGCACCATTCGATGATATTTTATTTATGGATGATGACTTTGATGATAGTTCCTCT"
+        "GAGGATGATCCCGTTGAGAATAGTCCTGTTGTGACTAGTCCCGTTGTATCAAGTTCTAAAAGCAGTTTTCAA 5 ");
+    string bad = "ATGTTAGTTAGTAAAAGCAACGGATTTAACGCTAGCGCAGTTTTGGGTAGTGGAAGTTATAATGAAAAT"
+                 "AAATCTTCTAAACACATGGAGCTACTAGCTCATAGTATTTTAAAATTAATTTGTAAGGAAGCTGCATCA"
+                 "GAGACGTATCGCGGTGCTCTTGAAACTTTACAAAAAATGATGTCTGAATGTATATATCAAGAAGGCAAC"
+                 "GCCTTTGTCATTATGGGAGCTGGAGAACAATTAAAACGTATTAAATATGAAGTTGGTGAAAATAACTTA"
+                 "AAGGTATTCAACGTACACTTTAATAATAATCACGAGTTAGTTAGTTCTGGTGAGCCTGACGTAATATGT"
+                 "TTAAGCAAGCAGGTCTGGGAAAATCTTCTCATTAAACTAAAGCTGGAAAACAATGAAAATGTGTTTTCT"
+                 "GAAACTAAAAAATTATCGAATAAAAATAATGCCGATCAGTTTTTTGAATGCGCTAAAAGAAATGAA";
     EXPECT_TRUE(l.get_valid_vcf_reference(bad).empty());
 }
 
-TEST(LocalPRGTest, get_valid_vcf_reference_valid_simple) {
-    LocalPRG test_prg(3, "long_enough", "AGTATA 5 GCC 7 CCC 8 TATG 7  6 GGAGCG 5 TATTTACGTTCGAGGTCCAGACGCTCTA");
+TEST(LocalPRGTest, get_valid_vcf_reference_valid_simple)
+{
+    LocalPRG test_prg(3, "long_enough",
+        "AGTATA 5 GCC 7 CCC 8 TATG 7  6 GGAGCG 5 TATTTACGTTCGAGGTCCAGACGCTCTA");
     std::string valid1 = "AGTATAGCCCCCTATTTACGTTCGAGGTCCAGACGCTCTA";
     std::string valid2 = "AGTATAGCCTATGTATTTACGTTCGAGGTCCAGACGCTCTA";
     std::string valid3 = "AGTATAGGAGCGTATTTACGTTCGAGGTCCAGACGCTCTA";
-    std::vector<LocalNodePtr> exp_nodes1 = {test_prg.prg.nodes[0], test_prg.prg.nodes[1], test_prg.prg.nodes[2],
-                                            test_prg.prg.nodes[4], test_prg.prg.nodes[6]};
-    std::vector<LocalNodePtr> exp_nodes2 = {test_prg.prg.nodes[0], test_prg.prg.nodes[1], test_prg.prg.nodes[3],
-                                            test_prg.prg.nodes[4], test_prg.prg.nodes[6]};
-    std::vector<LocalNodePtr> exp_nodes3 = {test_prg.prg.nodes[0], test_prg.prg.nodes[5], test_prg.prg.nodes[6]};
+    std::vector<LocalNodePtr> exp_nodes1
+        = { test_prg.prg.nodes[0], test_prg.prg.nodes[1], test_prg.prg.nodes[2],
+              test_prg.prg.nodes[4], test_prg.prg.nodes[6] };
+    std::vector<LocalNodePtr> exp_nodes2
+        = { test_prg.prg.nodes[0], test_prg.prg.nodes[1], test_prg.prg.nodes[3],
+              test_prg.prg.nodes[4], test_prg.prg.nodes[6] };
+    std::vector<LocalNodePtr> exp_nodes3
+        = { test_prg.prg.nodes[0], test_prg.prg.nodes[5], test_prg.prg.nodes[6] };
 
     auto result1 = test_prg.get_valid_vcf_reference(valid1);
     EXPECT_ITERABLE_EQ(std::vector<LocalNodePtr>, exp_nodes1, result1);
-    EXPECT_ITERABLE_EQ(std::vector<LocalNodePtr>, exp_nodes2, test_prg.get_valid_vcf_reference(valid2));
-    EXPECT_ITERABLE_EQ(std::vector<LocalNodePtr>, exp_nodes3, test_prg.get_valid_vcf_reference(valid3));
+    EXPECT_ITERABLE_EQ(std::vector<LocalNodePtr>, exp_nodes2,
+        test_prg.get_valid_vcf_reference(valid2));
+    EXPECT_ITERABLE_EQ(std::vector<LocalNodePtr>, exp_nodes3,
+        test_prg.get_valid_vcf_reference(valid3));
 }
 
-TEST(LocalPRGTest, get_valid_vcf_reference_valid_rev) {
-    LocalPRG test_prg(3, "long_enough", "AGTATA 5 GCC 7 CCC 8 TATG 7  6 GGAGCG 5 TATTTACGTTCGAGGTCCAGACGCTCTA");
+TEST(LocalPRGTest, get_valid_vcf_reference_valid_rev)
+{
+    LocalPRG test_prg(3, "long_enough",
+        "AGTATA 5 GCC 7 CCC 8 TATG 7  6 GGAGCG 5 TATTTACGTTCGAGGTCCAGACGCTCTA");
     std::string valid1 = rev_complement("AGTATAGCCCCCTATTTACGTTCGAGGTCCAGACGCTCTA");
     std::string valid2 = rev_complement("AGTATAGCCTATGTATTTACGTTCGAGGTCCAGACGCTCTA");
     std::string valid3 = rev_complement("AGTATAGGAGCGTATTTACGTTCGAGGTCCAGACGCTCTA");
-    std::vector<LocalNodePtr> exp_nodes1 = {test_prg.prg.nodes[0], test_prg.prg.nodes[1], test_prg.prg.nodes[2],
-                                            test_prg.prg.nodes[4], test_prg.prg.nodes[6]};
-    std::vector<LocalNodePtr> exp_nodes2 = {test_prg.prg.nodes[0], test_prg.prg.nodes[1], test_prg.prg.nodes[3],
-                                            test_prg.prg.nodes[4], test_prg.prg.nodes[6]};
-    std::vector<LocalNodePtr> exp_nodes3 = {test_prg.prg.nodes[0], test_prg.prg.nodes[5], test_prg.prg.nodes[6]};
+    std::vector<LocalNodePtr> exp_nodes1
+        = { test_prg.prg.nodes[0], test_prg.prg.nodes[1], test_prg.prg.nodes[2],
+              test_prg.prg.nodes[4], test_prg.prg.nodes[6] };
+    std::vector<LocalNodePtr> exp_nodes2
+        = { test_prg.prg.nodes[0], test_prg.prg.nodes[1], test_prg.prg.nodes[3],
+              test_prg.prg.nodes[4], test_prg.prg.nodes[6] };
+    std::vector<LocalNodePtr> exp_nodes3
+        = { test_prg.prg.nodes[0], test_prg.prg.nodes[5], test_prg.prg.nodes[6] };
 
-    EXPECT_ITERABLE_EQ(std::vector<LocalNodePtr>, exp_nodes1, test_prg.get_valid_vcf_reference(valid1));
-    EXPECT_ITERABLE_EQ(std::vector<LocalNodePtr>, exp_nodes2, test_prg.get_valid_vcf_reference(valid2));
-    EXPECT_ITERABLE_EQ(std::vector<LocalNodePtr>, exp_nodes3, test_prg.get_valid_vcf_reference(valid3));
+    EXPECT_ITERABLE_EQ(std::vector<LocalNodePtr>, exp_nodes1,
+        test_prg.get_valid_vcf_reference(valid1));
+    EXPECT_ITERABLE_EQ(std::vector<LocalNodePtr>, exp_nodes2,
+        test_prg.get_valid_vcf_reference(valid2));
+    EXPECT_ITERABLE_EQ(std::vector<LocalNodePtr>, exp_nodes3,
+        test_prg.get_valid_vcf_reference(valid3));
 }
 
-TEST(LocalPRGTest, get_valid_vcf_reference_invalid) {
-    LocalPRG test_prg(3, "long_enough", "AGTATA 5 GCC 7 CCC 8 TATG 7  6 GGAGCGTCGAGGTCCAGTCGAGGTCCAG 6  5 TATTTACGTTCGAGGTCCAGACG");
+TEST(LocalPRGTest, get_valid_vcf_reference_invalid)
+{
+    LocalPRG test_prg(3, "long_enough",
+        "AGTATA 5 GCC 7 CCC 8 TATG 7  6 GGAGCGTCGAGGTCCAGTCGAGGTCCAG 6  5 "
+        "TATTTACGTTCGAGGTCCAGACG");
     std::string null = "";
     std::string snp_away_from_graph = "AGTATAGCCCCCTAGTTACGTTCGAGGTCCAGACG";
     std::string too_short = "AGTATATATTTACGTTCGAGGTCCAGACG";
@@ -1884,22 +2390,23 @@ TEST(LocalPRGTest, get_valid_vcf_reference_invalid) {
     EXPECT_TRUE(test_prg.get_valid_vcf_reference(snp_away_from_graph).empty());
     EXPECT_TRUE(test_prg.get_valid_vcf_reference(too_short).empty());
     EXPECT_TRUE(test_prg.get_valid_vcf_reference(starts_late).empty());
-    std::vector<LocalNodePtr> exp_nodes1 = {test_prg.prg.nodes[0], test_prg.prg.nodes[1], test_prg.prg.nodes[2],
-                                            test_prg.prg.nodes[4], test_prg.prg.nodes[7]};
-    EXPECT_ITERABLE_EQ(std::vector<LocalNodePtr>, exp_nodes1, test_prg.get_valid_vcf_reference(ends_less_than_a_node_early));
+    std::vector<LocalNodePtr> exp_nodes1
+        = { test_prg.prg.nodes[0], test_prg.prg.nodes[1], test_prg.prg.nodes[2],
+              test_prg.prg.nodes[4], test_prg.prg.nodes[7] };
+    EXPECT_ITERABLE_EQ(std::vector<LocalNodePtr>, exp_nodes1,
+        test_prg.get_valid_vcf_reference(ends_less_than_a_node_early));
     EXPECT_TRUE(test_prg.get_valid_vcf_reference(ends_a_node_early).empty());
-
 }
 
-TEST(LocalPRGTest, random_path) {
-    LocalPRG test_prg(3, "long_enough", "AGTATA 5 GCC 7 CCC 8 TATG 7  6 GGACCAG 6  5 TATTTACG");
+TEST(LocalPRGTest, random_path)
+{
+    LocalPRG test_prg(
+        3, "long_enough", "AGTATA 5 GCC 7 CCC 8 TATG 7  6 GGACCAG 6  5 TATTTACG");
     std::set<std::string> random_paths;
     while (random_paths.size() < 4) {
         random_paths.insert(test_prg.random_path());
     }
-    std::set<std::string> exp_random_paths = {"AGTATAGCCCCCTATTTACG",
-                                              "AGTATAGCCTATGTATTTACG",
-                                              "AGTATAGGACCAGTATTTACG",
-                                              "AGTATATATTTACG"};
+    std::set<std::string> exp_random_paths = { "AGTATAGCCCCCTATTTACG",
+        "AGTATAGCCTATGTATTTACG", "AGTATAGGACCAGTATTTACG", "AGTATATATTTACG" };
     EXPECT_ITERABLE_EQ(std::set<std::string>, exp_random_paths, random_paths);
 }

--- a/test/localgraph_test.cpp
+++ b/test/localgraph_test.cpp
@@ -1,17 +1,17 @@
-#include "gtest/gtest.h"
-#include "test_macro.cpp"
 #include "interval.h"
-#include "prg/path.h"
 #include "localPRG.h"
 #include "localgraph.h"
 #include "localnode.h"
-#include <stdint.h>
+#include "prg/path.h"
+#include "test_macro.cpp"
+#include "gtest/gtest.h"
 #include <iostream>
-
+#include <stdint.h>
 
 using namespace std;
 
-TEST(LocalGraphTest, add_node) {
+TEST(LocalGraphTest, add_node)
+{
     // add node and check it's there
     LocalGraph lg1;
     lg1.add_node(0, "AGCT", Interval(0, 4));
@@ -27,7 +27,8 @@ TEST(LocalGraphTest, add_node) {
     EXPECT_DEATH(lg1.add_node(1, "AGG", Interval(0, 4)), "");
 }
 
-TEST(LocalGraphTest, add_edge) {
+TEST(LocalGraphTest, add_edge)
+{
     LocalGraph lg2;
     lg2.add_node(0, "A", Interval(0, 1));
     lg2.add_node(1, "GC", Interval(4, 6));
@@ -43,7 +44,8 @@ TEST(LocalGraphTest, add_edge) {
     EXPECT_DEATH(lg2.add_edge(0, 4), "");
 }
 
-TEST(LocalGraphTest, equals) {
+TEST(LocalGraphTest, equals)
+{
     LocalGraph lg1;
     lg1.add_node(0, "AGCT", Interval(0, 4));
     EXPECT_EQ(lg1, lg1);
@@ -103,7 +105,8 @@ TEST(LocalGraphTest, equals) {
     EXPECT_EQ((lg2 == lg2r), false);
 }
 
-TEST(LocalGraphTest, not_equals) {
+TEST(LocalGraphTest, not_equals)
+{
     LocalGraph lg1;
     lg1.add_node(0, "AGCT", Interval(0, 4));
     EXPECT_EQ((lg1 != lg1), false);
@@ -163,7 +166,8 @@ TEST(LocalGraphTest, not_equals) {
     EXPECT_EQ((lg2 != lg2r), true);
 }
 
-TEST(LocalGraphTest, write_gfa) {
+TEST(LocalGraphTest, write_gfa)
+{
     LocalGraph lg2;
     lg2.add_node(0, "A", Interval(0, 1));
     lg2.add_node(1, "GC", Interval(4, 6));
@@ -177,7 +181,8 @@ TEST(LocalGraphTest, write_gfa) {
     lg2.write_gfa("localgraph_test.gfa");
 }
 
-TEST(LocalGraphTest, read_gfa) {
+TEST(LocalGraphTest, read_gfa)
+{
     LocalGraph lg2, read_lg2;
     lg2.add_node(0, "A", Interval(0, 1));
     lg2.add_node(1, "GC", Interval(4, 6));
@@ -192,7 +197,8 @@ TEST(LocalGraphTest, read_gfa) {
     EXPECT_EQ(lg2, read_lg2);
 }
 
-TEST(LocalGraphTest, walk) {
+TEST(LocalGraphTest, walk)
+{
     LocalGraph lg2;
     lg2.add_node(0, "A", Interval(0, 1));
     lg2.add_node(1, "GC", Interval(4, 6));
@@ -206,10 +212,10 @@ TEST(LocalGraphTest, walk) {
     // simple case, there are 2 paths of length 3
     vector<PathPtr> q1;
     prg::Path p;
-    deque<Interval> d = {Interval(0, 1), Interval(4, 6)};
+    deque<Interval> d = { Interval(0, 1), Interval(4, 6) };
     p.initialize(d);
     q1.push_back(std::make_shared<prg::Path>(p));
-    d = {Interval(0, 1), Interval(7, 8), Interval(13, 14)};
+    d = { Interval(0, 1), Interval(7, 8), Interval(13, 14) };
     p.initialize(d);
     q1.push_back(std::make_shared<prg::Path>(p));
     vector<PathPtr> p1 = lg2.walk(0, 0, 3);
@@ -218,7 +224,7 @@ TEST(LocalGraphTest, walk) {
 
     // but only one can be extended to a path of length 4
     q1.clear();
-    d = {Interval(0, 1), Interval(4, 6), Interval(13, 14)};
+    d = { Interval(0, 1), Interval(4, 6), Interval(13, 14) };
     p.initialize(d);
     q1.push_back(std::make_shared<prg::Path>(p));
     p1 = lg2.walk(0, 0, 4);
@@ -227,7 +233,7 @@ TEST(LocalGraphTest, walk) {
 
     // for even simpler path of length 1
     q1.clear();
-    d = {Interval(0, 1)};
+    d = { Interval(0, 1) };
     p.initialize(d);
     q1.push_back(std::make_shared<prg::Path>(p));
     p1 = lg2.walk(0, 0, 1);
@@ -242,7 +248,7 @@ TEST(LocalGraphTest, walk) {
 
     // 1 path starting from middle var site
     q1.clear();
-    d = {Interval(4, 6), Interval(13, 14)};
+    d = { Interval(4, 6), Interval(13, 14) };
     p.initialize(d);
     q1.push_back(std::make_shared<prg::Path>(p));
     p1 = lg2.walk(1, 4, 3);
@@ -268,10 +274,12 @@ TEST(LocalGraphTest, walk) {
     lg3.add_edge(5, 6);
 
     q1.clear();
-    d = {Interval(0, 1), Interval(4, 5), Interval(8, 9), Interval(16, 16), Interval(23, 24)};
+    d = { Interval(0, 1), Interval(4, 5), Interval(8, 9), Interval(16, 16),
+        Interval(23, 24) };
     p.initialize(d);
     q1.push_back(std::make_shared<prg::Path>(p));
-    d = {Interval(0, 1), Interval(4, 5), Interval(12, 13), Interval(16, 16), Interval(23, 24)};
+    d = { Interval(0, 1), Interval(4, 5), Interval(12, 13), Interval(16, 16),
+        Interval(23, 24) };
     p.initialize(d);
     q1.push_back(std::make_shared<prg::Path>(p));
     p1 = lg3.walk(0, 0, 4);
@@ -280,7 +288,7 @@ TEST(LocalGraphTest, walk) {
 
     // also want to allow walks starting from an empty node, including the empty node
     q1.clear();
-    d = {Interval(16, 16), Interval(23, 24)};
+    d = { Interval(16, 16), Interval(23, 24) };
     p.initialize(d);
     q1.push_back(std::make_shared<prg::Path>(p));
     p1 = lg3.walk(4, 16, 1);
@@ -288,7 +296,8 @@ TEST(LocalGraphTest, walk) {
     EXPECT_EQ(equal, true);
 }
 
-TEST(LocalGraphTest, walk_back) {
+TEST(LocalGraphTest, walk_back)
+{
     LocalGraph lg2;
     lg2.add_node(0, "A", Interval(0, 1));
     lg2.add_node(1, "GC", Interval(4, 6));
@@ -302,10 +311,10 @@ TEST(LocalGraphTest, walk_back) {
     // simple case, there are 2 paths of length 3
     vector<PathPtr> q1;
     prg::Path p;
-    deque<Interval> d = {Interval(4, 6), Interval(13, 14)};
+    deque<Interval> d = { Interval(4, 6), Interval(13, 14) };
     p.initialize(d);
     q1.push_back(std::make_shared<prg::Path>(p));
-    d = {Interval(0, 1), Interval(7, 8), Interval(13, 14)};
+    d = { Interval(0, 1), Interval(7, 8), Interval(13, 14) };
     p.initialize(d);
     q1.push_back(std::make_shared<prg::Path>(p));
     vector<PathPtr> p1 = lg2.walk_back(3, 14, 3);
@@ -314,7 +323,7 @@ TEST(LocalGraphTest, walk_back) {
 
     // but only one can be extended to a path of length 4
     q1.clear();
-    d = {Interval(0, 1), Interval(4, 6), Interval(13, 14)};
+    d = { Interval(0, 1), Interval(4, 6), Interval(13, 14) };
     p.initialize(d);
     q1.push_back(std::make_shared<prg::Path>(p));
     p1 = lg2.walk_back(3, 14, 4);
@@ -323,7 +332,7 @@ TEST(LocalGraphTest, walk_back) {
 
     // for even simpler path of length 1
     q1.clear();
-    d = {Interval(0, 1)};
+    d = { Interval(0, 1) };
     p.initialize(d);
     q1.push_back(std::make_shared<prg::Path>(p));
     p1 = lg2.walk_back(0, 1, 1);
@@ -338,7 +347,7 @@ TEST(LocalGraphTest, walk_back) {
 
     // 1 path starting from middle var site
     q1.clear();
-    d = {Interval(0, 1), Interval(4, 6)};
+    d = { Interval(0, 1), Interval(4, 6) };
     p.initialize(d);
     q1.push_back(std::make_shared<prg::Path>(p));
     p1 = lg2.walk_back(1, 6, 3);
@@ -364,10 +373,12 @@ TEST(LocalGraphTest, walk_back) {
     lg3.add_edge(5, 6);
 
     q1.clear();
-    d = {Interval(0, 1), Interval(4, 5), Interval(8, 9), Interval(16, 16), Interval(23, 24)};
+    d = { Interval(0, 1), Interval(4, 5), Interval(8, 9), Interval(16, 16),
+        Interval(23, 24) };
     p.initialize(d);
     q1.push_back(std::make_shared<prg::Path>(p));
-    d = {Interval(0, 1), Interval(4, 5), Interval(12, 13), Interval(16, 16), Interval(23, 24)};
+    d = { Interval(0, 1), Interval(4, 5), Interval(12, 13), Interval(16, 16),
+        Interval(23, 24) };
     p.initialize(d);
     q1.push_back(std::make_shared<prg::Path>(p));
     p1 = lg3.walk_back(6, 24, 4);
@@ -376,10 +387,10 @@ TEST(LocalGraphTest, walk_back) {
 
     // also want to allow walks starting from an empty node, including the empty node
     q1.clear();
-    d = {Interval(8, 9), Interval(16, 16)};
+    d = { Interval(8, 9), Interval(16, 16) };
     p.initialize(d);
     q1.push_back(std::make_shared<prg::Path>(p));
-    d = {Interval(12, 13), Interval(16, 16)};
+    d = { Interval(12, 13), Interval(16, 16) };
     p.initialize(d);
     q1.push_back(std::make_shared<prg::Path>(p));
     p1 = lg3.walk_back(4, 16, 1);
@@ -387,7 +398,8 @@ TEST(LocalGraphTest, walk_back) {
     EXPECT_EQ(equal, true);
 }
 
-TEST(LocalGraphTest, nodes_along_string) {
+TEST(LocalGraphTest, nodes_along_string)
+{
     LocalGraph lg2, read_lg2;
     lg2.add_node(0, "A", Interval(0, 1));
     lg2.add_node(1, "GC", Interval(4, 6));
@@ -398,30 +410,30 @@ TEST(LocalGraphTest, nodes_along_string) {
     lg2.add_edge(1, 3);
     lg2.add_edge(2, 3);
 
-    vector<LocalNodePtr> v_exp = {lg2.nodes[0], lg2.nodes[1], lg2.nodes[3]};
+    vector<LocalNodePtr> v_exp = { lg2.nodes[0], lg2.nodes[1], lg2.nodes[3] };
     vector<LocalNodePtr> v = lg2.nodes_along_string("AGCT");
     EXPECT_ITERABLE_EQ(vector<LocalNodePtr>, v_exp, v);
 
-    v_exp = {lg2.nodes[0], lg2.nodes[2], lg2.nodes[3]};
+    v_exp = { lg2.nodes[0], lg2.nodes[2], lg2.nodes[3] };
     v = lg2.nodes_along_string("AGT");
     EXPECT_ITERABLE_EQ(vector<LocalNodePtr>, v_exp, v);
 
-    v_exp = {lg2.nodes[0], lg2.nodes[1]};
+    v_exp = { lg2.nodes[0], lg2.nodes[1] };
     v = lg2.nodes_along_string("AGC");
     EXPECT_ITERABLE_EQ(vector<LocalNodePtr>, v_exp, v);
 
-    v_exp = {lg2.nodes[0], lg2.nodes[1], lg2.nodes[3]};
+    v_exp = { lg2.nodes[0], lg2.nodes[1], lg2.nodes[3] };
     v = lg2.nodes_along_string("AGC", true);
     EXPECT_ITERABLE_EQ(vector<LocalNodePtr>, v_exp, v);
 
-    v_exp = {lg2.nodes[0], lg2.nodes[1]};
+    v_exp = { lg2.nodes[0], lg2.nodes[1] };
     v = lg2.nodes_along_string("AgC");
     EXPECT_ITERABLE_EQ(vector<LocalNodePtr>, v_exp, v);
 
     // check for simple prgs
     LocalGraph lg1, read_lg1;
     lg1.add_node(0, "AGTTCGTAGACCAACGCGCT", Interval(0, 20));
-    v_exp = {lg1.nodes[0]};
+    v_exp = { lg1.nodes[0] };
     v = lg1.nodes_along_string("AGTTCGTagACCAACGCGCT");
     EXPECT_ITERABLE_EQ(vector<LocalNodePtr>, v_exp, v);
     v_exp = {};
@@ -439,17 +451,17 @@ TEST(LocalGraphTest, nodes_along_string) {
     lg3.add_edge(1, 3);
     lg3.add_edge(2, 3);
 
-    v_exp = {lg3.nodes[0], lg3.nodes[1]};
+    v_exp = { lg3.nodes[0], lg3.nodes[1] };
     v = lg3.nodes_along_string("AGC");
     EXPECT_ITERABLE_EQ(vector<LocalNodePtr>, v_exp, v);
 
-    v_exp = {lg3.nodes[0], lg3.nodes[2], lg3.nodes[3]};
+    v_exp = { lg3.nodes[0], lg3.nodes[2], lg3.nodes[3] };
     v = lg3.nodes_along_string("AGC", true);
     EXPECT_ITERABLE_EQ(vector<LocalNodePtr>, v_exp, v);
-
 }
 
-TEST(LocalGraphTest, top_path) {
+TEST(LocalGraphTest, top_path)
+{
     LocalGraph lg2;
     lg2.add_node(0, "A", Interval(0, 1));
     lg2.add_node(1, "GC", Interval(4, 6));
@@ -460,17 +472,19 @@ TEST(LocalGraphTest, top_path) {
     lg2.add_edge(1, 3);
     lg2.add_edge(2, 3);
 
-    vector<LocalNodePtr> v_exp = {lg2.nodes[0], lg2.nodes[1], lg2.nodes[3]};
+    vector<LocalNodePtr> v_exp = { lg2.nodes[0], lg2.nodes[1], lg2.nodes[3] };
     vector<LocalNodePtr> v = lg2.top_path();
     EXPECT_ITERABLE_EQ(vector<LocalNodePtr>, v_exp, v);
 
     LocalPRG lp3 = LocalPRG(3, "3", "T 5 G 7 C 8 T 7  6 G 5 TATG");
-    v_exp = {lp3.prg.nodes[0], lp3.prg.nodes[1], lp3.prg.nodes[2], lp3.prg.nodes[4], lp3.prg.nodes[6]};
+    v_exp = { lp3.prg.nodes[0], lp3.prg.nodes[1], lp3.prg.nodes[2], lp3.prg.nodes[4],
+        lp3.prg.nodes[6] };
     v = lp3.prg.top_path();
     EXPECT_ITERABLE_EQ(vector<LocalNodePtr>, v_exp, v);
 }
 
-TEST(LocalGraphTest, bottom_path) {
+TEST(LocalGraphTest, bottom_path)
+{
     LocalGraph lg2;
     lg2.add_node(0, "A", Interval(0, 1));
     lg2.add_node(1, "GC", Interval(4, 6));
@@ -481,12 +495,12 @@ TEST(LocalGraphTest, bottom_path) {
     lg2.add_edge(1, 3);
     lg2.add_edge(2, 3);
 
-    vector<LocalNodePtr> v_exp = {lg2.nodes[0], lg2.nodes[2], lg2.nodes[3]};
+    vector<LocalNodePtr> v_exp = { lg2.nodes[0], lg2.nodes[2], lg2.nodes[3] };
     vector<LocalNodePtr> v = lg2.bottom_path();
     EXPECT_ITERABLE_EQ(vector<LocalNodePtr>, v_exp, v);
 
     LocalPRG lp3 = LocalPRG(3, "3", "T 5 G 7 C 8 T 7  6 G 5 TATG");
-    v_exp = {lp3.prg.nodes[0], lp3.prg.nodes[5], lp3.prg.nodes[6]};
+    v_exp = { lp3.prg.nodes[0], lp3.prg.nodes[5], lp3.prg.nodes[6] };
     v = lp3.prg.bottom_path();
     EXPECT_ITERABLE_EQ(vector<LocalNodePtr>, v_exp, v);
 }

--- a/test/localnode_test.cpp
+++ b/test/localnode_test.cpp
@@ -1,13 +1,13 @@
-#include "gtest/gtest.h"
-#include "localnode.h"
 #include "interval.h"
-#include <stdint.h>
+#include "localnode.h"
+#include "gtest/gtest.h"
 #include <iostream>
-
+#include <stdint.h>
 
 using namespace std;
 
-TEST(LocalNodeTest, create) {
+TEST(LocalNodeTest, create)
+{
 
     LocalNode ln("ACGTA", Interval(0, 5), 0);
 
@@ -18,7 +18,8 @@ TEST(LocalNodeTest, create) {
     EXPECT_EQ(j, ln.id);
 }
 
-TEST(LocalNodeTest, equals) {
+TEST(LocalNodeTest, equals)
+{
     LocalNode ln1("ACGTA", Interval(0, 5), 0);
     LocalNode ln2("AGCTA", Interval(0, 5), 0);
     LocalNode ln3("ACGTA", Interval(0, 4), 0);
@@ -29,10 +30,10 @@ TEST(LocalNodeTest, equals) {
     EXPECT_EQ(ln3, ln3);
     EXPECT_EQ(ln4, ln4);
     EXPECT_EQ((ln1 == ln2), false);
-    //EXPECT_EQ((ln1==ln3), false); //now interval associated with a node does not matter
+    // EXPECT_EQ((ln1==ln3), false); //now interval associated with a node does not
+    // matter
     EXPECT_EQ((ln1 == ln4), false);
     EXPECT_EQ((ln2 == ln3), false);
     EXPECT_EQ((ln2 == ln4), false);
     EXPECT_EQ((ln3 == ln4), false);
 }
-

--- a/test/main.cpp
+++ b/test/main.cpp
@@ -1,8 +1,8 @@
-#include <boost/log/core.hpp>
 #include "gtest/gtest.h"
+#include <boost/log/core.hpp>
 
-
-int main(int argc, char **argv) {
+int main(int argc, char** argv)
+{
     auto core = boost::log::core::get();
     core->set_logging_enabled(false);
 

--- a/test/minihit_test.cpp
+++ b/test/minihit_test.cpp
@@ -1,29 +1,29 @@
-#include "gtest/gtest.h"
+#include "interval.h"
+#include "inthash.h"
 #include "minihit.h"
 #include "minimizer.h"
 #include "minirecord.h"
-#include "interval.h"
 #include "prg/path.h"
-#include "inthash.h"
-#include <stdint.h>
-#include <iostream>
+#include "gtest/gtest.h"
 #include <algorithm>
-
+#include <iostream>
+#include <stdint.h>
 
 using namespace std;
 
-TEST(MinimizerHitTest, create) {
+TEST(MinimizerHitTest, create)
+{
     KmerHash hash;
     pair<uint64_t, uint64_t> kh = hash.kmerhash("ACGTA", 5);
     Minimizer m(min(kh.first, kh.second), 0, 5, 0);
-    deque<Interval> d = {Interval(7, 8), Interval(10, 14)};
+    deque<Interval> d = { Interval(7, 8), Interval(10, 14) };
     prg::Path p;
     p.initialize(d);
     MiniRecord mr(0, p, 0, 0);
     MinimizerHit mh(1, m, mr);
     uint32_t j(1);
     EXPECT_EQ(j, mh.get_read_id());
-    EXPECT_EQ((uint) 0, mh.get_read_start_position());
+    EXPECT_EQ((uint)0, mh.get_read_start_position());
     j = 0;
     EXPECT_EQ(j, mh.get_prg_id());
     EXPECT_EQ(p, mh.get_prg_path());
@@ -33,19 +33,20 @@ TEST(MinimizerHitTest, create) {
     kh = hash.kmerhash("hell", 4);
     m = Minimizer(min(kh.first, kh.second), 1, 5, 0);
     EXPECT_DEATH(MinimizerHit(1, m, mr), "");
-    //TEST SECOND CONSTRUCTOR!!
+    // TEST SECOND CONSTRUCTOR!!
 }
 
-TEST(MinimizerHitTest, checkStrand) {
+TEST(MinimizerHitTest, checkStrand)
+{
     KmerHash hash;
     pair<uint64_t, uint64_t> kh = hash.kmerhash("ACGTA", 5);
-    deque<Interval> d = {Interval(7, 8), Interval(10, 14)};
+    deque<Interval> d = { Interval(7, 8), Interval(10, 14) };
     prg::Path p;
     p.initialize(d);
 
-
     {
-        Minimizer m(min(kh.first, kh.second), 0, 5, 0);;
+        Minimizer m(min(kh.first, kh.second), 0, 5, 0);
+        ;
         MiniRecord mr(0, p, 0, 0);
         MinimizerHit mh(1, m, mr);
         EXPECT_EQ(mh.is_forward(), true);
@@ -66,18 +67,19 @@ TEST(MinimizerHitTest, checkStrand) {
     }
 }
 
-TEST(MinimizerHitTest, equals) {
+TEST(MinimizerHitTest, equals)
+{
     KmerHash hash;
     pair<uint64_t, uint64_t> kh = hash.kmerhash("ACGTA", 5);
     Minimizer m1(min(kh.first, kh.second), 0, 5, 0);
-    deque<Interval> d = {Interval(7, 8), Interval(10, 14)};
+    deque<Interval> d = { Interval(7, 8), Interval(10, 14) };
     prg::Path p;
     p.initialize(d);
     MiniRecord mr1(0, p, 0, 0);
     MinimizerHit mh1(1, m1, mr1);
 
     Minimizer m2(min(kh.first, kh.second), 0, 5, 0);
-    d = {Interval(7, 9), Interval(11, 14)};
+    d = { Interval(7, 9), Interval(11, 14) };
     p.initialize(d);
     MiniRecord mr2(0, p, 0, 0);
     MinimizerHit mh2(1, m2, mr2);
@@ -87,42 +89,40 @@ TEST(MinimizerHitTest, equals) {
     EXPECT_EQ((mh1 == mh2), false);
 }
 
-TEST(MinimizerHitTest, compare) {
+TEST(MinimizerHitTest, compare)
+{
     set<MinimizerHit> hits;
     KmerHash hash;
 
     pair<uint64_t, uint64_t> kh = hash.kmerhash("ACGTA", 5);
     Minimizer m12 = Minimizer(min(kh.first, kh.second), 1, 6, 0);
-    deque<Interval> d = {Interval(7, 8), Interval(10, 14)};
+    deque<Interval> d = { Interval(7, 8), Interval(10, 14) };
     prg::Path p;
     p.initialize(d);
     MiniRecord mr12 = MiniRecord(0, p, 0, 0);
     MinimizerHit mh1(1, m12, mr12);
     MinimizerHit mh2(0, m12, mr12);
 
-
-
     Minimizer m3 = Minimizer(min(kh.first, kh.second), 0, 5, 0);
-    d = {Interval(6, 10), Interval(11, 12)};
+    d = { Interval(6, 10), Interval(11, 12) };
     p.initialize(d);
     MiniRecord mr3 = MiniRecord(0, p, 0, 0);
     MinimizerHit mh3(1, m3, mr3);
 
-
     Minimizer m4 = Minimizer(min(kh.first, kh.second), 0, 5, 0);
-    d = {Interval(6, 10), Interval(12, 13)};
+    d = { Interval(6, 10), Interval(12, 13) };
     p.initialize(d);
     MiniRecord mr4 = MiniRecord(0, p, 0, 0);
     MinimizerHit mh4(1, m4, mr4);
 
     Minimizer m5 = Minimizer(min(kh.first, kh.second), 0, 5, 0);
-    d = {Interval(6, 10), Interval(13, 13), Interval(14, 15)};
+    d = { Interval(6, 10), Interval(13, 13), Interval(14, 15) };
     p.initialize(d);
     MiniRecord mr5 = MiniRecord(0, p, 0, 0);
     MinimizerHit mh5(1, m5, mr5);
 
     Minimizer m6 = Minimizer(min(kh.first, kh.second), 0, 5, 0);
-    d = {Interval(6, 10), Interval(14, 14), Interval(14, 15)};
+    d = { Interval(6, 10), Interval(14, 14), Interval(14, 15) };
     p.initialize(d);
     MiniRecord mr6 = MiniRecord(0, p, 0, 0);
     MinimizerHit mh6(1, m6, mr6);
@@ -149,4 +149,3 @@ TEST(MinimizerHitTest, compare) {
     }
     EXPECT_EQ(expected[0], *(--hits.end()));
 }
-

--- a/test/minihits_test.cpp
+++ b/test/minihits_test.cpp
@@ -1,65 +1,66 @@
-#include "gtest/gtest.h"
-#include "minihits.h"
+#include "interval.h"
+#include "inthash.h"
 #include "minihit.h"
+#include "minihits.h"
 #include "minimizer.h"
 #include "minirecord.h"
-#include "interval.h"
 #include "prg/path.h"
-#include "inthash.h"
-#include <stdint.h>
-#include <iostream>
+#include "gtest/gtest.h"
 #include <algorithm>
-
+#include <iostream>
+#include <stdint.h>
 
 using namespace std;
 
-TEST(MinimizerHitsTest, add_hit) {
+TEST(MinimizerHitsTest, add_hit)
+{
     // tests both add_hit and that sort doesn't break. Doesn't test resut of sort
     MinimizerHits mhits;
     KmerHash hash;
     pair<uint64_t, uint64_t> kh = hash.kmerhash("ACGTA", 5);
-    deque<Interval> d = {Interval(7, 8), Interval(10, 14)};
+    deque<Interval> d = { Interval(7, 8), Interval(10, 14) };
     prg::Path p;
     p.initialize(d);
 
     Minimizer m1(min(kh.first, kh.second), 1, 6, 0);
     MiniRecord mr1(0, p, 0, 0);
     mhits.add_hit(1, m1, mr1);
-    EXPECT_EQ((uint) 1, mhits.hits.size());
-    //mhits.add_hit(1, m, mr);
-    //EXPECT_EQ((uint)1, mhits.uhits.size());
+    EXPECT_EQ((uint)1, mhits.hits.size());
+    // mhits.add_hit(1, m, mr);
+    // EXPECT_EQ((uint)1, mhits.uhits.size());
     mhits.add_hit(2, m1, mr1);
-    EXPECT_EQ((uint) 2, mhits.hits.size());
+    EXPECT_EQ((uint)2, mhits.hits.size());
 
     Minimizer m3(min(kh.first, kh.second), 0, 5, 0);
     MiniRecord mr3(0, p, 0, 0);
     mhits.add_hit(1, m3, mr3);
-    EXPECT_EQ((uint) 3, mhits.hits.size());
+    EXPECT_EQ((uint)3, mhits.hits.size());
 
-    d = {Interval(6, 10), Interval(11, 12)};
+    d = { Interval(6, 10), Interval(11, 12) };
     p.initialize(d);
     Minimizer m4(min(kh.first, kh.second), 0, 5, 0);
     MiniRecord mr4(0, p, 0, 0);
     mhits.add_hit(1, m4, mr4);
-    EXPECT_EQ((uint) 4, mhits.hits.size());
+    EXPECT_EQ((uint)4, mhits.hits.size());
 
-    d = {Interval(6, 10), Interval(12, 13)};
+    d = { Interval(6, 10), Interval(12, 13) };
     p.initialize(d);
     Minimizer m5(min(kh.first, kh.second), 0, 5, 0);
     MiniRecord mr5(0, p, 0, 0);
     mhits.add_hit(1, m5, mr5);
-    EXPECT_EQ((uint) 5, mhits.hits.size());
+    EXPECT_EQ((uint)5, mhits.hits.size());
 
     uint32_t j(5);
     EXPECT_EQ(j, mhits.hits.size());
 }
 
-TEST(MinimizerHitsTest, pComp) {
+TEST(MinimizerHitsTest, pComp)
+{
     MinimizerHits mhits;
     vector<MinimizerHit> expected;
     KmerHash hash;
     pair<uint64_t, uint64_t> kh = hash.kmerhash("ACGTA", 5);
-    deque<Interval> d = {Interval(7, 8), Interval(10, 14)};
+    deque<Interval> d = { Interval(7, 8), Interval(10, 14) };
     prg::Path p;
     p.initialize(d);
 
@@ -71,34 +72,36 @@ TEST(MinimizerHitsTest, pComp) {
     expected.push_back(MinimizerHit(0, m1, mr1));
 
     Minimizer m2(min(kh.first, kh.second), 0, 5, 0);
-    d = {Interval(6, 10), Interval(11, 12)};
+    d = { Interval(6, 10), Interval(11, 12) };
     p.initialize(d);
     MiniRecord mr2(0, p, 0, 0);
     mhits.add_hit(1, m2, mr2);
     expected.push_back(MinimizerHit(1, m2, mr2));
 
     Minimizer m3(min(kh.first, kh.second), 0, 5, 0);
-    d = {Interval(6, 10), Interval(12, 13)};
+    d = { Interval(6, 10), Interval(12, 13) };
     p.initialize(d);
     MiniRecord mr3(0, p, 0, 0);
     mhits.add_hit(1, m3, mr3);
     expected.push_back(MinimizerHit(1, m3, mr3));
 
     uint32_t j(1);
-    for (set<MinimizerHitPtr, pComp>::iterator it = mhits.hits.begin(); it != --mhits.hits.end(); ++it) {
+    for (set<MinimizerHitPtr, pComp>::iterator it = mhits.hits.begin();
+         it != --mhits.hits.end(); ++it) {
         EXPECT_EQ(expected[j], **it);
         j++;
     }
     EXPECT_EQ(expected[0], **(--mhits.hits.end()));
 }
 
-TEST(MinimizerHitsTest, pComp_path) {
+TEST(MinimizerHitsTest, pComp_path)
+{
     set<MinimizerHitPtr, pComp_path> mhitspath;
     MinimizerHits mhits;
     deque<MinimizerHit> expected;
     KmerHash hash;
     pair<uint64_t, uint64_t> kh = hash.kmerhash("ACGTA", 5);
-    deque<Interval> d = {Interval(7, 8), Interval(10, 14)};
+    deque<Interval> d = { Interval(7, 8), Interval(10, 14) };
     prg::Path p;
     p.initialize(d);
 
@@ -109,47 +112,48 @@ TEST(MinimizerHitsTest, pComp_path) {
     mhits.add_hit(1, m1, mr1);
     expected.push_back(MinimizerHit(1, m1, mr1));
 
-
     Minimizer m2(min(kh.first, kh.second), 0, 5, 0);
     MiniRecord mr2(0, p, 0, 0);
     mhits.add_hit(2, m2, mr2);
     expected.push_back(MinimizerHit(2, m2, mr2));
 
-    d = {Interval(6, 10), Interval(12, 13)};
+    d = { Interval(6, 10), Interval(12, 13) };
     p.initialize(d);
     Minimizer m3(min(kh.first, kh.second), 0, 5, 0);
     MiniRecord mr3(0, p, 0, 0);
     mhits.add_hit(1, m3, mr3);
     expected.push_front(MinimizerHit(1, m3, mr3));
 
-    d = {Interval(6, 10), Interval(11, 12)};
+    d = { Interval(6, 10), Interval(11, 12) };
     p.initialize(d);
     Minimizer m4(min(kh.first, kh.second), 0, 5, 0);
     MiniRecord mr4(0, p, 0, 0);
     mhits.add_hit(1, m4, mr4);
     expected.push_front(MinimizerHit(1, m4, mr4));
 
-    for (set<MinimizerHitPtr, pComp>::iterator it = mhits.hits.begin(); it != --mhits.hits.end(); ++it) {
+    for (set<MinimizerHitPtr, pComp>::iterator it = mhits.hits.begin();
+         it != --mhits.hits.end(); ++it) {
         mhitspath.insert(*it);
     }
     uint32_t j(0);
-    for (set<MinimizerHitPtr, pComp_path>::iterator it = mhitspath.begin(); it != mhitspath.end(); ++it) {
+    for (set<MinimizerHitPtr, pComp_path>::iterator it = mhitspath.begin();
+         it != mhitspath.end(); ++it) {
         EXPECT_EQ(expected[j], **it);
         j++;
     }
 }
 
-TEST(MinimizerHitsTest, clusterComp) {
+TEST(MinimizerHitsTest, clusterComp)
+{
     set<set<MinimizerHitPtr, pComp>, clusterComp> clusters_of_hits;
     set<MinimizerHitPtr, pComp> current_cluster;
     vector<MinimizerHitPtr> expected1, expected2;
 
     KmerHash hash;
     pair<uint64_t, uint64_t> kh = hash.kmerhash("ACGTA", 5);
-    deque<Interval> d = {Interval(7, 8), Interval(10, 14)};
+    deque<Interval> d = { Interval(7, 8), Interval(10, 14) };
     prg::Path p;
     p.initialize(d);
-
 
     Minimizer m1(min(kh.first, kh.second), 1, 6, 0);
     MiniRecord mr1(0, p, 0, 0);
@@ -169,7 +173,7 @@ TEST(MinimizerHitsTest, clusterComp) {
     current_cluster.insert(mh);
     expected2.push_back(mh);
 
-    d = {Interval(6, 10), Interval(11, 12)};
+    d = { Interval(6, 10), Interval(11, 12) };
     p.initialize(d);
     Minimizer m3(min(kh.first, kh.second), 0, 5, 0);
     MiniRecord mr3(0, p, 0, 0);
@@ -177,7 +181,7 @@ TEST(MinimizerHitsTest, clusterComp) {
     current_cluster.insert(mh);
     expected2.push_back(mh);
 
-    d = {Interval(6, 10), Interval(12, 13)};
+    d = { Interval(6, 10), Interval(12, 13) };
     p.initialize(d);
     Minimizer m4(min(kh.first, kh.second), 0, 5, 0);
     MiniRecord mr4(0, p, 0, 0);
@@ -195,9 +199,12 @@ TEST(MinimizerHitsTest, clusterComp) {
     EXPECT_EQ(j, clusters_of_hits.begin()->size());
 
     // check that this is indeed the cluster we think
-    // note that can't sort the set of hits by pcomp without changing the defintion of cluster comparison function
+    // note that can't sort the set of hits by pcomp without changing the defintion of
+    // cluster comparison function
     for (set<MinimizerHitPtr, pComp>::iterator it = clusters_of_hits.begin()->begin();
          it != clusters_of_hits.begin()->end(); ++it) {
-        EXPECT_EQ(((*expected2[0] == **it) or (*expected2[1] == **it) or (*expected2[2] == **it)), true);
+        EXPECT_EQ(((*expected2[0] == **it) or (*expected2[1] == **it)
+                      or (*expected2[2] == **it)),
+            true);
     }
 }

--- a/test/minimizer_test.cpp
+++ b/test/minimizer_test.cpp
@@ -1,14 +1,13 @@
 //#include <limits.h>
-#include "gtest/gtest.h"
-#include "minimizer.h"
-#include "prg/path.h"
 #include "interval.h"
 #include "inthash.h"
-#include <set>
-#include <vector>
-#include <stdint.h>
+#include "minimizer.h"
+#include "prg/path.h"
+#include "gtest/gtest.h"
 #include <iostream>
-
+#include <set>
+#include <stdint.h>
+#include <vector>
 
 using std::set;
 using namespace std;
@@ -19,7 +18,8 @@ class Path;
 
 struct Minimizer;
 
-TEST(MinimizerTest, create) {
+TEST(MinimizerTest, create)
+{
     KmerHash hash;
     pair<uint64_t, uint64_t> kh = hash.kmerhash("ACGTA", 5);
     Minimizer m1(kh.first, 0, 5, 0);
@@ -47,11 +47,13 @@ TEST(MinimizerTest, create) {
     EXPECT_EQ(m3.pos_of_kmer_in_read.get_end(), j);
 
     EXPECT_DEATH(Minimizer(kh.first, 0, 2, 0), ""); // interval too short to be valid
-    //EXPECT_DEATH(Minimizer(kh.first, 0,8,0),""); // interval too long to be valid
-    EXPECT_DEATH(Minimizer(kh.first, 2, 0, 0), ""); // doesn't generate an interval as 2>0
+    // EXPECT_DEATH(Minimizer(kh.first, 0,8,0),""); // interval too long to be valid
+    EXPECT_DEATH(
+        Minimizer(kh.first, 2, 0, 0), ""); // doesn't generate an interval as 2>0
 }
 
-TEST(MinimizerTest, less_than) {
+TEST(MinimizerTest, less_than)
+{
     KmerHash hash;
     pair<uint64_t, uint64_t> kh1 = hash.kmerhash("AGGTG", 5);
     Minimizer m1(kh1.first, 0, 5, 0);
@@ -70,22 +72,29 @@ TEST(MinimizerTest, less_than) {
     s.insert(m5);
 
     uint32_t j = 5;
-    EXPECT_EQ(s.size(), j) << "size of set of minimizers " << s.size() << " is not equal to 5.";
+    EXPECT_EQ(s.size(), j) << "size of set of minimizers " << s.size()
+                           << " is not equal to 5.";
 
-    // note this is a bad test as need to know the order of hash.kmerhash values to set this up
-    vector<Minimizer> v = {m4, m2, m5, m1, m3};
+    // note this is a bad test as need to know the order of hash.kmerhash values to set
+    // this up
+    vector<Minimizer> v = { m4, m2, m5, m1, m3 };
     int i = 0;
     for (std::set<Minimizer>::iterator it = s.begin(); it != s.end(); ++it) {
-        EXPECT_EQ(it->canonical_kmer_hash, v[i].canonical_kmer_hash) << "for i " << i << " kmers do not agree: " << it->canonical_kmer_hash << ", " << v[i].canonical_kmer_hash;
+        EXPECT_EQ(it->canonical_kmer_hash, v[i].canonical_kmer_hash)
+            << "for i " << i << " kmers do not agree: " << it->canonical_kmer_hash
+            << ", " << v[i].canonical_kmer_hash;
         EXPECT_EQ(it->pos_of_kmer_in_read.start, v[i].pos_of_kmer_in_read.start)
-                            << "start positions do not agree: " << it->pos_of_kmer_in_read.start << ", " << v[i].pos_of_kmer_in_read.start;
+            << "start positions do not agree: " << it->pos_of_kmer_in_read.start << ", "
+            << v[i].pos_of_kmer_in_read.start;
         EXPECT_EQ(it->pos_of_kmer_in_read.get_end(), v[i].pos_of_kmer_in_read.get_end())
-                            << "end positions do not agree: " << it->pos_of_kmer_in_read.get_end() << ", " << v[i].pos_of_kmer_in_read.get_end();
+            << "end positions do not agree: " << it->pos_of_kmer_in_read.get_end()
+            << ", " << v[i].pos_of_kmer_in_read.get_end();
         ++i;
     }
 }
 
-TEST(MinimizerTest, equals) {
+TEST(MinimizerTest, equals)
+{
     KmerHash hash;
     pair<uint64_t, uint64_t> kh1 = hash.kmerhash("AGGTG", 5);
     Minimizer m1(kh1.first, 0, 5, 0);

--- a/test/minirecord_test.cpp
+++ b/test/minirecord_test.cpp
@@ -1,17 +1,17 @@
-#include "gtest/gtest.h"
 #include "minirecord.h"
 #include "prg/path.h"
-#include <stdint.h>
+#include "gtest/gtest.h"
 #include <iostream>
-
+#include <stdint.h>
 
 using namespace std;
 
-TEST(MiniRecordTest, create) {
-    deque<Interval> v1 = {Interval(0, 5)};
-    deque<Interval> v2 = {Interval(1, 4), Interval(15, 17)};
-    deque<Interval> v3 = {Interval(1, 6)};
-    deque<Interval> v4 = {Interval(0, 3), Interval(16, 18)};
+TEST(MiniRecordTest, create)
+{
+    deque<Interval> v1 = { Interval(0, 5) };
+    deque<Interval> v2 = { Interval(1, 4), Interval(15, 17) };
+    deque<Interval> v3 = { Interval(1, 6) };
+    deque<Interval> v4 = { Interval(0, 3), Interval(16, 18) };
 
     prg::Path p;
     p.initialize(v1);
@@ -36,11 +36,12 @@ TEST(MiniRecordTest, create) {
     EXPECT_EQ(p, m4.path);
 }
 
-TEST(MiniRecordTest, equals) {
-    deque<Interval> v1 = {Interval(0, 5)};
-    deque<Interval> v2 = {Interval(1, 4), Interval(15, 17)};
-    deque<Interval> v3 = {Interval(1, 6)};
-    deque<Interval> v4 = {Interval(0, 3), Interval(16, 18)};
+TEST(MiniRecordTest, equals)
+{
+    deque<Interval> v1 = { Interval(0, 5) };
+    deque<Interval> v2 = { Interval(1, 4), Interval(15, 17) };
+    deque<Interval> v3 = { Interval(1, 6) };
+    deque<Interval> v4 = { Interval(0, 3), Interval(16, 18) };
 
     prg::Path p;
     p.initialize(v1);
@@ -62,9 +63,10 @@ TEST(MiniRecordTest, equals) {
     EXPECT_EQ((m3 == m4), false);
 }
 
-TEST(MiniRecordTest, write) {
+TEST(MiniRecordTest, write)
+{
     deque<Interval> d;
-    d = {Interval(1, 3), Interval(4, 5), Interval(6, 6), Interval(9, 40)};
+    d = { Interval(1, 3), Interval(4, 5), Interval(6, 6), Interval(9, 40) };
     prg::Path p;
     p.initialize(d);
     MiniRecord mr(1, p, 0, 0);
@@ -74,9 +76,10 @@ TEST(MiniRecordTest, write) {
     EXPECT_EQ(out.str(), "(1, 4{[1, 3)[4, 5)[6, 6)[9, 40)}, 0, 0)");
 }
 
-TEST(MiniRecordTest, read) {
+TEST(MiniRecordTest, read)
+{
     deque<Interval> d;
-    d = {Interval(1, 3), Interval(4, 5), Interval(6, 6), Interval(9, 40)};
+    d = { Interval(1, 3), Interval(4, 5), Interval(6, 6), Interval(9, 40) };
     prg::Path p;
     p.initialize(d);
     MiniRecord mr1(1, p, 0, 0), mr2;

--- a/test/noise_filtering_test.cpp
+++ b/test/noise_filtering_test.cpp
@@ -1,263 +1,287 @@
-#include "gtest/gtest.h"
-#include "test_macro.cpp"
-#include "noise_filtering.h"
-#include "pangenome_graph_class.h"
-#include "pangenome/panread.h"
-#include "pangenome/pannode.h"
 #include "minihit.h"
-
+#include "noise_filtering.h"
+#include "pangenome/pannode.h"
+#include "pangenome/panread.h"
+#include "pangenome_graph_class.h"
+#include "test_macro.cpp"
+#include "gtest/gtest.h"
 
 using namespace std;
 
-TEST(NoiseFilteringTest, node_plus_orientation_to_num) {
-    EXPECT_EQ((uint_least32_t) 0, node_plus_orientation_to_num(0, false));
-    EXPECT_EQ((uint_least32_t) 1, node_plus_orientation_to_num(0, true));
-    EXPECT_EQ((uint_least32_t) 2, node_plus_orientation_to_num(1, false));
-    EXPECT_EQ((uint_least32_t) 3, node_plus_orientation_to_num(1, true));
+TEST(NoiseFilteringTest, node_plus_orientation_to_num)
+{
+    EXPECT_EQ((uint_least32_t)0, node_plus_orientation_to_num(0, false));
+    EXPECT_EQ((uint_least32_t)1, node_plus_orientation_to_num(0, true));
+    EXPECT_EQ((uint_least32_t)2, node_plus_orientation_to_num(1, false));
+    EXPECT_EQ((uint_least32_t)3, node_plus_orientation_to_num(1, true));
 }
 
-TEST(NoiseFilteringTest, num_to_node_plus_orientation) {
+TEST(NoiseFilteringTest, num_to_node_plus_orientation)
+{
     uint_least32_t node_id;
     bool node_orientation;
 
     num_to_node_plus_orientation(node_id, node_orientation, 0);
-    EXPECT_EQ((uint_least32_t) 0, node_id);
+    EXPECT_EQ((uint_least32_t)0, node_id);
     EXPECT_EQ(node_orientation, false);
 
     num_to_node_plus_orientation(node_id, node_orientation, 1);
-    EXPECT_EQ((uint_least32_t) 0, node_id);
+    EXPECT_EQ((uint_least32_t)0, node_id);
     EXPECT_EQ(node_orientation, true);
 
     num_to_node_plus_orientation(node_id, node_orientation, 2);
-    EXPECT_EQ((uint_least32_t) 1, node_id);
+    EXPECT_EQ((uint_least32_t)1, node_id);
     EXPECT_EQ(node_orientation, false);
 
     num_to_node_plus_orientation(node_id, node_orientation, 3);
-    EXPECT_EQ((uint_least32_t) 1, node_id);
+    EXPECT_EQ((uint_least32_t)1, node_id);
     EXPECT_EQ(node_orientation, true);
 }
 
-TEST(NoiseFilteringTest, rc_num) {
-    EXPECT_EQ(node_plus_orientation_to_num(0, false), rc_num(node_plus_orientation_to_num(0, true)));
-    EXPECT_EQ(node_plus_orientation_to_num(0, true), rc_num(node_plus_orientation_to_num(0, false)));
-    EXPECT_EQ(node_plus_orientation_to_num(1, false), rc_num(node_plus_orientation_to_num(1, true)));
-    EXPECT_EQ(node_plus_orientation_to_num(1, true), rc_num(node_plus_orientation_to_num(1, false)));
-    EXPECT_EQ(node_plus_orientation_to_num(2, false), rc_num(node_plus_orientation_to_num(2, true)));
-    EXPECT_EQ(node_plus_orientation_to_num(2, true), rc_num(node_plus_orientation_to_num(2, false)));
+TEST(NoiseFilteringTest, rc_num)
+{
+    EXPECT_EQ(node_plus_orientation_to_num(0, false),
+        rc_num(node_plus_orientation_to_num(0, true)));
+    EXPECT_EQ(node_plus_orientation_to_num(0, true),
+        rc_num(node_plus_orientation_to_num(0, false)));
+    EXPECT_EQ(node_plus_orientation_to_num(1, false),
+        rc_num(node_plus_orientation_to_num(1, true)));
+    EXPECT_EQ(node_plus_orientation_to_num(1, true),
+        rc_num(node_plus_orientation_to_num(1, false)));
+    EXPECT_EQ(node_plus_orientation_to_num(2, false),
+        rc_num(node_plus_orientation_to_num(2, true)));
+    EXPECT_EQ(node_plus_orientation_to_num(2, true),
+        rc_num(node_plus_orientation_to_num(2, false)));
 }
 
-TEST(NoiseFilteringTest, hashed_node_ids_to_ids_and_orientations) {
-    std::deque<uint_least32_t> d = {3, 1, 2, 0};
+TEST(NoiseFilteringTest, hashed_node_ids_to_ids_and_orientations)
+{
+    std::deque<uint_least32_t> d = { 3, 1, 2, 0 };
     vector<uint_least32_t> v;
-    vector<uint_least32_t> v_exp = {1, 0, 1, 0};
+    vector<uint_least32_t> v_exp = { 1, 0, 1, 0 };
     vector<bool> b;
-    vector<bool> b_exp = {true, true, false, false};
+    vector<bool> b_exp = { true, true, false, false };
 
     hashed_node_ids_to_ids_and_orientations(d, v, b);
     EXPECT_ITERABLE_EQ(vector<uint_least32_t>, v_exp, v);
     EXPECT_ITERABLE_EQ(vector<bool>, b_exp, b);
 }
 
-TEST(NoiseFilteringOverlapForwards, SimpleCase_True) {
-    std::deque<uint_least32_t> d1 = {0, 1, 2};
-    std::deque<uint_least32_t> d2 = {1, 2, 3};
+TEST(NoiseFilteringOverlapForwards, SimpleCase_True)
+{
+    std::deque<uint_least32_t> d1 = { 0, 1, 2 };
+    std::deque<uint_least32_t> d2 = { 1, 2, 3 };
     bool result = overlap_forwards(d1, d2);
     EXPECT_TRUE(result);
     result = overlap_forwards(d2, d1);
     EXPECT_FALSE(result);
 }
 
-TEST(NoiseFilteringOverlapForwards, SimpleCase_False) {
-    std::deque<uint_least32_t> d1 = {0, 1, 2};
-    std::deque<uint_least32_t> d2 = {1, 2, 3};
+TEST(NoiseFilteringOverlapForwards, SimpleCase_False)
+{
+    std::deque<uint_least32_t> d1 = { 0, 1, 2 };
+    std::deque<uint_least32_t> d2 = { 1, 2, 3 };
     bool result = overlap_forwards(d2, d1);
     EXPECT_FALSE(result);
 }
 
-TEST(NoiseFilteringOverlapForwards, FirstLongerThanSecond_True) {
-    std::deque<uint_least32_t> d1 = {0, 4, 6, 2, 5, 4, 0, 1, 2};
-    std::deque<uint_least32_t> d2 = {1, 2, 3};
+TEST(NoiseFilteringOverlapForwards, FirstLongerThanSecond_True)
+{
+    std::deque<uint_least32_t> d1 = { 0, 4, 6, 2, 5, 4, 0, 1, 2 };
+    std::deque<uint_least32_t> d2 = { 1, 2, 3 };
     bool result = overlap_forwards(d1, d2);
     EXPECT_TRUE(result);
 }
 
-TEST(NoiseFilteringOverlapForwards, OverlapShiftedMoreThanOne_False) {
-    std::deque<uint_least32_t> d1 = {0, 4, 6, 2, 5, 4, 0, 1, 2};
-    std::deque<uint_least32_t> d2 = {1, 2, 3, 4};
+TEST(NoiseFilteringOverlapForwards, OverlapShiftedMoreThanOne_False)
+{
+    std::deque<uint_least32_t> d1 = { 0, 4, 6, 2, 5, 4, 0, 1, 2 };
+    std::deque<uint_least32_t> d2 = { 1, 2, 3, 4 };
     bool result = overlap_forwards(d1, d2);
     EXPECT_FALSE(result);
 }
 
-TEST(NoiseFilteringOverlapForwards, SecondLongerThanFirst_Death) {
-    std::deque<uint_least32_t> d1 = {0, 4, 6, 2, 5, 4, 0, 1, 2};
-    std::deque<uint_least32_t> d2 = {0, 4, 6, 2, 5, 4, 0, 1, 2, 3};
+TEST(NoiseFilteringOverlapForwards, SecondLongerThanFirst_Death)
+{
+    std::deque<uint_least32_t> d1 = { 0, 4, 6, 2, 5, 4, 0, 1, 2 };
+    std::deque<uint_least32_t> d2 = { 0, 4, 6, 2, 5, 4, 0, 1, 2, 3 };
     EXPECT_DEATH(overlap_forwards(d1, d2), "");
 }
 
-TEST(NoiseFilteringTest, overlap_backwards) {
-    std::deque<uint_least32_t> d1 = {0, 1, 2};
-    std::deque<uint_least32_t> d2 = {1, 2, 3};
+TEST(NoiseFilteringTest, overlap_backwards)
+{
+    std::deque<uint_least32_t> d1 = { 0, 1, 2 };
+    std::deque<uint_least32_t> d2 = { 1, 2, 3 };
     EXPECT_EQ(overlap_backwards(d2, d1), true);
     EXPECT_EQ(overlap_backwards(d1, d2), false);
     EXPECT_EQ(overlap_backwards(d1, d1), false);
     EXPECT_EQ(overlap_backwards(d2, d2), false);
 
     // works when d1 longer than d2
-    d1 = {0, 4, 6, 2, 5, 4, 0, 1, 2};
-    d2 = {1, 0, 4};
+    d1 = { 0, 4, 6, 2, 5, 4, 0, 1, 2 };
+    d2 = { 1, 0, 4 };
     EXPECT_EQ(overlap_backwards(d1, d2), true);
     EXPECT_EQ(overlap_backwards(d1, d1), false);
     EXPECT_EQ(overlap_backwards(d2, d2), false);
 
-
     // if overlap > 1 then is false
-    d2 = {1, 2, 0, 4};
+    d2 = { 1, 2, 0, 4 };
     EXPECT_EQ(overlap_backwards(d1, d2), false);
     EXPECT_EQ(overlap_backwards(d2, d2), false);
 
     // if d2 longer than d1, should still work?
-    d2 = {3, 0, 4, 6, 2, 5, 4, 0, 1, 2, 4, 6};
+    d2 = { 3, 0, 4, 6, 2, 5, 4, 0, 1, 2, 4, 6 };
     EXPECT_EQ(overlap_backwards(d1, d2), true);
 }
 
-TEST(NoiseFilteringTest, rc_hashed_node_ids) {
-    std::deque<uint_least32_t> d1 = {0, 1, 2, 5, 9, 10, 46, 322, 6779};
-    std::deque<uint_least32_t> d2 = {6778, 323, 47, 11, 8, 4, 3, 0, 1};
+TEST(NoiseFilteringTest, rc_hashed_node_ids)
+{
+    std::deque<uint_least32_t> d1 = { 0, 1, 2, 5, 9, 10, 46, 322, 6779 };
+    std::deque<uint_least32_t> d2 = { 6778, 323, 47, 11, 8, 4, 3, 0, 1 };
     EXPECT_ITERABLE_EQ(std::deque<uint_least32_t>, d1, rc_hashed_node_ids(d2));
     EXPECT_ITERABLE_EQ(std::deque<uint_least32_t>, d2, rc_hashed_node_ids(d1));
 }
 
-TEST(NoiseFilteringDbgNodeIdsToIdsAndOrientations, AllNodesOverlapForward_ConvertCorrectly) {
+TEST(NoiseFilteringDbgNodeIdsToIdsAndOrientations,
+    AllNodesOverlapForward_ConvertCorrectly)
+{
     uint32_t read_id = 0;
 
     debruijn::Graph dbg(3);
-    std::deque<uint_least32_t> d = {0, 2, 6};
+    std::deque<uint_least32_t> d = { 0, 2, 6 };
     dbg.add_node(d, read_id);
-    d = {2, 6, 11};
+    d = { 2, 6, 11 };
     dbg.add_node(d, read_id);
-    d = {6, 11, 12};
+    d = { 6, 11, 12 };
     dbg.add_node(d, read_id);
-    d = {11, 12, 198};
+    d = { 11, 12, 198 };
     dbg.add_node(d, read_id);
-    d = {12, 198, 60};
+    d = { 12, 198, 60 };
     dbg.add_node(d, read_id);
-    d = {198, 60, 6};
+    d = { 198, 60, 6 };
     dbg.add_node(d, read_id);
 
-    std::deque<uint32_t> tig = {0, 1, 2, 3, 4, 5};
+    std::deque<uint32_t> tig = { 0, 1, 2, 3, 4, 5 };
     vector<uint_least32_t> node_ids;
     vector<bool> node_orients;
     dbg_node_ids_to_ids_and_orientations(dbg, tig, node_ids, node_orients);
 
-    vector<uint_least32_t> exp = {0, 1, 3, 5, 6, 99, 30, 3};
-    vector<bool> exp_o = {0, 0, 0, 1, 0, 0, 0, 0};
+    vector<uint_least32_t> exp = { 0, 1, 3, 5, 6, 99, 30, 3 };
+    vector<bool> exp_o = { 0, 0, 0, 1, 0, 0, 0, 0 };
     EXPECT_ITERABLE_EQ(vector<uint_least32_t>, exp, node_ids);
     EXPECT_ITERABLE_EQ(vector<bool>, exp_o, node_orients);
 }
 
-TEST(NoiseFilteringDbgNodeIdsToIdsAndOrientations, AllNodesOverlapBackward_ConvertCorrectly) {
+TEST(NoiseFilteringDbgNodeIdsToIdsAndOrientations,
+    AllNodesOverlapBackward_ConvertCorrectly)
+{
     uint32_t read_id = 0;
 
     debruijn::Graph dbg(3);
-    std::deque<uint_least32_t> d = {0, 2, 6};
+    std::deque<uint_least32_t> d = { 0, 2, 6 };
     dbg.add_node(d, read_id);
-    d = {2, 6, 11};
+    d = { 2, 6, 11 };
     dbg.add_node(d, read_id);
-    d = {6, 11, 12};
+    d = { 6, 11, 12 };
     dbg.add_node(d, read_id);
-    d = {11, 12, 198};
+    d = { 11, 12, 198 };
     dbg.add_node(d, read_id);
-    d = {12, 198, 60};
+    d = { 12, 198, 60 };
     dbg.add_node(d, read_id);
-    d = {198, 60, 6};
+    d = { 198, 60, 6 };
     dbg.add_node(d, read_id);
 
-    std::deque<uint32_t> tig = {5, 4, 3, 2, 1, 0};
+    std::deque<uint32_t> tig = { 5, 4, 3, 2, 1, 0 };
     vector<uint_least32_t> node_ids;
     vector<bool> node_orients;
     dbg_node_ids_to_ids_and_orientations(dbg, tig, node_ids, node_orients);
 
-    vector<uint_least32_t> exp = {0, 1, 3, 5, 6, 99, 30, 3};
-    vector<bool> exp_o = {0, 0, 0, 1, 0, 0, 0, 0};
+    vector<uint_least32_t> exp = { 0, 1, 3, 5, 6, 99, 30, 3 };
+    vector<bool> exp_o = { 0, 0, 0, 1, 0, 0, 0, 0 };
     EXPECT_ITERABLE_EQ(vector<uint_least32_t>, exp, node_ids);
     EXPECT_ITERABLE_EQ(vector<bool>, exp_o, node_orients);
 }
 
-TEST(NoiseFilteringDbgNodeIdsToIdsAndOrientations, OverlapForwardsSomeReverseComplement_ConvertCorrectly) {
-
-    debruijn::Graph dbg(3);
-
-    // read 0 0->1->3->5->6
-    //        0  0  0  1  0
-    uint32_t read_id = 0;
-    std::deque<uint_least32_t> d = {0, 2, 6};
-    dbg.add_node(d, read_id);
-    d = {2, 6, 11};
-    dbg.add_node(d, read_id);
-    d = {6, 11, 12};
-    dbg.add_node(d, read_id);
-
-    // read 1 3->30->99->6->5->3
-    //        0  0   1   1  0  1
-    read_id = 1;
-    d = {6, 60, 199};
-    dbg.add_node(d, read_id);
-    d = {60, 199, 13};
-    dbg.add_node(d, read_id);
-    d = {199, 13, 10};
-    dbg.add_node(d, read_id);
-    d = {13, 10, 7};
-    dbg.add_node(d, read_id);
-
-    std::deque<uint32_t> tig = {0, 1, 2, 5, 4, 3};
-    vector<uint_least32_t> node_ids;
-    vector<bool> node_orients;
-    dbg_node_ids_to_ids_and_orientations(dbg, tig, node_ids, node_orients);
-
-    vector<uint_least32_t> exp = {0, 1, 3, 5, 6, 99, 30, 3};
-    vector<bool> exp_o = {0, 0, 0, 1, 0, 0, 1, 1};
-    EXPECT_ITERABLE_EQ(vector<uint_least32_t>, exp, node_ids);
-    EXPECT_ITERABLE_EQ(vector<bool>, exp_o, node_orients);
-}
-
-TEST(NoiseFilteringDbgNodeIdsToIdsAndOrientations, OverlapBackwardsSomeReverseComplement_ConvertCorrectly) {
+TEST(NoiseFilteringDbgNodeIdsToIdsAndOrientations,
+    OverlapForwardsSomeReverseComplement_ConvertCorrectly)
+{
 
     debruijn::Graph dbg(3);
 
     // read 0 0->1->3->5->6
     //        0  0  0  1  0
     uint32_t read_id = 0;
-    std::deque<uint_least32_t> d = {0, 2, 6};
+    std::deque<uint_least32_t> d = { 0, 2, 6 };
     dbg.add_node(d, read_id);
-    d = {2, 6, 11};
+    d = { 2, 6, 11 };
     dbg.add_node(d, read_id);
-    d = {6, 11, 12};
+    d = { 6, 11, 12 };
     dbg.add_node(d, read_id);
 
     // read 1 3->30->99->6->5->3
     //        0  0   1   1  0  1
     read_id = 1;
-    d = {6, 60, 199};
+    d = { 6, 60, 199 };
     dbg.add_node(d, read_id);
-    d = {60, 199, 13};
+    d = { 60, 199, 13 };
     dbg.add_node(d, read_id);
-    d = {199, 13, 10};
+    d = { 199, 13, 10 };
     dbg.add_node(d, read_id);
-    d = {13, 10, 7};
+    d = { 13, 10, 7 };
     dbg.add_node(d, read_id);
 
-    std::deque<uint32_t> tig = {3, 4, 5, 2, 1, 0};
+    std::deque<uint32_t> tig = { 0, 1, 2, 5, 4, 3 };
     vector<uint_least32_t> node_ids;
     vector<bool> node_orients;
     dbg_node_ids_to_ids_and_orientations(dbg, tig, node_ids, node_orients);
 
-    vector<uint_least32_t> exp = {3, 30, 99, 6, 5, 3, 1, 0};
-    vector<bool> exp_o = {0, 0, 1, 1, 0, 1, 1, 1};
+    vector<uint_least32_t> exp = { 0, 1, 3, 5, 6, 99, 30, 3 };
+    vector<bool> exp_o = { 0, 0, 0, 1, 0, 0, 1, 1 };
     EXPECT_ITERABLE_EQ(vector<uint_least32_t>, exp, node_ids);
     EXPECT_ITERABLE_EQ(vector<bool>, exp_o, node_orients);
 }
 
-TEST(NoiseFilteringTest, construct_debruijn_graph) {
+TEST(NoiseFilteringDbgNodeIdsToIdsAndOrientations,
+    OverlapBackwardsSomeReverseComplement_ConvertCorrectly)
+{
+
+    debruijn::Graph dbg(3);
+
+    // read 0 0->1->3->5->6
+    //        0  0  0  1  0
+    uint32_t read_id = 0;
+    std::deque<uint_least32_t> d = { 0, 2, 6 };
+    dbg.add_node(d, read_id);
+    d = { 2, 6, 11 };
+    dbg.add_node(d, read_id);
+    d = { 6, 11, 12 };
+    dbg.add_node(d, read_id);
+
+    // read 1 3->30->99->6->5->3
+    //        0  0   1   1  0  1
+    read_id = 1;
+    d = { 6, 60, 199 };
+    dbg.add_node(d, read_id);
+    d = { 60, 199, 13 };
+    dbg.add_node(d, read_id);
+    d = { 199, 13, 10 };
+    dbg.add_node(d, read_id);
+    d = { 13, 10, 7 };
+    dbg.add_node(d, read_id);
+
+    std::deque<uint32_t> tig = { 3, 4, 5, 2, 1, 0 };
+    vector<uint_least32_t> node_ids;
+    vector<bool> node_orients;
+    dbg_node_ids_to_ids_and_orientations(dbg, tig, node_ids, node_orients);
+
+    vector<uint_least32_t> exp = { 3, 30, 99, 6, 5, 3, 1, 0 };
+    vector<bool> exp_o = { 0, 0, 1, 1, 0, 1, 1, 1 };
+    EXPECT_ITERABLE_EQ(vector<uint_least32_t>, exp, node_ids);
+    EXPECT_ITERABLE_EQ(vector<bool>, exp_o, node_orients);
+}
+
+TEST(NoiseFilteringTest, construct_debruijn_graph)
+{
     set<MinimizerHitPtr, pComp> dummy_cluster;
 
     auto pangraph = std::make_shared<pangenome::Graph>(pangenome::Graph());
@@ -318,70 +342,71 @@ TEST(NoiseFilteringTest, construct_debruijn_graph) {
     construct_debruijn_graph(pangraph, dbg);
 
     debruijn::Graph dbg_exp(3);
-    std::deque<uint_least32_t> d = {0, 2, 4};
+    std::deque<uint_least32_t> d = { 0, 2, 4 };
     debruijn::OrientedNodePtr n1 = dbg_exp.add_node(d, 0);
-    d = {2, 4, 6};
+    d = { 2, 4, 6 };
     debruijn::OrientedNodePtr n2 = dbg_exp.add_node(d, 0);
     dbg_exp.add_edge(n1, n2);
-    d = {4, 6, 8};
+    d = { 4, 6, 8 };
     n1 = dbg_exp.add_node(d, 0);
     dbg_exp.add_edge(n2, n1);
-    d = {6, 8, 10};
+    d = { 6, 8, 10 };
     n2 = dbg_exp.add_node(d, 0);
     dbg_exp.add_edge(n1, n2);
 
-    d = {6, 8, 10};
+    d = { 6, 8, 10 };
     n2 = dbg_exp.add_node(d, 1);
-    d = {8, 10, 0};
+    d = { 8, 10, 0 };
     n1 = dbg_exp.add_node(d, 1);
     dbg_exp.add_edge(n2, n1);
-    d = {10, 0, 2};
+    d = { 10, 0, 2 };
     n2 = dbg_exp.add_node(d, 1);
     dbg_exp.add_edge(n1, n2);
-    d = {0, 2, 4};
+    d = { 0, 2, 4 };
     n1 = dbg_exp.add_node(d, 1);
     dbg_exp.add_edge(n2, n1);
 
-    d = {2, 4, 6};
+    d = { 2, 4, 6 };
     n1 = dbg_exp.add_node(d, 2);
-    d = {4, 6, 14};
+    d = { 4, 6, 14 };
     n2 = dbg_exp.add_node(d, 2);
     dbg_exp.add_edge(n1, n2);
 
-    d = {0, 12, 6};
+    d = { 0, 12, 6 };
     n1 = dbg_exp.add_node(d, 3);
-    d = {12, 6, 8};
+    d = { 12, 6, 8 };
     n2 = dbg_exp.add_node(d, 3);
     dbg_exp.add_edge(n1, n2);
 
-    d = {0, 2, 4};
+    d = { 0, 2, 4 };
     n1 = dbg_exp.add_node(d, 4);
-    d = {2, 4, 12};
+    d = { 2, 4, 12 };
     n2 = dbg_exp.add_node(d, 4);
     dbg_exp.add_edge(n1, n2);
-    d = {4, 12, 6};
+    d = { 4, 12, 6 };
     n1 = dbg_exp.add_node(d, 4);
     dbg_exp.add_edge(n2, n1);
-    d = {12, 6, 8};
+    d = { 12, 6, 8 };
     n2 = dbg_exp.add_node(d, 4);
     dbg_exp.add_edge(n1, n2);
-    d = {6, 8, 10};
+    d = { 6, 8, 10 };
     n1 = dbg_exp.add_node(d, 4);
     dbg_exp.add_edge(n2, n1);
 
-    d = {12, 2, 4};
+    d = { 12, 2, 4 };
     n1 = dbg_exp.add_node(d, 5);
-    d = {2, 4, 12};
+    d = { 2, 4, 12 };
     n2 = dbg_exp.add_node(d, 5);
     dbg_exp.add_edge(n1, n2);
-    d = {4, 12, 6};
+    d = { 4, 12, 6 };
     n1 = dbg_exp.add_node(d, 5);
     dbg_exp.add_edge(n2, n1);
 
     EXPECT_EQ(dbg_exp, dbg);
 }
 
-TEST(NoiseFilteringRemoveLeaves, OneDBGNode_RemovedFromPanGraph) {
+TEST(NoiseFilteringRemoveLeaves, OneDBGNode_RemovedFromPanGraph)
+{
     set<MinimizerHitPtr, pComp> dummy_cluster;
     auto pangraph = std::make_shared<pangenome::Graph>(pangenome::Graph());
 
@@ -401,7 +426,8 @@ TEST(NoiseFilteringRemoveLeaves, OneDBGNode_RemovedFromPanGraph) {
     EXPECT_EQ(pg_exp, *pangraph);
 }
 
-TEST(NoiseFilteringRemoveLeaves, OneDBGNode_RemovedFromDBGraph) {
+TEST(NoiseFilteringRemoveLeaves, OneDBGNode_RemovedFromDBGraph)
+{
     set<MinimizerHitPtr, pComp> dummy_cluster;
     auto pangraph = std::make_shared<pangenome::Graph>(pangenome::Graph());
 
@@ -420,7 +446,8 @@ TEST(NoiseFilteringRemoveLeaves, OneDBGNode_RemovedFromDBGraph) {
     EXPECT_EQ(dbg_exp, dbg);
 }
 
-TEST(NoiseFilteringRemoveLeaves, OneLoop_NoLeavesRemoved) {
+TEST(NoiseFilteringRemoveLeaves, OneLoop_NoLeavesRemoved)
+{
     set<MinimizerHitPtr, pComp> dummy_cluster;
     auto pangraph = std::make_shared<pangenome::Graph>(pangenome::Graph());
 
@@ -446,7 +473,6 @@ TEST(NoiseFilteringRemoveLeaves, OneLoop_NoLeavesRemoved) {
     pangraph->add_hits_between_PRG_and_read(l1, 1, dummy_cluster);
     pangraph->add_hits_between_PRG_and_read(l2, 1, dummy_cluster);
 
-
     debruijn::Graph dbg(3);
     construct_debruijn_graph(pangraph, dbg);
     uint pg_size = pangraph->nodes.size();
@@ -457,7 +483,8 @@ TEST(NoiseFilteringRemoveLeaves, OneLoop_NoLeavesRemoved) {
     EXPECT_EQ(dbg.nodes.size(), dbg_size);
 }
 
-TEST(NoiseFilteringRemoveLeaves, OneLoopAndDeviantPath_OneLeafRemoved) {
+TEST(NoiseFilteringRemoveLeaves, OneLoopAndDeviantPath_OneLeafRemoved)
+{
     set<MinimizerHitPtr, pComp> dummy_cluster;
     auto pangraph = std::make_shared<pangenome::Graph>(pangenome::Graph());
 
@@ -500,10 +527,11 @@ TEST(NoiseFilteringRemoveLeaves, OneLoopAndDeviantPath_OneLeafRemoved) {
     EXPECT_EQ(pangraph->nodes.size(), pg_size - 1);
     EXPECT_TRUE(pangraph->nodes.find(7) == pangraph->nodes.end());
     EXPECT_EQ(dbg.nodes.size(), dbg_size - 1);
-    EXPECT_TRUE(dbg.nodes.find(dbg.node_hash[{4, 6, 14}]) == dbg.nodes.end());
+    EXPECT_TRUE(dbg.nodes.find(dbg.node_hash[{ 4, 6, 14 }]) == dbg.nodes.end());
 }
 
-TEST(NoiseFilteringRemoveLeaves, OneLoopAndIncorrectPath_TwoLeavesRemoved) {
+TEST(NoiseFilteringRemoveLeaves, OneLoopAndIncorrectPath_TwoLeavesRemoved)
+{
     set<MinimizerHitPtr, pComp> dummy_cluster;
     auto pangraph = std::make_shared<pangenome::Graph>(pangenome::Graph());
 
@@ -533,7 +561,7 @@ TEST(NoiseFilteringRemoveLeaves, OneLoopAndIncorrectPath_TwoLeavesRemoved) {
 
     // incorrect short
     pangraph->add_hits_between_PRG_and_read(l0, 3, dummy_cluster);
-    pangraph->add_hits_between_PRG_and_read(l5, 3, dummy_cluster);//6
+    pangraph->add_hits_between_PRG_and_read(l5, 3, dummy_cluster); // 6
     pangraph->add_hits_between_PRG_and_read(l3, 3, dummy_cluster);
     pangraph->add_hits_between_PRG_and_read(l4, 3, dummy_cluster);
 
@@ -545,11 +573,12 @@ TEST(NoiseFilteringRemoveLeaves, OneLoopAndIncorrectPath_TwoLeavesRemoved) {
 
     EXPECT_EQ(pangraph->nodes.size(), pg_size);
     EXPECT_EQ(dbg.nodes.size(), dbg_size - 2);
-    EXPECT_TRUE(dbg.nodes.find(dbg.node_hash[{0, 10, 6}]) == dbg.nodes.end());
-    EXPECT_TRUE(dbg.nodes.find(dbg.node_hash[{10, 6, 8}]) == dbg.nodes.end());
+    EXPECT_TRUE(dbg.nodes.find(dbg.node_hash[{ 0, 10, 6 }]) == dbg.nodes.end());
+    EXPECT_TRUE(dbg.nodes.find(dbg.node_hash[{ 10, 6, 8 }]) == dbg.nodes.end());
 }
 
-TEST(NoiseFilteringRemoveLeaves, OneLoopAndDeviatesInMiddle_NoLeavesRemoved) {
+TEST(NoiseFilteringRemoveLeaves, OneLoopAndDeviatesInMiddle_NoLeavesRemoved)
+{
     set<MinimizerHitPtr, pComp> dummy_cluster;
     auto pangraph = std::make_shared<pangenome::Graph>(pangenome::Graph());
 
@@ -596,7 +625,8 @@ TEST(NoiseFilteringRemoveLeaves, OneLoopAndDeviatesInMiddle_NoLeavesRemoved) {
     EXPECT_EQ(dbg.nodes.size(), dbg_size);
 }
 
-TEST(NoiseFilteringRemoveLeaves, OneLoopAndLongerWrongPath_LeavesRemoved) {
+TEST(NoiseFilteringRemoveLeaves, OneLoopAndLongerWrongPath_LeavesRemoved)
+{
     set<MinimizerHitPtr, pComp> dummy_cluster;
     auto pangraph = std::make_shared<pangenome::Graph>(pangenome::Graph());
 
@@ -624,11 +654,10 @@ TEST(NoiseFilteringRemoveLeaves, OneLoopAndLongerWrongPath_LeavesRemoved) {
     pangraph->add_hits_between_PRG_and_read(l1, 1, dummy_cluster);
     pangraph->add_hits_between_PRG_and_read(l2, 1, dummy_cluster);
 
-
     // incorrect longer
     pangraph->add_hits_between_PRG_and_read(l6, 5, dummy_cluster);
     pangraph->add_hits_between_PRG_and_read(l1, 5, dummy_cluster);
-    pangraph->add_hits_between_PRG_and_read(l7, 5, dummy_cluster);//2
+    pangraph->add_hits_between_PRG_and_read(l7, 5, dummy_cluster); // 2
     pangraph->add_hits_between_PRG_and_read(l6, 5, dummy_cluster);
     pangraph->add_hits_between_PRG_and_read(l3, 5, dummy_cluster);
 
@@ -642,12 +671,13 @@ TEST(NoiseFilteringRemoveLeaves, OneLoopAndLongerWrongPath_LeavesRemoved) {
     EXPECT_TRUE(pangraph->nodes.find(6) == pangraph->nodes.end());
     EXPECT_TRUE(pangraph->nodes.find(7) == pangraph->nodes.end());
     EXPECT_EQ(dbg.nodes.size(), dbg_size - 3);
-    EXPECT_TRUE(dbg.nodes.find(dbg.node_hash[{12, 2, 14}]) == dbg.nodes.end());
-    EXPECT_TRUE(dbg.nodes.find(dbg.node_hash[{2, 14, 12}]) == dbg.nodes.end());
-    EXPECT_TRUE(dbg.nodes.find(dbg.node_hash[{14, 12, 6}]) == dbg.nodes.end());
+    EXPECT_TRUE(dbg.nodes.find(dbg.node_hash[{ 12, 2, 14 }]) == dbg.nodes.end());
+    EXPECT_TRUE(dbg.nodes.find(dbg.node_hash[{ 2, 14, 12 }]) == dbg.nodes.end());
+    EXPECT_TRUE(dbg.nodes.find(dbg.node_hash[{ 14, 12, 6 }]) == dbg.nodes.end());
 }
 
-TEST(NoiseFilteringRemoveLeaves, AllTogether_GraphsLookCorrect) {
+TEST(NoiseFilteringRemoveLeaves, AllTogether_GraphsLookCorrect)
+{
     set<MinimizerHitPtr, pComp> dummy_cluster;
     auto pangraph = std::make_shared<pangenome::Graph>(pangenome::Graph());
 
@@ -696,7 +726,7 @@ TEST(NoiseFilteringRemoveLeaves, AllTogether_GraphsLookCorrect) {
 
     // incorrect short
     pangraph->add_hits_between_PRG_and_read(l0, 3, dummy_cluster);
-    pangraph->add_hits_between_PRG_and_read(l5, 3, dummy_cluster);//6
+    pangraph->add_hits_between_PRG_and_read(l5, 3, dummy_cluster); // 6
     pangraph->add_hits_between_PRG_and_read(l3, 3, dummy_cluster);
     pangraph->add_hits_between_PRG_and_read(l4, 3, dummy_cluster);
 
@@ -712,58 +742,58 @@ TEST(NoiseFilteringRemoveLeaves, AllTogether_GraphsLookCorrect) {
     // incorrect longer
     pangraph->add_hits_between_PRG_and_read(l6, 5, dummy_cluster);
     pangraph->add_hits_between_PRG_and_read(l1, 5, dummy_cluster);
-    pangraph->add_hits_between_PRG_and_read(l1, 5, dummy_cluster);//2
+    pangraph->add_hits_between_PRG_and_read(l1, 5, dummy_cluster); // 2
     pangraph->add_hits_between_PRG_and_read(l6, 5, dummy_cluster);
     pangraph->add_hits_between_PRG_and_read(l3, 5, dummy_cluster);
 
     construct_debruijn_graph(pangraph, dbg);
     remove_leaves(pangraph, dbg);
 
-    std::deque<uint_least32_t> d = {0, 2, 4};
+    std::deque<uint_least32_t> d = { 0, 2, 4 };
     debruijn::OrientedNodePtr n1 = dbg_exp.add_node(d, 0);
-    d = {2, 4, 6};
+    d = { 2, 4, 6 };
     debruijn::OrientedNodePtr n2 = dbg_exp.add_node(d, 0);
     dbg_exp.add_edge(n1, n2);
-    d = {4, 6, 8};
+    d = { 4, 6, 8 };
     n1 = dbg_exp.add_node(d, 0);
     dbg_exp.add_edge(n2, n1);
-    d = {6, 8, 10};
+    d = { 6, 8, 10 };
     n2 = dbg_exp.add_node(d, 0);
     dbg_exp.add_edge(n1, n2);
 
-    d = {6, 8, 10};
+    d = { 6, 8, 10 };
     n2 = dbg_exp.add_node(d, 1);
-    d = {8, 10, 0};
+    d = { 8, 10, 0 };
     n1 = dbg_exp.add_node(d, 1);
     dbg_exp.add_edge(n2, n1);
-    d = {10, 0, 2};
+    d = { 10, 0, 2 };
     n2 = dbg_exp.add_node(d, 1);
     dbg_exp.add_edge(n1, n2);
-    d = {0, 2, 4};
+    d = { 0, 2, 4 };
     n1 = dbg_exp.add_node(d, 1);
     dbg_exp.add_edge(n2, n1);
 
-    d = {2, 4, 6};
+    d = { 2, 4, 6 };
     n1 = dbg_exp.add_node(d, 2);
 
-    d = {0, 2, 4};
+    d = { 0, 2, 4 };
     n1 = dbg_exp.add_node(d, 4);
-    d = {2, 4, 12};
+    d = { 2, 4, 12 };
     n2 = dbg_exp.add_node(d, 4);
     dbg_exp.add_edge(n1, n2);
-    d = {4, 12, 6};
+    d = { 4, 12, 6 };
     n1 = dbg_exp.add_node(d, 4);
     dbg_exp.add_edge(n2, n1);
-    d = {12, 6, 8};
+    d = { 12, 6, 8 };
     n2 = dbg_exp.add_node(d, 4);
     dbg_exp.add_edge(n1, n2);
-    d = {6, 8, 10};
+    d = { 6, 8, 10 };
     n1 = dbg_exp.add_node(d, 4);
     dbg_exp.add_edge(n2, n1);
 
-    d = {2, 4, 12};
+    d = { 2, 4, 12 };
     n2 = dbg_exp.add_node(d, 4);
-    d = {4, 12, 6};
+    d = { 4, 12, 6 };
     n1 = dbg_exp.add_node(d, 4);
     dbg_exp.add_edge(n2, n1);
 
@@ -798,7 +828,8 @@ TEST(NoiseFilteringRemoveLeaves, AllTogether_GraphsLookCorrect) {
     EXPECT_EQ(pg_exp, *pangraph);
 }
 
-TEST(NoiseFilteringFilterUnitigs, SimpleCaseNothingToDo_ReadsUnchanged) {
+TEST(NoiseFilteringFilterUnitigs, SimpleCaseNothingToDo_ReadsUnchanged)
+{
     set<MinimizerHitPtr, pComp> dummy_cluster;
     auto pangraph = std::make_shared<pangenome::Graph>(pangenome::Graph());
 
@@ -831,7 +862,7 @@ TEST(NoiseFilteringFilterUnitigs, SimpleCaseNothingToDo_ReadsUnchanged) {
     construct_debruijn_graph(pangraph, dbg);
     filter_unitigs(pangraph, dbg, 1);
 
-    pangenome::Graph *pg_exp;
+    pangenome::Graph* pg_exp;
     pg_exp = new pangenome::Graph();
     pg_exp->add_hits_between_PRG_and_read(l0, 0, dummy_cluster);
     pg_exp->add_hits_between_PRG_and_read(l1, 0, dummy_cluster);
@@ -850,20 +881,29 @@ TEST(NoiseFilteringFilterUnitigs, SimpleCaseNothingToDo_ReadsUnchanged) {
     pg_exp->add_hits_between_PRG_and_read(l0, 1, dummy_cluster);
 
     // check contents of read 0 are correct
-    EXPECT_EQ(pg_exp->reads[0]->get_nodes().size(), pangraph->reads[0]->get_nodes().size());
-    for (uint i = 0; i < min(pangraph->reads[0]->get_nodes().size(), pg_exp->reads[0]->get_nodes().size()); ++i) {
-        EXPECT_EQ(*pangraph->reads[0]->get_nodes()[i].lock(), *pg_exp->reads[0]->get_nodes()[i].lock());
+    EXPECT_EQ(
+        pg_exp->reads[0]->get_nodes().size(), pangraph->reads[0]->get_nodes().size());
+    for (uint i = 0; i < min(pangraph->reads[0]->get_nodes().size(),
+                         pg_exp->reads[0]->get_nodes().size());
+         ++i) {
+        EXPECT_EQ(*pangraph->reads[0]->get_nodes()[i].lock(),
+            *pg_exp->reads[0]->get_nodes()[i].lock());
     }
     // check contents of read 1 are correct
-    EXPECT_EQ(pg_exp->reads[1]->get_nodes().size(), pangraph->reads[1]->get_nodes().size());
-    for (uint i = 0; i < min(pangraph->reads[1]->get_nodes().size(), pg_exp->reads[1]->get_nodes().size()); ++i) {
-        EXPECT_EQ(*pangraph->reads[1]->get_nodes()[i].lock(), *pg_exp->reads[1]->get_nodes()[i].lock());
+    EXPECT_EQ(
+        pg_exp->reads[1]->get_nodes().size(), pangraph->reads[1]->get_nodes().size());
+    for (uint i = 0; i < min(pangraph->reads[1]->get_nodes().size(),
+                         pg_exp->reads[1]->get_nodes().size());
+         ++i) {
+        EXPECT_EQ(*pangraph->reads[1]->get_nodes()[i].lock(),
+            *pg_exp->reads[1]->get_nodes()[i].lock());
     }
 
     delete pg_exp;
 }
 
-TEST(NoiseFilteringFilterUnitigs, SimpleCaseNothingToDoCycle_ReadsUnchanged) {
+TEST(NoiseFilteringFilterUnitigs, SimpleCaseNothingToDoCycle_ReadsUnchanged)
+{
     set<MinimizerHitPtr, pComp> dummy_cluster;
     auto pangraph = std::make_shared<pangenome::Graph>(pangenome::Graph());
 
@@ -895,7 +935,7 @@ TEST(NoiseFilteringFilterUnitigs, SimpleCaseNothingToDoCycle_ReadsUnchanged) {
     construct_debruijn_graph(pangraph, dbg);
     filter_unitigs(pangraph, dbg, 1);
 
-    pangenome::Graph *pg_exp;
+    pangenome::Graph* pg_exp;
     pg_exp = new pangenome::Graph();
     pg_exp->add_hits_between_PRG_and_read(l0, 0, dummy_cluster);
     pg_exp->add_hits_between_PRG_and_read(l1, 0, dummy_cluster);
@@ -912,16 +952,23 @@ TEST(NoiseFilteringFilterUnitigs, SimpleCaseNothingToDoCycle_ReadsUnchanged) {
     pg_exp->add_hits_between_PRG_and_read(l0, 1, dummy_cluster);
     pg_exp->add_hits_between_PRG_and_read(l1, 1, dummy_cluster);
 
-
     // check contents of read 0 are correct
-    EXPECT_EQ(pg_exp->reads[0]->get_nodes().size(), pangraph->reads[0]->get_nodes().size());
-    for (uint i = 0; i < min(pangraph->reads[0]->get_nodes().size(), pg_exp->reads[0]->get_nodes().size()); ++i) {
-        EXPECT_EQ(*pangraph->reads[0]->get_nodes()[i].lock(), *pg_exp->reads[0]->get_nodes()[i].lock());
+    EXPECT_EQ(
+        pg_exp->reads[0]->get_nodes().size(), pangraph->reads[0]->get_nodes().size());
+    for (uint i = 0; i < min(pangraph->reads[0]->get_nodes().size(),
+                         pg_exp->reads[0]->get_nodes().size());
+         ++i) {
+        EXPECT_EQ(*pangraph->reads[0]->get_nodes()[i].lock(),
+            *pg_exp->reads[0]->get_nodes()[i].lock());
     }
     // check contents of read 1 are correct
-    EXPECT_EQ(pg_exp->reads[1]->get_nodes().size(), pangraph->reads[1]->get_nodes().size());
-    for (uint i = 0; i < min(pangraph->reads[1]->get_nodes().size(), pg_exp->reads[1]->get_nodes().size()); ++i) {
-        EXPECT_EQ(*pangraph->reads[1]->get_nodes()[i].lock(), *pg_exp->reads[1]->get_nodes()[i].lock());
+    EXPECT_EQ(
+        pg_exp->reads[1]->get_nodes().size(), pangraph->reads[1]->get_nodes().size());
+    for (uint i = 0; i < min(pangraph->reads[1]->get_nodes().size(),
+                         pg_exp->reads[1]->get_nodes().size());
+         ++i) {
+        EXPECT_EQ(*pangraph->reads[1]->get_nodes()[i].lock(),
+            *pg_exp->reads[1]->get_nodes()[i].lock());
     }
 
     delete pg_exp;
@@ -982,19 +1029,22 @@ TEST(NoiseFilteringFilterUnitigs, SimpleCaseNothingToDoCycle_ReadsUnchanged) {
 
     // check contents of read 0 are correct
     EXPECT_EQ(pg_exp->reads[0]->get_nodes().size(), pg->reads[0]->get_nodes().size());
-    for (uint i=0; i < min(pg->reads[0]->get_nodes().size(), pg_exp->reads[0]->get_nodes().size()); ++i)
+    for (uint i=0; i < min(pg->reads[0]->get_nodes().size(),
+pg_exp->reads[0]->get_nodes().size()); ++i)
     {
         EXPECT_EQ(*pg->reads[0]->get_nodes()[i], *pg_exp->reads[0]->get_nodes()[i]);
     }
     // check contents of read 1 are correct
     EXPECT_EQ(pg_exp->reads[1]->get_nodes().size(), pg->reads[1]->get_nodes().size());
-    for (uint i=0; i < min(pg->reads[1]->get_nodes().size(),pg_exp->reads[1]->get_nodes().size()) ; ++i)
+    for (uint i=0; i <
+min(pg->reads[1]->get_nodes().size(),pg_exp->reads[1]->get_nodes().size()) ; ++i)
     {
         EXPECT_EQ(*pg->reads[1]->get_nodes()[i], *pg_exp->reads[1]->get_nodes()[i]);
     }
     // check contents of read 2 are correct
     EXPECT_EQ(pg_exp->reads[2]->get_nodes().size(), pg->reads[2]->get_nodes().size());
-    for (uint i=0; i < min(pg->reads[2]->get_nodes().size(),pg_exp->reads[2]->get_nodes().size()) ; ++i)
+    for (uint i=0; i <
+min(pg->reads[2]->get_nodes().size(),pg_exp->reads[2]->get_nodes().size()) ; ++i)
     {
         EXPECT_EQ(*pg->reads[2]->get_nodes()[i], *pg_exp->reads[2]->get_nodes()[i]);
     }
@@ -1036,8 +1086,8 @@ TEST(NoiseFilteringFilterUnitigs,FilterUnitigsReadStartsRightAndDeviates_DbgAlso
     filter_unitigs(pg, dbg, 1);
 
     EXPECT_EQ(num_nodes-1,dbg.nodes.size());
-    bool result = dbg.nodes.find(5) == dbg.nodes.end(); // node <2,3,7> will be 5th in dbg
-    EXPECT_TRUE(result);
+    bool result = dbg.nodes.find(5) == dbg.nodes.end(); // node <2,3,7> will be 5th in
+dbg EXPECT_TRUE(result);
 
     delete pg;
 }*/
@@ -1112,15 +1162,15 @@ TEST(NoiseFilteringFilterUnitigs,FilterUnitigsReadWrong_DbgAlsoPruned)
     filter_unitigs(pg, dbg, 1);
 
     EXPECT_EQ(num_nodes-2,dbg.nodes.size());
-    bool result = dbg.nodes.find(5) == dbg.nodes.end(); // node <0,5,3> will be 5th in dbg
-    EXPECT_TRUE(result);
-    result = dbg.nodes.find(6) == dbg.nodes.end(); // node <5,3,4> will be 6th in dbg
-    EXPECT_TRUE(result);
+    bool result = dbg.nodes.find(5) == dbg.nodes.end(); // node <0,5,3> will be 5th in
+dbg EXPECT_TRUE(result); result = dbg.nodes.find(6) == dbg.nodes.end(); // node <5,3,4>
+will be 6th in dbg EXPECT_TRUE(result);
 
     delete pg;
 }*/
 
-TEST(NoiseFilteringFilterUnitigs, FilterUnitigsReadDeviatesInMiddle_ReadPruned) {
+TEST(NoiseFilteringFilterUnitigs, FilterUnitigsReadDeviatesInMiddle_ReadPruned)
+{
     set<MinimizerHitPtr, pComp> dummy_cluster;
     auto pangraph = std::make_shared<pangenome::Graph>(pangenome::Graph());
 
@@ -1160,7 +1210,7 @@ TEST(NoiseFilteringFilterUnitigs, FilterUnitigsReadDeviatesInMiddle_ReadPruned) 
     construct_debruijn_graph(pangraph, dbg);
     filter_unitigs(pangraph, dbg, 1);
 
-    pangenome::Graph *pg_exp;
+    pangenome::Graph* pg_exp;
     pg_exp = new pangenome::Graph();
     pg_exp->add_hits_between_PRG_and_read(l0, 0, dummy_cluster);
     pg_exp->add_hits_between_PRG_and_read(l1, 0, dummy_cluster);
@@ -1183,11 +1233,14 @@ TEST(NoiseFilteringFilterUnitigs, FilterUnitigsReadDeviatesInMiddle_ReadPruned) 
     pg_exp->add_hits_between_PRG_and_read(l4, 4, dummy_cluster);
     pg_exp->add_hits_between_PRG_and_read(l5, 4, dummy_cluster);
 
-
     // check contents of read 4 are correct
-    EXPECT_EQ(pg_exp->reads[4]->get_nodes().size(), pangraph->reads[4]->get_nodes().size());
-    for (uint i = 0; i < min(pangraph->reads[4]->get_nodes().size(), pg_exp->reads[4]->get_nodes().size()); ++i) {
-        EXPECT_EQ(*pangraph->reads[4]->get_nodes()[i].lock(), *pg_exp->reads[4]->get_nodes()[i].lock());
+    EXPECT_EQ(
+        pg_exp->reads[4]->get_nodes().size(), pangraph->reads[4]->get_nodes().size());
+    for (uint i = 0; i < min(pangraph->reads[4]->get_nodes().size(),
+                         pg_exp->reads[4]->get_nodes().size());
+         ++i) {
+        EXPECT_EQ(*pangraph->reads[4]->get_nodes()[i].lock(),
+            *pg_exp->reads[4]->get_nodes()[i].lock());
     }
     delete pg_exp;
 }
@@ -1228,17 +1281,16 @@ TEST(NoiseFilteringFilterUnitigs, FilterUnitigsReadDeviatesInMiddle_ReadPruned) 
     filter_unitigs(pg, dbg, 1);
 
     EXPECT_EQ(num_nodes-3,dbg.nodes.size());
-    bool result = dbg.nodes.find(5) == dbg.nodes.end(); // node <1,2,6> will be 5th in dbg
-    EXPECT_TRUE(result);
-    result = dbg.nodes.find(6) == dbg.nodes.end(); // node <2,6,3> will be 6th in dbg
-    EXPECT_TRUE(result);
-    result = dbg.nodes.find(7) == dbg.nodes.end(); // node <6,3,4> will be 7th in dbg
-    EXPECT_TRUE(result);
+    bool result = dbg.nodes.find(5) == dbg.nodes.end(); // node <1,2,6> will be 5th in
+dbg EXPECT_TRUE(result); result = dbg.nodes.find(6) == dbg.nodes.end(); // node <2,6,3>
+will be 6th in dbg EXPECT_TRUE(result); result = dbg.nodes.find(7) == dbg.nodes.end();
+// node <6,3,4> will be 7th in dbg EXPECT_TRUE(result);
 
     delete pg;
 }*/
 
-TEST(NoiseFilteringFilterUnitigs, FilterUnitigsReadDeviatesLongerInMiddle_ReadPruned) {
+TEST(NoiseFilteringFilterUnitigs, FilterUnitigsReadDeviatesLongerInMiddle_ReadPruned)
+{
     set<MinimizerHitPtr, pComp> dummy_cluster;
     auto pangraph = std::make_shared<pangenome::Graph>(pangenome::Graph());
 
@@ -1284,7 +1336,7 @@ TEST(NoiseFilteringFilterUnitigs, FilterUnitigsReadDeviatesLongerInMiddle_ReadPr
     construct_debruijn_graph(pangraph, dbg);
     filter_unitigs(pangraph, dbg, 1);
 
-    pangenome::Graph *pg_exp;
+    pangenome::Graph* pg_exp;
     pg_exp = new pangenome::Graph();
     pg_exp->add_hits_between_PRG_and_read(l0, 0, dummy_cluster);
     pg_exp->add_hits_between_PRG_and_read(l1, 0, dummy_cluster);
@@ -1308,9 +1360,13 @@ TEST(NoiseFilteringFilterUnitigs, FilterUnitigsReadDeviatesLongerInMiddle_ReadPr
     pg_exp->add_hits_between_PRG_and_read(l5, 5, dummy_cluster);
 
     // check contents of read 4 are correct
-    EXPECT_EQ(pg_exp->reads[5]->get_nodes().size(), pangraph->reads[5]->get_nodes().size());
-    for (uint i = 0; i < min(pangraph->reads[5]->get_nodes().size(), pg_exp->reads[5]->get_nodes().size()); ++i) {
-        EXPECT_EQ(*pangraph->reads[5]->get_nodes()[i].lock(), *pg_exp->reads[5]->get_nodes()[i].lock());
+    EXPECT_EQ(
+        pg_exp->reads[5]->get_nodes().size(), pangraph->reads[5]->get_nodes().size());
+    for (uint i = 0; i < min(pangraph->reads[5]->get_nodes().size(),
+                         pg_exp->reads[5]->get_nodes().size());
+         ++i) {
+        EXPECT_EQ(*pangraph->reads[5]->get_nodes()[i].lock(),
+            *pg_exp->reads[5]->get_nodes()[i].lock());
     }
 
     delete pg_exp;
@@ -1354,21 +1410,19 @@ TEST(NoiseFilteringFilterUnitigs, FilterUnitigsReadDeviatesLongerInMiddle_ReadPr
     filter_unitigs(pg, dbg, 1);
 
     EXPECT_EQ(num_nodes-5,dbg.nodes.size());
-    bool result = dbg.nodes.find(5) == dbg.nodes.end(); // node <1,2,9> will be 5th in dbg
-    EXPECT_TRUE(result);
-    result = dbg.nodes.find(6) == dbg.nodes.end(); // node <2,9,10> will be 6th in dbg
-    EXPECT_TRUE(result);
-    result = dbg.nodes.find(7) == dbg.nodes.end(); // node <9,10,11> will be 7th in dbg
-    EXPECT_TRUE(result);
-    result = dbg.nodes.find(8) == dbg.nodes.end(); // node <10,11,3> will be 8th in dbg
-    EXPECT_TRUE(result);
-    result = dbg.nodes.find(9) == dbg.nodes.end(); // node <11,3,4> will be 9th in dbg
+    bool result = dbg.nodes.find(5) == dbg.nodes.end(); // node <1,2,9> will be 5th in
+dbg EXPECT_TRUE(result); result = dbg.nodes.find(6) == dbg.nodes.end(); // node <2,9,10>
+will be 6th in dbg EXPECT_TRUE(result); result = dbg.nodes.find(7) == dbg.nodes.end();
+// node <9,10,11> will be 7th in dbg EXPECT_TRUE(result); result = dbg.nodes.find(8) ==
+dbg.nodes.end(); // node <10,11,3> will be 8th in dbg EXPECT_TRUE(result); result =
+dbg.nodes.find(9) == dbg.nodes.end(); // node <11,3,4> will be 9th in dbg
     EXPECT_TRUE(result);
 
     delete pg;
 }*/
 
-TEST(NoiseFilteringFilterUnitigs, AllTogether_PanGraphIsAsExpected) {
+TEST(NoiseFilteringFilterUnitigs, AllTogether_PanGraphIsAsExpected)
+{
     set<MinimizerHitPtr, pComp> dummy_cluster;
     auto pangraph = std::make_shared<pangenome::Graph>(pangenome::Graph());
 
@@ -1400,7 +1454,7 @@ TEST(NoiseFilteringFilterUnitigs, AllTogether_PanGraphIsAsExpected) {
 
     // incorrect short
     pangraph->add_hits_between_PRG_and_read(l0, 3, dummy_cluster);
-    pangraph->add_hits_between_PRG_and_read(l5, 3, dummy_cluster);//6
+    pangraph->add_hits_between_PRG_and_read(l5, 3, dummy_cluster); // 6
     pangraph->add_hits_between_PRG_and_read(l3, 3, dummy_cluster);
     pangraph->add_hits_between_PRG_and_read(l4, 3, dummy_cluster);
 
@@ -1436,7 +1490,6 @@ TEST(NoiseFilteringFilterUnitigs, AllTogether_PanGraphIsAsExpected) {
     pg_exp.add_hits_between_PRG_and_read(l4, 0, dummy_cluster);
     pg_exp.add_hits_between_PRG_and_read(l5, 0, dummy_cluster);
 
-
     // starts correct and deviates
     pg_exp.add_hits_between_PRG_and_read(l1, 2, dummy_cluster);
     pg_exp.add_hits_between_PRG_and_read(l2, 2, dummy_cluster);
@@ -1445,7 +1498,7 @@ TEST(NoiseFilteringFilterUnitigs, AllTogether_PanGraphIsAsExpected) {
 
     // incorrect short
     pg_exp.add_hits_between_PRG_and_read(l0, 3, dummy_cluster);
-    pg_exp.add_hits_between_PRG_and_read(l5, 3, dummy_cluster);//6
+    pg_exp.add_hits_between_PRG_and_read(l5, 3, dummy_cluster); // 6
     pg_exp.add_hits_between_PRG_and_read(l3, 3, dummy_cluster);
     pg_exp.add_hits_between_PRG_and_read(l4, 3, dummy_cluster);
 
@@ -1575,7 +1628,8 @@ TEST(NoiseFilteringFilterUnitigs, AllTogether_PanGraphIsAsExpected) {
     delete pg;
 }*/
 
-TEST(NoiseFilteringTest, detangle_pangraph_with_debruijn_graph) {
+TEST(NoiseFilteringTest, detangle_pangraph_with_debruijn_graph)
+{
     set<MinimizerHitPtr, pComp> dummy_cluster;
     auto pangraph = std::make_shared<pangenome::Graph>(pangenome::Graph());
 
@@ -1604,7 +1658,6 @@ TEST(NoiseFilteringTest, detangle_pangraph_with_debruijn_graph) {
     pangraph->add_hits_between_PRG_and_read(l1, 1, dummy_cluster);
     pangraph->add_hits_between_PRG_and_read(l2, 1, dummy_cluster);
 
-
     // starts correct and deviates
     pangraph->add_hits_between_PRG_and_read(l1, 2, dummy_cluster);
     pangraph->add_hits_between_PRG_and_read(l2, 2, dummy_cluster);
@@ -1613,7 +1666,7 @@ TEST(NoiseFilteringTest, detangle_pangraph_with_debruijn_graph) {
 
     // incorrect short
     pangraph->add_hits_between_PRG_and_read(l0, 3, dummy_cluster);
-    pangraph->add_hits_between_PRG_and_read(l5, 3, dummy_cluster);//6
+    pangraph->add_hits_between_PRG_and_read(l5, 3, dummy_cluster); // 6
     pangraph->add_hits_between_PRG_and_read(l3, 3, dummy_cluster);
     pangraph->add_hits_between_PRG_and_read(l4, 3, dummy_cluster);
 
@@ -1628,7 +1681,7 @@ TEST(NoiseFilteringTest, detangle_pangraph_with_debruijn_graph) {
 
     debruijn::Graph dbg(3);
     construct_debruijn_graph(pangraph, dbg);
-    //detangle_pangraph_with_debruijn_graph(pg, dbg);
+    // detangle_pangraph_with_debruijn_graph(pg, dbg);
 
     pangenome::Graph pg_exp;
     pangenome::ReadPtr r;
@@ -1649,8 +1702,8 @@ TEST(NoiseFilteringTest, detangle_pangraph_with_debruijn_graph) {
     pg_exp.nodes[11] = n;
     r = make_shared<pangenome::Read>(0);
     pg_exp.reads[0] = r;
-    r->set_nodes({pg_exp.nodes[0], pg_exp.nodes[1], pg_exp.nodes[2], pg_exp.nodes[8],
-                pg_exp.nodes[9], pg_exp.nodes[10], pg_exp.nodes[11]});
+    r->set_nodes({ pg_exp.nodes[0], pg_exp.nodes[1], pg_exp.nodes[2], pg_exp.nodes[8],
+        pg_exp.nodes[9], pg_exp.nodes[10], pg_exp.nodes[11] });
 
     n = make_shared<pangenome::Node>(l1, 12);
     pg_exp.nodes[12] = n;
@@ -1658,8 +1711,8 @@ TEST(NoiseFilteringTest, detangle_pangraph_with_debruijn_graph) {
     pg_exp.nodes[13] = n;
     r = make_shared<pangenome::Read>(1);
     pg_exp.reads[1] = r;
-    r->set_nodes({pg_exp.nodes[8], pg_exp.nodes[9], pg_exp.nodes[10], pg_exp.nodes[11],
-                pg_exp.nodes[12], pg_exp.nodes[13]});
+    r->set_nodes({ pg_exp.nodes[8], pg_exp.nodes[9], pg_exp.nodes[10], pg_exp.nodes[11],
+        pg_exp.nodes[12], pg_exp.nodes[13] });
 
     n = make_shared<pangenome::Node>(l1, 20);
     pg_exp.nodes[20] = n;
@@ -1671,7 +1724,8 @@ TEST(NoiseFilteringTest, detangle_pangraph_with_debruijn_graph) {
     pg_exp.nodes[7] = n;
     r = make_shared<pangenome::Read>(2);
     pg_exp.reads[2] = r;
-    r->set_nodes({pg_exp.nodes[20], pg_exp.nodes[21], pg_exp.nodes[22], pg_exp.nodes[7]});
+    r->set_nodes(
+        { pg_exp.nodes[20], pg_exp.nodes[21], pg_exp.nodes[22], pg_exp.nodes[7] });
 
     n = make_shared<pangenome::Node>(l0, 23);
     pg_exp.nodes[23] = n;
@@ -1683,7 +1737,8 @@ TEST(NoiseFilteringTest, detangle_pangraph_with_debruijn_graph) {
     pg_exp.nodes[4] = n;
     r = make_shared<pangenome::Read>(3);
     pg_exp.reads[3] = r;
-    r->set_nodes({pg_exp.nodes[23], pg_exp.nodes[5], pg_exp.nodes[3], pg_exp.nodes[4]});
+    r->set_nodes(
+        { pg_exp.nodes[23], pg_exp.nodes[5], pg_exp.nodes[3], pg_exp.nodes[4] });
 
     n = make_shared<pangenome::Node>(l0, 14);
     pg_exp.nodes[14] = n;
@@ -1701,13 +1756,14 @@ TEST(NoiseFilteringTest, detangle_pangraph_with_debruijn_graph) {
     pg_exp.nodes[19] = n;
     r = make_shared<pangenome::Read>(4);
     pg_exp.reads[4] = r;
-    r->set_nodes({pg_exp.nodes[14], pg_exp.nodes[15], pg_exp.nodes[16], pg_exp.nodes[6],
-                pg_exp.nodes[17], pg_exp.nodes[18], pg_exp.nodes[19]});
+    r->set_nodes({ pg_exp.nodes[14], pg_exp.nodes[15], pg_exp.nodes[16],
+        pg_exp.nodes[6], pg_exp.nodes[17], pg_exp.nodes[18], pg_exp.nodes[19] });
 
-    //EXPECT_EQ(pg_exp, *pg);
+    // EXPECT_EQ(pg_exp, *pg);
 }
 
-TEST(NoiseFilteringTest, clean_pangraph_with_debruijn_graph) {
+TEST(NoiseFilteringTest, clean_pangraph_with_debruijn_graph)
+{
     set<MinimizerHitPtr, pComp> dummy_cluster;
     auto pangraph = std::make_shared<pangenome::Graph>(pangenome::Graph());
 
@@ -1735,7 +1791,7 @@ TEST(NoiseFilteringTest, clean_pangraph_with_debruijn_graph) {
 
     // incorrect short
     pangraph->add_hits_between_PRG_and_read(l0, 3, dummy_cluster);
-    pangraph->add_hits_between_PRG_and_read(l5, 3, dummy_cluster);//6
+    pangraph->add_hits_between_PRG_and_read(l5, 3, dummy_cluster); // 6
     pangraph->add_hits_between_PRG_and_read(l3, 3, dummy_cluster);
     pangraph->add_hits_between_PRG_and_read(l4, 3, dummy_cluster);
 
@@ -1748,7 +1804,7 @@ TEST(NoiseFilteringTest, clean_pangraph_with_debruijn_graph) {
     pangraph->add_hits_between_PRG_and_read(l4, 4, dummy_cluster);
     pangraph->add_hits_between_PRG_and_read(l5, 4, dummy_cluster);
 
-    //clean_pangraph_with_debruijn_graph(pg, 3, 1);
+    // clean_pangraph_with_debruijn_graph(pg, 3, 1);
 
     pangenome::Graph pg_exp;
     pg_exp.add_hits_between_PRG_and_read(l0, 0, dummy_cluster);
@@ -1771,10 +1827,11 @@ TEST(NoiseFilteringTest, clean_pangraph_with_debruijn_graph) {
     pg_exp.add_hits_between_PRG_and_read(l4, 4, dummy_cluster);
     pg_exp.add_hits_between_PRG_and_read(l5, 4, dummy_cluster);
 
-    //EXPECT_EQ(pg_exp, *pg);
+    // EXPECT_EQ(pg_exp, *pg);
 }
 
-TEST(NoiseFilteringTest, write_pangraph_gfa) {
+TEST(NoiseFilteringTest, write_pangraph_gfa)
+{
     set<MinimizerHitPtr, pComp> dummy_cluster;
     auto pangraph = std::make_shared<pangenome::Graph>(pangenome::Graph());
 
@@ -1803,7 +1860,6 @@ TEST(NoiseFilteringTest, write_pangraph_gfa) {
     pangraph->add_hits_between_PRG_and_read(l1, 1, dummy_cluster);
     pangraph->add_hits_between_PRG_and_read(l2, 1, dummy_cluster);
 
-
     // starts correct and deviates
     pangraph->add_hits_between_PRG_and_read(l1, 2, dummy_cluster);
     pangraph->add_hits_between_PRG_and_read(l2, 2, dummy_cluster);
@@ -1812,7 +1868,7 @@ TEST(NoiseFilteringTest, write_pangraph_gfa) {
 
     // incorrect short
     pangraph->add_hits_between_PRG_and_read(l0, 3, dummy_cluster);
-    pangraph->add_hits_between_PRG_and_read(l5, 3, dummy_cluster);//6
+    pangraph->add_hits_between_PRG_and_read(l5, 3, dummy_cluster); // 6
     pangraph->add_hits_between_PRG_and_read(l3, 3, dummy_cluster);
     pangraph->add_hits_between_PRG_and_read(l4, 3, dummy_cluster);
 

--- a/test/pangenome_graph_class.h
+++ b/test/pangenome_graph_class.h
@@ -1,4 +1,5 @@
 #include "pangenome/pangraph.h"
+#include "gtest/gtest.h"
 
 class PGraphTester : public pangenome::Graph {
 public:

--- a/test/pangenome_graph_class.h
+++ b/test/pangenome_graph_class.h
@@ -1,9 +1,8 @@
 #include "pangenome/pangraph.h"
 
-
 class PGraphTester : public pangenome::Graph {
 public:
-    using Graph::Graph; //inherits all ctors from pangenome::Graph
+    using Graph::Graph; // inherits all ctors from pangenome::Graph
 
     friend class PangenomeGraphTest_add_node_Test;
 

--- a/test/pangraph_test.cpp
+++ b/test/pangraph_test.cpp
@@ -1,138 +1,141 @@
-#include "gtest/gtest.h"
-#include "test_macro.cpp"
+#include "localPRG.h"
+#include "minihit.h"
 #include "pangenome/ns.cpp"
-#include "pangenome_graph_class.h"
 #include "pangenome/pannode.h"
 #include "pangenome/panread.h"
 #include "pangenome/pansample.h"
-#include "minihit.h"
-#include "localPRG.h"
-#include <stdint.h>
-#include <numeric>
-#include <cassert>
-#include <iostream>
-#include <fstream>
+#include "pangenome_graph_class.h"
+#include "test_macro.cpp"
+#include "gtest/gtest.h"
 #include <boost/filesystem.hpp>
-
+#include <cassert>
+#include <fstream>
+#include <iostream>
+#include <numeric>
+#include <stdint.h>
 
 using namespace pangenome;
 
-TEST(PangenomeGraphConstructor, constructors_and_get_sample) {
+TEST(PangenomeGraphConstructor, constructors_and_get_sample)
+{
     {
-        //testing default constructor
+        // testing default constructor
         PGraphTester pg;
-        std::vector <std::string> expectedSamples = {"sample_1"};
+        std::vector<std::string> expectedSamples = { "sample_1" };
         EXPECT_EQ(pg.samples.size(), 1);
-        pg.get_sample("sample_1")->name=="sample_1";
+        pg.get_sample("sample_1")->name == "sample_1";
         EXPECT_EQ(pg.next_id, 0);
         EXPECT_EQ(pg.reads.size(), 0);
         EXPECT_EQ(pg.nodes.size(), 0);
     }
     {
-        //testing 1-argument constructor
-        PGraphTester pg({"test_sample"});
-        std::vector <std::string> expectedSamples = {"test_sample"};
+        // testing 1-argument constructor
+        PGraphTester pg({ "test_sample" });
+        std::vector<std::string> expectedSamples = { "test_sample" };
         EXPECT_EQ(pg.samples.size(), 1);
-        pg.get_sample("test_sample")->name=="test_sample";
+        pg.get_sample("test_sample")->name == "test_sample";
         EXPECT_EQ(pg.next_id, 0);
         EXPECT_EQ(pg.reads.size(), 0);
         EXPECT_EQ(pg.nodes.size(), 0);
     }
     {
-        //testing 3-argument constructor
-        std::vector<std::string> expectedSamples = {"test1", "test2", "test3"};
+        // testing 3-argument constructor
+        std::vector<std::string> expectedSamples = { "test1", "test2", "test3" };
         PGraphTester pg(expectedSamples);
         EXPECT_EQ(pg.samples.size(), expectedSamples.size());
-        pg.get_sample("test1")->name=="test1";
-        pg.get_sample("test2")->name=="test2";
-        pg.get_sample("test3")->name=="test3";
+        pg.get_sample("test1")->name == "test1";
+        pg.get_sample("test2")->name == "test2";
+        pg.get_sample("test3")->name == "test3";
         EXPECT_EQ(pg.next_id, 0);
         EXPECT_EQ(pg.reads.size(), 0);
         EXPECT_EQ(pg.nodes.size(), 0);
     }
 }
 
-TEST(PangenomeGraphRead, add_read_and_get_read) {
+TEST(PangenomeGraphRead, add_read_and_get_read)
+{
     PGraphTester pg;
     uint32_t read_id = 2;
 
-    //first trivial tests - read is not in the graph
-    EXPECT_EQ(pg.reads.size(), (uint) 0);
+    // first trivial tests - read is not in the graph
+    EXPECT_EQ(pg.reads.size(), (uint)0);
     try {
         pg.get_read(read_id);
         FAIL() << "pg.get_read(read_id) should throw std::out_of_range\n";
+    } catch (const std::out_of_range&) {
+    } catch (...) {
+        FAIL() << "pg.get_read(read_id) should throw std::out_of_range\n";
     }
-    catch (const std::out_of_range &) {}
-    catch(...){ FAIL() << "pg.get_read(read_id) should throw std::out_of_range\n"; }
 
-    //add read
+    // add read
     pg.add_read(read_id);
-    //and test
-    EXPECT_EQ(pg.reads.size(), (uint) 1);
+    // and test
+    EXPECT_EQ(pg.reads.size(), (uint)1);
     EXPECT_EQ(pg.get_read(read_id)->id, read_id);
 
-    //add read again
-    pg.add_read(read_id); //this should not change anything
-    //and test
-    EXPECT_EQ(pg.reads.size(), (uint) 1);
+    // add read again
+    pg.add_read(read_id); // this should not change anything
+    // and test
+    EXPECT_EQ(pg.reads.size(), (uint)1);
     EXPECT_EQ(pg.get_read(read_id)->id, read_id);
 
-    //add a different read
+    // add a different read
     uint32_t read_id_2 = 10;
     pg.add_read(read_id_2);
-    //and test
-    EXPECT_EQ(pg.reads.size(), (uint) 2);
+    // and test
+    EXPECT_EQ(pg.reads.size(), (uint)2);
     EXPECT_EQ(pg.get_read(read_id)->id, read_id);
-    EXPECT_EQ(pg.reads.size(), (uint) 2);
+    EXPECT_EQ(pg.reads.size(), (uint)2);
     EXPECT_EQ(pg.get_read(read_id_2)->id, read_id_2);
 }
 
-
-TEST(PangenomeGraphNode, add_node_and_get_node) {
+TEST(PangenomeGraphNode, add_node_and_get_node)
+{
     PGraphTester pg;
     uint32_t prg_id = 0;
     auto prg_pointer = std::make_shared<LocalPRG>(prg_id, "", "");
 
-    //trivial test - nodes are empty
-    EXPECT_EQ(pg.nodes.size(), (uint) 0);
+    // trivial test - nodes are empty
+    EXPECT_EQ(pg.nodes.size(), (uint)0);
     try {
         pg.get_node(prg_id);
         FAIL() << "pg.get_node() should throw std::out_of_range\n";
+    } catch (const std::out_of_range&) {
+    } catch (...) {
+        FAIL() << "pg.get_node() should throw std::out_of_range\n";
     }
-    catch (const std::out_of_range &) {}
-    catch(...){ FAIL() << "pg.get_node() should throw std::out_of_range\n"; }
     try {
         pg.get_node(prg_pointer);
         FAIL() << "pg.get_node() should throw std::out_of_range\n";
+    } catch (const std::out_of_range&) {
+    } catch (...) {
+        FAIL() << "pg.get_node() should throw std::out_of_range\n";
     }
-    catch (const std::out_of_range &) {}
-    catch(...){ FAIL() << "pg.get_node() should throw std::out_of_range\n"; }
 
-
-    //add a node
+    // add a node
     pg.add_node(prg_pointer);
-    //test if the node was added
-    EXPECT_EQ(pg.nodes.size(), (uint) 1);
+    // test if the node was added
+    EXPECT_EQ(pg.nodes.size(), (uint)1);
     EXPECT_EQ(pg.get_node(prg_id)->prg_id, prg_id);
     EXPECT_EQ(pg.get_node(prg_id)->node_id, prg_id);
     EXPECT_EQ(pg.get_node(prg_pointer)->prg_id, prg_id);
     EXPECT_EQ(pg.get_node(prg_pointer)->node_id, prg_id);
 
-    //add the node again - nothing should change
+    // add the node again - nothing should change
     pg.add_node(prg_pointer);
-    //test if the node was added
-    EXPECT_EQ(pg.nodes.size(), (uint) 1);
+    // test if the node was added
+    EXPECT_EQ(pg.nodes.size(), (uint)1);
     EXPECT_EQ(pg.get_node(prg_id)->prg_id, prg_id);
     EXPECT_EQ(pg.get_node(prg_id)->node_id, prg_id);
     EXPECT_EQ(pg.get_node(prg_pointer)->prg_id, prg_id);
     EXPECT_EQ(pg.get_node(prg_pointer)->node_id, prg_id);
 
-    //add a second node
+    // add a second node
     uint32_t prg_id_2 = 10;
     auto prg_pointer_2 = std::make_shared<LocalPRG>(prg_id_2, "", "");
     pg.add_node(prg_pointer_2);
-    //test if the node was added
-    EXPECT_EQ(pg.nodes.size(), (uint) 2);
+    // test if the node was added
+    EXPECT_EQ(pg.nodes.size(), (uint)2);
     EXPECT_EQ(pg.get_node(prg_id)->prg_id, prg_id);
     EXPECT_EQ(pg.get_node(prg_id)->node_id, prg_id);
     EXPECT_EQ(pg.get_node(prg_pointer)->prg_id, prg_id);
@@ -142,11 +145,11 @@ TEST(PangenomeGraphNode, add_node_and_get_node) {
     EXPECT_EQ(pg.get_node(prg_pointer_2)->prg_id, prg_id_2);
     EXPECT_EQ(pg.get_node(prg_pointer_2)->node_id, prg_id_2);
 
-    //add a third node, with a prg that was already added, but with a different node_id
-    uint32_t other_node_id_for_prg_pointer = prg_id+1;
+    // add a third node, with a prg that was already added, but with a different node_id
+    uint32_t other_node_id_for_prg_pointer = prg_id + 1;
     pg.add_node(prg_pointer, other_node_id_for_prg_pointer);
-    //test if it was added
-    EXPECT_EQ(pg.nodes.size(), (uint) 3);
+    // test if it was added
+    EXPECT_EQ(pg.nodes.size(), (uint)3);
     EXPECT_EQ(pg.get_node(prg_id)->prg_id, prg_id);
     EXPECT_EQ(pg.get_node(prg_id)->node_id, prg_id);
     EXPECT_EQ(pg.get_node(prg_pointer)->prg_id, prg_id);
@@ -156,17 +159,18 @@ TEST(PangenomeGraphNode, add_node_and_get_node) {
     EXPECT_EQ(pg.get_node(prg_pointer_2)->prg_id, prg_id_2);
     EXPECT_EQ(pg.get_node(prg_pointer_2)->node_id, prg_id_2);
     EXPECT_EQ(pg.get_node(other_node_id_for_prg_pointer)->prg_id, prg_id);
-    EXPECT_EQ(pg.get_node(other_node_id_for_prg_pointer)->node_id, other_node_id_for_prg_pointer);
+    EXPECT_EQ(pg.get_node(other_node_id_for_prg_pointer)->node_id,
+        other_node_id_for_prg_pointer);
 }
 
-
-//function that will make things easier by setting up MiniRecord, MinimizerHit, cluster and prg
-void setup_minimizerhit_cluster_prg_function (uint32_t prg_id, uint32_t read_id,
-                                              MiniRecord* mr1,
-                                              MinimizerHitPtr* minimizer_hit,
-                                              std::shared_ptr<std::set<MinimizerHitPtr, pComp>>* cluster_pointer,
-                                              std::shared_ptr<LocalPRG>* prg_pointer) {
-    std::deque<Interval> raw_path = {Interval(7, 8), Interval(10, 14)};
+// function that will make things easier by setting up MiniRecord, MinimizerHit, cluster
+// and prg
+void setup_minimizerhit_cluster_prg_function(uint32_t prg_id, uint32_t read_id,
+    MiniRecord* mr1, MinimizerHitPtr* minimizer_hit,
+    std::shared_ptr<std::set<MinimizerHitPtr, pComp>>* cluster_pointer,
+    std::shared_ptr<LocalPRG>* prg_pointer)
+{
+    std::deque<Interval> raw_path = { Interval(7, 8), Interval(10, 14) };
     prg::Path path;
     path.initialize(raw_path);
 
@@ -182,11 +186,11 @@ void setup_minimizerhit_cluster_prg_function (uint32_t prg_id, uint32_t read_id,
     (*prg_pointer) = std::make_shared<LocalPRG>(prg_id, "", "");
 }
 
-
-TEST(PangenomeGraph_add_hits_between_PRG_and_read, AddClusters) {
+TEST(PangenomeGraph_add_hits_between_PRG_and_read, AddClusters)
+{
     PGraphTester pg;
 
-    //test 1: add a cluster
+    // test 1: add a cluster
     uint32_t prg_id_1 = 1;
     uint32_t read_id_1 = 100;
     MiniRecord mr1;
@@ -194,95 +198,131 @@ TEST(PangenomeGraph_add_hits_between_PRG_and_read, AddClusters) {
     std::shared_ptr<std::set<MinimizerHitPtr, pComp>> cluster_pointer_1;
     std::shared_ptr<LocalPRG> prg_pointer_1;
     {
-        setup_minimizerhit_cluster_prg_function(prg_id_1, read_id_1, &mr1, &minimizer_hit_1, &cluster_pointer_1, &prg_pointer_1);
+        setup_minimizerhit_cluster_prg_function(prg_id_1, read_id_1, &mr1,
+            &minimizer_hit_1, &cluster_pointer_1, &prg_pointer_1);
         pg.add_hits_between_PRG_and_read(prg_pointer_1, read_id_1, *cluster_pointer_1);
 
-        //test if everything is fine
-        EXPECT_EQ(pg.nodes.size(), 1); //is the node really inserted?
-        EXPECT_EQ(pg.get_node(prg_id_1)->node_id, prg_id_1); //is the node really inserted?
-        EXPECT_EQ(pg.get_node(prg_id_1)->covg, 1); //is the coverage of the node 1?
-        EXPECT_EQ(pg.get_node(prg_id_1)->reads.size(), 1); //is the read really inserted in the node?
-        EXPECT_EQ(pg.get_node(prg_id_1)->reads.begin()->get()->id, read_id_1); //is the read really inserted in the node?
+        // test if everything is fine
+        EXPECT_EQ(pg.nodes.size(), 1); // is the node really inserted?
+        EXPECT_EQ(
+            pg.get_node(prg_id_1)->node_id, prg_id_1); // is the node really inserted?
+        EXPECT_EQ(pg.get_node(prg_id_1)->covg, 1); // is the coverage of the node 1?
+        EXPECT_EQ(pg.get_node(prg_id_1)->reads.size(),
+            1); // is the read really inserted in the node?
+        EXPECT_EQ(pg.get_node(prg_id_1)->reads.begin()->get()->id,
+            read_id_1); // is the read really inserted in the node?
         EXPECT_EQ(pg.reads.size(), 1);
-        EXPECT_EQ(pg.get_read(read_id_1)->id, read_id_1); //is the read really inserted?
-        EXPECT_EQ(pg.get_read(read_id_1)->get_hits_as_unordered_map().size(), 1); //is the hit really inserted?
-        EXPECT_EQ(*pg.get_read(read_id_1)->get_hits_as_unordered_map()[prg_id_1][0], *minimizer_hit_1); //is the hit really inserted?
-        EXPECT_EQ(pg.get_read(read_id_1)->get_hits_as_unordered_map()[prg_id_1][0]->get_kmer_node_id(), prg_id_1); //is the node really inserted in the read?
-        EXPECT_EQ(pg.get_read(read_id_1)->node_orientations.size(), 1); //is the node_orientation was inserted in the read?
-        EXPECT_EQ(pg.get_read(read_id_1)->node_orientations[0], true); //is the node_orientation was inserted in the read?
+        EXPECT_EQ(pg.get_read(read_id_1)->id, read_id_1); // is the read really
+                                                          // inserted?
+        EXPECT_EQ(pg.get_read(read_id_1)->get_hits_as_unordered_map().size(),
+            1); // is the hit really inserted?
+        EXPECT_EQ(*pg.get_read(read_id_1)->get_hits_as_unordered_map()[prg_id_1][0],
+            *minimizer_hit_1); // is the hit really inserted?
+        EXPECT_EQ(pg.get_read(read_id_1)
+                      ->get_hits_as_unordered_map()[prg_id_1][0]
+                      ->get_kmer_node_id(),
+            prg_id_1); // is the node really inserted in the read?
+        EXPECT_EQ(pg.get_read(read_id_1)->node_orientations.size(),
+            1); // is the node_orientation was inserted in the read?
+        EXPECT_EQ(pg.get_read(read_id_1)->node_orientations[0],
+            true); // is the node_orientation was inserted in the read?
     }
 
-    //test 2: add a cluster with the same read_id, but different prg_id
+    // test 2: add a cluster with the same read_id, but different prg_id
     uint32_t prg_id_2 = 2;
     MiniRecord mr2;
     MinimizerHitPtr minimizer_hit_2;
     std::shared_ptr<std::set<MinimizerHitPtr, pComp>> cluster_pointer_2;
     std::shared_ptr<LocalPRG> prg_pointer_2;
     {
-        setup_minimizerhit_cluster_prg_function(prg_id_2, read_id_1, &mr2, &minimizer_hit_2, &cluster_pointer_2, &prg_pointer_2);
+        setup_minimizerhit_cluster_prg_function(prg_id_2, read_id_1, &mr2,
+            &minimizer_hit_2, &cluster_pointer_2, &prg_pointer_2);
         pg.add_hits_between_PRG_and_read(prg_pointer_2, read_id_1, *cluster_pointer_2);
 
-        //test if everything is fine
-        EXPECT_EQ(pg.nodes.size(), 2); //is the node really inserted?
+        // test if everything is fine
+        EXPECT_EQ(pg.nodes.size(), 2); // is the node really inserted?
         EXPECT_EQ(pg.get_node(prg_id_1)->node_id, prg_id_1);
-        EXPECT_EQ(pg.get_node(prg_id_2)->node_id, prg_id_2); //is the node really inserted?
-        EXPECT_EQ(pg.get_node(prg_id_1)->covg, 1); //is the coverage of the node 1?
-        EXPECT_EQ(pg.get_node(prg_id_2)->covg, 1); //is the coverage of the node 1?
-        EXPECT_EQ(pg.get_node(prg_id_1)->reads.size(), 1); //is the read really inserted in the node?
-        EXPECT_EQ(pg.get_node(prg_id_2)->reads.size(), 1); //is the read really inserted in the node?
-        EXPECT_EQ(pg.get_node(prg_id_1)->reads.begin()->get()->id, read_id_1); //is the read really inserted in the node?
-        EXPECT_EQ(pg.get_node(prg_id_2)->reads.begin()->get()->id, read_id_1); //is the read really inserted in the node?
+        EXPECT_EQ(
+            pg.get_node(prg_id_2)->node_id, prg_id_2); // is the node really inserted?
+        EXPECT_EQ(pg.get_node(prg_id_1)->covg, 1); // is the coverage of the node 1?
+        EXPECT_EQ(pg.get_node(prg_id_2)->covg, 1); // is the coverage of the node 1?
+        EXPECT_EQ(pg.get_node(prg_id_1)->reads.size(),
+            1); // is the read really inserted in the node?
+        EXPECT_EQ(pg.get_node(prg_id_2)->reads.size(),
+            1); // is the read really inserted in the node?
+        EXPECT_EQ(pg.get_node(prg_id_1)->reads.begin()->get()->id,
+            read_id_1); // is the read really inserted in the node?
+        EXPECT_EQ(pg.get_node(prg_id_2)->reads.begin()->get()->id,
+            read_id_1); // is the read really inserted in the node?
         EXPECT_EQ(pg.reads.size(), 1);
-        EXPECT_EQ(pg.get_read(read_id_1)->id, read_id_1); //is the read really inserted?
-        EXPECT_EQ(pg.get_read(read_id_1)->get_hits_as_unordered_map().size(), 2); //we should have another hit here
-        EXPECT_EQ(*pg.get_read(read_id_1)->get_hits_as_unordered_map()[prg_id_1][0], *minimizer_hit_1); //is the hit really inserted?
-        EXPECT_EQ(*pg.get_read(read_id_1)->get_hits_as_unordered_map()[prg_id_2][0], *minimizer_hit_2); //is the hit really inserted?
-        EXPECT_EQ(pg.get_read(read_id_1)->node_orientations.size(), 2); //is the node_orientation was inserted in the read?
-        EXPECT_EQ(pg.get_read(read_id_1)->node_orientations[0], true); //is the node_orientation was inserted in the read?
-        EXPECT_EQ(pg.get_read(read_id_1)->node_orientations[1], true); //is the node_orientation was inserted in the read?
+        EXPECT_EQ(pg.get_read(read_id_1)->id, read_id_1); // is the read really
+                                                          // inserted?
+        EXPECT_EQ(pg.get_read(read_id_1)->get_hits_as_unordered_map().size(),
+            2); // we should have another hit here
+        EXPECT_EQ(*pg.get_read(read_id_1)->get_hits_as_unordered_map()[prg_id_1][0],
+            *minimizer_hit_1); // is the hit really inserted?
+        EXPECT_EQ(*pg.get_read(read_id_1)->get_hits_as_unordered_map()[prg_id_2][0],
+            *minimizer_hit_2); // is the hit really inserted?
+        EXPECT_EQ(pg.get_read(read_id_1)->node_orientations.size(),
+            2); // is the node_orientation was inserted in the read?
+        EXPECT_EQ(pg.get_read(read_id_1)->node_orientations[0],
+            true); // is the node_orientation was inserted in the read?
+        EXPECT_EQ(pg.get_read(read_id_1)->node_orientations[1],
+            true); // is the node_orientation was inserted in the read?
     }
 
-    //test 3: add a cluster with the same prg_id, but different read_id
+    // test 3: add a cluster with the same prg_id, but different read_id
     uint32_t read_id_3 = 101;
     MiniRecord mr3;
     MinimizerHitPtr minimizer_hit_3;
     std::shared_ptr<std::set<MinimizerHitPtr, pComp>> cluster_pointer_3;
     std::shared_ptr<LocalPRG> prg_pointer_3;
     {
-        setup_minimizerhit_cluster_prg_function(prg_id_1, read_id_3, &mr3, &minimizer_hit_3, &cluster_pointer_3, &prg_pointer_3);
+        setup_minimizerhit_cluster_prg_function(prg_id_1, read_id_3, &mr3,
+            &minimizer_hit_3, &cluster_pointer_3, &prg_pointer_3);
         pg.add_hits_between_PRG_and_read(prg_pointer_3, read_id_3, *cluster_pointer_3);
 
+        // test if everything is fine
+        EXPECT_EQ(pg.nodes.size(), 2); // nothing should change from the previous test
+        EXPECT_EQ(pg.get_node(prg_id_1)->node_id,
+            prg_id_1); // nothing should change from the previous test
+        EXPECT_EQ(pg.get_node(prg_id_2)->node_id,
+            prg_id_2); // nothing should change from the previous test
+        EXPECT_EQ(pg.get_node(prg_id_1)->covg, 2); // coverage should change to 2
+        EXPECT_EQ(pg.get_node(prg_id_2)->covg,
+            1); // nothing should change from the previous test
+        EXPECT_EQ(pg.get_node(prg_id_1)->reads.size(),
+            2); // is the read really inserted in the node?
+        EXPECT_EQ(pg.get_node(prg_id_2)->reads.size(),
+            1); // is the read really inserted in the node?
 
-        //test if everything is fine
-        EXPECT_EQ(pg.nodes.size(), 2); //nothing should change from the previous test
-        EXPECT_EQ(pg.get_node(prg_id_1)->node_id, prg_id_1); //nothing should change from the previous test
-        EXPECT_EQ(pg.get_node(prg_id_2)->node_id, prg_id_2); //nothing should change from the previous test
-        EXPECT_EQ(pg.get_node(prg_id_1)->covg, 2); //coverage should change to 2
-        EXPECT_EQ(pg.get_node(prg_id_2)->covg, 1); //nothing should change from the previous test
-        EXPECT_EQ(pg.get_node(prg_id_1)->reads.size(), 2); //is the read really inserted in the node?
-        EXPECT_EQ(pg.get_node(prg_id_2)->reads.size(), 1); //is the read really inserted in the node?
-
-        std::vector<ReadPtr> reads_in_node_as_vector(pg.get_node(prg_id_1)->reads.begin(), pg.get_node(prg_id_1)->reads.end());
-        EXPECT_TRUE((reads_in_node_as_vector[0]->id==read_id_1 && reads_in_node_as_vector[1]->id==read_id_3) ||
-                    (reads_in_node_as_vector[0]->id==read_id_3 && reads_in_node_as_vector[1]->id==read_id_1));
+        std::vector<ReadPtr> reads_in_node_as_vector(
+            pg.get_node(prg_id_1)->reads.begin(), pg.get_node(prg_id_1)->reads.end());
+        EXPECT_TRUE((reads_in_node_as_vector[0]->id == read_id_1
+                        && reads_in_node_as_vector[1]->id == read_id_3)
+            || (reads_in_node_as_vector[0]->id == read_id_3
+                && reads_in_node_as_vector[1]->id == read_id_1));
 
         EXPECT_EQ(pg.reads.size(), 2);
         EXPECT_EQ(pg.get_read(read_id_3)->id, read_id_3);
         EXPECT_EQ(pg.get_read(read_id_3)->get_hits_as_unordered_map().size(), 1);
-        EXPECT_EQ(*pg.get_read(read_id_3)->get_hits_as_unordered_map()[prg_id_1][0], *minimizer_hit_3);
+        EXPECT_EQ(*pg.get_read(read_id_3)->get_hits_as_unordered_map()[prg_id_1][0],
+            *minimizer_hit_3);
         EXPECT_EQ(pg.get_read(read_id_3)->get_nodes().size(), 1);
         EXPECT_EQ(pg.get_read(read_id_3)->get_nodes()[0].lock()->node_id, prg_id_1);
         EXPECT_EQ(pg.get_read(read_id_3)->node_orientations.size(), 1);
         EXPECT_EQ(pg.get_read(read_id_3)->node_orientations[0], true);
     }
 
-    //TODO: improve this? - add the cluster again, add another cluster, other situations, etc...
+    // TODO: improve this? - add the cluster again, add another cluster, other
+    // situations, etc...
 }
 
-TEST(PangenomeGraphAddNode, NodeDoesntAlreadyExist_PangenomeGraphNodesContainsNodeId) {
+TEST(PangenomeGraphAddNode, NodeDoesntAlreadyExist_PangenomeGraphNodesContainsNodeId)
+{
     PGraphTester pg;
 
-    EXPECT_EQ(pg.nodes.size(), (uint) 0);
+    EXPECT_EQ(pg.nodes.size(), (uint)0);
 
     uint32_t node_id = 5;
     uint32_t prg_id = 10;
@@ -291,12 +331,12 @@ TEST(PangenomeGraphAddNode, NodeDoesntAlreadyExist_PangenomeGraphNodesContainsNo
 
     NodePtr pan_node = std::make_shared<pangenome::Node>(prg_pointer);
     EXPECT_EQ(*pg.nodes[node_id], *pan_node);
-    EXPECT_EQ(pg.nodes[node_id]->node_id, (uint) node_id);
-    EXPECT_EQ(pg.nodes[node_id]->prg_id, (uint) node_id);
+    EXPECT_EQ(pg.nodes[node_id]->node_id, (uint)node_id);
+    EXPECT_EQ(pg.nodes[node_id]->prg_id, (uint)node_id);
     EXPECT_EQ(pg.nodes[node_id]->name, "prg_name");
-    EXPECT_EQ(pg.nodes[node_id]->covg, (uint) 0);
-    EXPECT_EQ(pg.nodes[node_id]->reads.size(), (uint) 0);
-    EXPECT_EQ(pg.nodes[node_id]->samples.size(), (uint) 0);
+    EXPECT_EQ(pg.nodes[node_id]->covg, (uint)0);
+    EXPECT_EQ(pg.nodes[node_id]->reads.size(), (uint)0);
+    EXPECT_EQ(pg.nodes[node_id]->samples.size(), (uint)0);
 
     auto result = pg.nodes.find(node_id) != pg.nodes.end();
     EXPECT_TRUE(result);
@@ -305,9 +345,9 @@ TEST(PangenomeGraphAddNode, NodeDoesntAlreadyExist_PangenomeGraphNodesContainsNo
     EXPECT_TRUE(result);
 }
 
-/* this test is now comprised on TEST(PangenomeGraph_add_hits_between_PRG_and_read, AddClusters)
-TEST(PangenomeGraphAddCoverage, NodeDoesntAlreadyExist_PangenomeGraphNodeContainsReadPtr) {
-    PGraphTester pg;
+/* this test is now comprised on TEST(PangenomeGraph_add_hits_between_PRG_and_read,
+AddClusters) TEST(PangenomeGraphAddCoverage,
+NodeDoesntAlreadyExist_PangenomeGraphNodeContainsReadPtr) { PGraphTester pg;
 
     uint32_t read_id = 2;
     pg.add_read(read_id);
@@ -324,10 +364,11 @@ TEST(PangenomeGraphAddCoverage, NodeDoesntAlreadyExist_PangenomeGraphNodeContain
 }
  */
 
-TEST(PangenomeGraph_add_hits_between_PRG_and_read, AddTheSameClusterTwice) {
+TEST(PangenomeGraph_add_hits_between_PRG_and_read, AddTheSameClusterTwice)
+{
     PGraphTester pg;
 
-    //test 1: add a cluster
+    // test 1: add a cluster
     uint32_t prg_id_1 = 1;
     uint32_t read_id_1 = 100;
     MiniRecord mr1;
@@ -335,49 +376,67 @@ TEST(PangenomeGraph_add_hits_between_PRG_and_read, AddTheSameClusterTwice) {
     std::shared_ptr<std::set<MinimizerHitPtr, pComp>> cluster_pointer_1;
     std::shared_ptr<LocalPRG> prg_pointer_1;
     {
-        setup_minimizerhit_cluster_prg_function(prg_id_1, read_id_1, &mr1, &minimizer_hit_1, &cluster_pointer_1, &prg_pointer_1);
+        setup_minimizerhit_cluster_prg_function(prg_id_1, read_id_1, &mr1,
+            &minimizer_hit_1, &cluster_pointer_1, &prg_pointer_1);
         pg.add_hits_between_PRG_and_read(prg_pointer_1, read_id_1, *cluster_pointer_1);
 
-        //test if everything is fine
-        EXPECT_EQ(pg.nodes.size(), 1); //is the node really inserted?
-        EXPECT_EQ(pg.get_node(prg_id_1)->node_id, prg_id_1); //is the node really inserted?
-        EXPECT_EQ(pg.get_node(prg_id_1)->covg, 1); //is the coverage of the node 1?
-        EXPECT_EQ(pg.get_node(prg_id_1)->reads.size(), 1); //is the read really inserted in the node?
-        EXPECT_EQ(pg.get_node(prg_id_1)->reads.begin()->get()->id, read_id_1); //is the read really inserted in the node?
+        // test if everything is fine
+        EXPECT_EQ(pg.nodes.size(), 1); // is the node really inserted?
+        EXPECT_EQ(
+            pg.get_node(prg_id_1)->node_id, prg_id_1); // is the node really inserted?
+        EXPECT_EQ(pg.get_node(prg_id_1)->covg, 1); // is the coverage of the node 1?
+        EXPECT_EQ(pg.get_node(prg_id_1)->reads.size(),
+            1); // is the read really inserted in the node?
+        EXPECT_EQ(pg.get_node(prg_id_1)->reads.begin()->get()->id,
+            read_id_1); // is the read really inserted in the node?
         EXPECT_EQ(pg.reads.size(), 1);
-        EXPECT_EQ(pg.get_read(read_id_1)->id, read_id_1); //is the read really inserted?
-        EXPECT_EQ(pg.get_read(read_id_1)->get_hits_as_unordered_map().size(), 1); //is the hit really inserted?
-        EXPECT_EQ(*pg.get_read(read_id_1)->get_hits_as_unordered_map()[prg_id_1][0], *minimizer_hit_1); //is the hit really inserted?
-        EXPECT_EQ(pg.get_read(read_id_1)->get_hits_as_unordered_map()[prg_id_1][0]->get_kmer_node_id(), prg_id_1); //is the node really inserted in the read?
-        EXPECT_EQ(pg.get_read(read_id_1)->node_orientations.size(), 1); //is the node_orientation was inserted in the read?
-        EXPECT_EQ(pg.get_read(read_id_1)->node_orientations[0], true); //is the node_orientation was inserted in the read?
+        EXPECT_EQ(pg.get_read(read_id_1)->id, read_id_1); // is the read really
+                                                          // inserted?
+        EXPECT_EQ(pg.get_read(read_id_1)->get_hits_as_unordered_map().size(),
+            1); // is the hit really inserted?
+        EXPECT_EQ(*pg.get_read(read_id_1)->get_hits_as_unordered_map()[prg_id_1][0],
+            *minimizer_hit_1); // is the hit really inserted?
+        EXPECT_EQ(pg.get_read(read_id_1)
+                      ->get_hits_as_unordered_map()[prg_id_1][0]
+                      ->get_kmer_node_id(),
+            prg_id_1); // is the node really inserted in the read?
+        EXPECT_EQ(pg.get_read(read_id_1)->node_orientations.size(),
+            1); // is the node_orientation was inserted in the read?
+        EXPECT_EQ(pg.get_read(read_id_1)->node_orientations[0],
+            true); // is the node_orientation was inserted in the read?
 
-
-        //add the cluster again
-        EXPECT_DEATH(pg.add_hits_between_PRG_and_read(prg_pointer_1, read_id_1, *cluster_pointer_1), "");
+        // add the cluster again
+        EXPECT_DEATH(pg.add_hits_between_PRG_and_read(
+                         prg_pointer_1, read_id_1, *cluster_pointer_1),
+            "");
 
         /*
         EXPECT_EQ(pg.nodes.size(), 1); //should not change
         EXPECT_EQ(pg.get_node(prg_id_1)->node_id, prg_id_1); //should not change
-        EXPECT_EQ(pg.get_node(prg_id_1)->covg, 2); //coverage should increase (TODO: reflect if this is really what should happen, since the read id is exactly the same)
-        EXPECT_EQ(pg.get_node(prg_id_1)->reads.size(), 2); //we should now have 2 reads
-        EXPECT_EQ(pg.get_node(prg_id_1)->reads.begin()->get()->id, read_id_1); //should not change
-        EXPECT_EQ((++pg.get_node(prg_id_1)->reads.begin())->get()->id, read_id_1); //the new read id should be also read_id_1
-        EXPECT_EQ(pg.reads.size(), 1); //should not change
-        EXPECT_EQ(pg.get_read(read_id_1)->id, read_id_1); //should not change
-        EXPECT_EQ(pg.get_read(read_id_1)->get_hits_as_unordered_map().size(), 1); //should not change
-        EXPECT_EQ(*pg.get_read(read_id_1)->get_hits_as_unordered_map()[prg_id_1][0], *minimizer_hit_1); //should not change
-        EXPECT_EQ(pg.get_read(read_id_1)->get_hits_as_unordered_map()[prg_id_1][0]->get_kmer_node_id(), prg_id_1); //should not change
-        EXPECT_EQ(pg.get_read(read_id_1)->node_orientations.size(), 1); //should not change
-        EXPECT_EQ(pg.get_read(read_id_1)->node_orientations[0], true); //should not change
+        EXPECT_EQ(pg.get_node(prg_id_1)->covg, 2); //coverage should increase (TODO:
+        reflect if this is really what should happen, since the read id is exactly the
+        same) EXPECT_EQ(pg.get_node(prg_id_1)->reads.size(), 2); //we should now have 2
+        reads EXPECT_EQ(pg.get_node(prg_id_1)->reads.begin()->get()->id, read_id_1);
+        //should not change
+        EXPECT_EQ((++pg.get_node(prg_id_1)->reads.begin())->get()->id, read_id_1); //the
+        new read id should be also read_id_1 EXPECT_EQ(pg.reads.size(), 1); //should not
+        change EXPECT_EQ(pg.get_read(read_id_1)->id, read_id_1); //should not change
+        EXPECT_EQ(pg.get_read(read_id_1)->get_hits_as_unordered_map().size(), 1);
+        //should not change
+        EXPECT_EQ(*pg.get_read(read_id_1)->get_hits_as_unordered_map()[prg_id_1][0],
+        *minimizer_hit_1); //should not change
+        EXPECT_EQ(pg.get_read(read_id_1)->get_hits_as_unordered_map()[prg_id_1][0]->get_kmer_node_id(),
+        prg_id_1); //should not change
+        EXPECT_EQ(pg.get_read(read_id_1)->node_orientations.size(), 1); //should not
+        change EXPECT_EQ(pg.get_read(read_id_1)->node_orientations[0], true); //should
+        not change
         */
     }
 }
 
-
-/* this test is now comprised on TEST(PangenomeGraph_add_hits_between_PRG_and_read, AddTheSameClusterTwice)
-TEST(PangenomeGraphAddCoverage, NodeAlreadyExists_PangenomeGraphNodeReadsContainsReadTwice) {
-    PGraphTester pg;
+/* this test is now comprised on TEST(PangenomeGraph_add_hits_between_PRG_and_read,
+AddTheSameClusterTwice) TEST(PangenomeGraphAddCoverage,
+NodeAlreadyExists_PangenomeGraphNodeReadsContainsReadTwice) { PGraphTester pg;
 
     uint32_t read_id = 2;
     pg.add_read(read_id);
@@ -396,11 +455,12 @@ TEST(PangenomeGraphAddCoverage, NodeAlreadyExists_PangenomeGraphNodeReadsContain
 }
 */
 
-TEST(PangenomeGraphAddNode, AddClusterWrongReadId_AssertCatches) {
+TEST(PangenomeGraphAddNode, AddClusterWrongReadId_AssertCatches)
+{
     uint32_t read_id = 1;
     uint32_t not_read_id = 7;
 
-    std::deque<Interval> raw_path = {Interval(7, 8), Interval(10, 14)};
+    std::deque<Interval> raw_path = { Interval(7, 8), Interval(10, 14) };
     prg::Path path;
     path.initialize(raw_path);
 
@@ -420,7 +480,8 @@ TEST(PangenomeGraphAddNode, AddClusterWrongReadId_AssertCatches) {
     EXPECT_DEATH(pg.add_hits_between_PRG_and_read(prg_pointer, read_id, cluster), "");
 }
 
-TEST(PangenomeGraphAddNode, AddClusterWrongPrgId_AssertCatches) {
+TEST(PangenomeGraphAddNode, AddClusterWrongPrgId_AssertCatches)
+{
     uint32_t read_id = 1;
     Read read(read_id);
 
@@ -428,7 +489,7 @@ TEST(PangenomeGraphAddNode, AddClusterWrongPrgId_AssertCatches) {
     uint32_t prg_id = 4;
     uint32_t not_prg_id = 7;
     Interval interval(0, 5);
-    std::deque<Interval> raw_path = {Interval(7, 8), Interval(10, 14)};
+    std::deque<Interval> raw_path = { Interval(7, 8), Interval(10, 14) };
     prg::Path path;
     path.initialize(raw_path);
     Minimizer m1(0, interval.start, interval.get_end(), 0); // kmer, start, end, strand
@@ -455,8 +516,8 @@ TEST(PangenomeGraphAddNode, AddNode_PangenomeGraphNodesContainsNodeId) {
 }
 */
 
-
-TEST(PangenomeGraphAddNode, AddNode_PangenomeGraphNodeHasRightProperties) {
+TEST(PangenomeGraphAddNode, AddNode_PangenomeGraphNodeHasRightProperties)
+{
     PGraphTester pg;
     uint32_t node_id = 15;
     auto prg_pointer = std::make_shared<LocalPRG>(node_id, "prg_name", "");
@@ -464,18 +525,20 @@ TEST(PangenomeGraphAddNode, AddNode_PangenomeGraphNodeHasRightProperties) {
 
     NodePtr pan_node = std::make_shared<pangenome::Node>(prg_pointer);
     EXPECT_EQ(*pg.nodes[node_id], *pan_node);
-    EXPECT_EQ(pg.nodes[node_id]->node_id, (uint) node_id);
-    EXPECT_EQ(pg.nodes[node_id]->prg_id, (uint) node_id);
+    EXPECT_EQ(pg.nodes[node_id]->node_id, (uint)node_id);
+    EXPECT_EQ(pg.nodes[node_id]->prg_id, (uint)node_id);
     EXPECT_EQ(pg.nodes[node_id]->name, "prg_name");
-    EXPECT_EQ(pg.nodes[node_id]->covg, (uint) 0);
-    EXPECT_EQ(pg.nodes[node_id]->reads.size(), (uint) 0);
-    EXPECT_EQ(pg.nodes[node_id]->samples.size(), (uint) 0);
+    EXPECT_EQ(pg.nodes[node_id]->covg, (uint)0);
+    EXPECT_EQ(pg.nodes[node_id]->reads.size(), (uint)0);
+    EXPECT_EQ(pg.nodes[node_id]->samples.size(), (uint)0);
 
-    //TODO: fix this
-    //EXPECT_EQ(pg.nodes[node_id]->kmer_prg_with_coverage, KmerGraphWithCoverage(&prg_pointer->kmer_prg));
+    // TODO: fix this
+    // EXPECT_EQ(pg.nodes[node_id]->kmer_prg_with_coverage,
+    // KmerGraphWithCoverage(&prg_pointer->kmer_prg));
 }
 
-TEST(PangenomeGraphAddNode, AddNode_PangenomeGraphReadHasRightProperties) {
+TEST(PangenomeGraphAddNode, AddNode_PangenomeGraphReadHasRightProperties)
+{
     std::set<MinimizerHitPtr, pComp> dummy_cluster;
     PGraphTester pg;
     uint32_t node_id = 0;
@@ -484,102 +547,103 @@ TEST(PangenomeGraphAddNode, AddNode_PangenomeGraphReadHasRightProperties) {
     pg.add_hits_between_PRG_and_read(prg_pointer, read_id, dummy_cluster);
 
     ReadPtr pr = std::make_shared<Read>(read_id);
-    EXPECT_EQ(pg.reads.size(), (uint) 1);
+    EXPECT_EQ(pg.reads.size(), (uint)1);
     EXPECT_EQ(*pg.reads[1], *pr);
-    EXPECT_EQ(pg.reads[1]->get_hits_as_unordered_map().size(), (uint) 1);
-    EXPECT_EQ(pg.reads[1]->get_hits_as_unordered_map()[0].size(), (uint) 0);
+    EXPECT_EQ(pg.reads[1]->get_hits_as_unordered_map().size(), (uint)1);
+    EXPECT_EQ(pg.reads[1]->get_hits_as_unordered_map()[0].size(), (uint)0);
 }
 
-TEST(PangenomeGraphTest, add_node_sample) {
+TEST(PangenomeGraphTest, add_node_sample)
+{
     // add node and check it's there
-    PGraphTester pg({"sample", "sample1"});
+    PGraphTester pg({ "sample", "sample1" });
 
     auto l0 = std::make_shared<LocalPRG>(LocalPRG(0, "zero", "AGCTGCTAGCTTCGGACGCACA"));
     std::vector<KmerNodePtr> kmp;
 
     pg.add_node(l0);
-    pg.add_hits_between_PRG_and_sample (0, "sample", kmp);
+    pg.add_hits_between_PRG_and_sample(0, "sample", kmp);
 
-    EXPECT_EQ(pg.nodes.size(), (uint) 1);
-    EXPECT_EQ(pg.nodes[0]->node_id, (uint) 0);
-    EXPECT_EQ(pg.nodes[0]->prg_id, (uint) 0);
+    EXPECT_EQ(pg.nodes.size(), (uint)1);
+    EXPECT_EQ(pg.nodes[0]->node_id, (uint)0);
+    EXPECT_EQ(pg.nodes[0]->prg_id, (uint)0);
     EXPECT_EQ(pg.nodes[0]->name, "zero");
-    EXPECT_EQ(pg.nodes[0]->covg, (uint) 1);
-    EXPECT_EQ(pg.nodes[0]->reads.size(), (uint) 0);
-    EXPECT_EQ(pg.nodes[0]->samples.size(), (uint) 1);
+    EXPECT_EQ(pg.nodes[0]->covg, (uint)1);
+    EXPECT_EQ(pg.nodes[0]->reads.size(), (uint)0);
+    EXPECT_EQ(pg.nodes[0]->samples.size(), (uint)1);
 
-    EXPECT_EQ(pg.samples.size(), (uint) 2);
+    EXPECT_EQ(pg.samples.size(), (uint)2);
     EXPECT_EQ(pg.samples["sample"]->name, "sample");
-    EXPECT_EQ(pg.samples["sample"]->paths.size(), (uint) 1);
-    EXPECT_EQ(pg.samples["sample"]->paths[0].size(), (uint) 1);
+    EXPECT_EQ(pg.samples["sample"]->paths.size(), (uint)1);
+    EXPECT_EQ(pg.samples["sample"]->paths[0].size(), (uint)1);
 
-    EXPECT_EQ(pg.reads.size(), (uint) 0);
+    EXPECT_EQ(pg.reads.size(), (uint)0);
 
     // add a second time
-    pg.add_hits_between_PRG_and_sample (0, "sample", kmp);
-    EXPECT_EQ(pg.nodes.size(), (uint) 1);
-    EXPECT_EQ(pg.nodes[0]->node_id, (uint) 0);
-    EXPECT_EQ(pg.nodes[0]->prg_id, (uint) 0);
+    pg.add_hits_between_PRG_and_sample(0, "sample", kmp);
+    EXPECT_EQ(pg.nodes.size(), (uint)1);
+    EXPECT_EQ(pg.nodes[0]->node_id, (uint)0);
+    EXPECT_EQ(pg.nodes[0]->prg_id, (uint)0);
     EXPECT_EQ(pg.nodes[0]->name, "zero");
-    EXPECT_EQ(pg.nodes[0]->covg, (uint) 2);
-    EXPECT_EQ(pg.nodes[0]->reads.size(), (uint) 0);
-    EXPECT_EQ(pg.nodes[0]->samples.size(), (uint) 1);
+    EXPECT_EQ(pg.nodes[0]->covg, (uint)2);
+    EXPECT_EQ(pg.nodes[0]->reads.size(), (uint)0);
+    EXPECT_EQ(pg.nodes[0]->samples.size(), (uint)1);
 
-    EXPECT_EQ(pg.samples.size(), (uint) 2);
+    EXPECT_EQ(pg.samples.size(), (uint)2);
     EXPECT_EQ(pg.samples["sample"]->name, "sample");
-    EXPECT_EQ(pg.samples["sample"]->paths.size(), (uint) 1);
-    EXPECT_EQ(pg.samples["sample"]->paths[0].size(), (uint) 2);
+    EXPECT_EQ(pg.samples["sample"]->paths.size(), (uint)1);
+    EXPECT_EQ(pg.samples["sample"]->paths[0].size(), (uint)2);
 
-    EXPECT_EQ(pg.reads.size(), (uint) 0);
+    EXPECT_EQ(pg.reads.size(), (uint)0);
 
     // add a node with a different sample
-    pg.add_hits_between_PRG_and_sample (0, "sample1", kmp);
-    EXPECT_EQ(pg.nodes.size(), (uint) 1);
-    EXPECT_EQ(pg.nodes[0]->node_id, (uint) 0);
-    EXPECT_EQ(pg.nodes[0]->prg_id, (uint) 0);
+    pg.add_hits_between_PRG_and_sample(0, "sample1", kmp);
+    EXPECT_EQ(pg.nodes.size(), (uint)1);
+    EXPECT_EQ(pg.nodes[0]->node_id, (uint)0);
+    EXPECT_EQ(pg.nodes[0]->prg_id, (uint)0);
     EXPECT_EQ(pg.nodes[0]->name, "zero");
-    EXPECT_EQ(pg.nodes[0]->covg, (uint) 3);
-    EXPECT_EQ(pg.nodes[0]->reads.size(), (uint) 0);
-    EXPECT_EQ(pg.nodes[0]->samples.size(), (uint) 2);
+    EXPECT_EQ(pg.nodes[0]->covg, (uint)3);
+    EXPECT_EQ(pg.nodes[0]->reads.size(), (uint)0);
+    EXPECT_EQ(pg.nodes[0]->samples.size(), (uint)2);
 
-    EXPECT_EQ(pg.samples.size(), (uint) 2);
+    EXPECT_EQ(pg.samples.size(), (uint)2);
     EXPECT_EQ(pg.samples["sample"]->name, "sample");
-    EXPECT_EQ(pg.samples["sample"]->paths.size(), (uint) 1);
-    EXPECT_EQ(pg.samples["sample"]->paths[0].size(), (uint) 2);
+    EXPECT_EQ(pg.samples["sample"]->paths.size(), (uint)1);
+    EXPECT_EQ(pg.samples["sample"]->paths[0].size(), (uint)2);
     EXPECT_EQ(pg.samples["sample1"]->name, "sample1");
-    EXPECT_EQ(pg.samples["sample1"]->paths.size(), (uint) 1);
-    EXPECT_EQ(pg.samples["sample1"]->paths[0].size(), (uint) 1);
+    EXPECT_EQ(pg.samples["sample1"]->paths.size(), (uint)1);
+    EXPECT_EQ(pg.samples["sample1"]->paths[0].size(), (uint)1);
 
-    EXPECT_EQ(pg.reads.size(), (uint) 0);
+    EXPECT_EQ(pg.reads.size(), (uint)0);
 
     // add a node with a different prg
     auto l1 = std::make_shared<LocalPRG>(LocalPRG(1, "one", "AGCTGCTAGCTTCGGACGCACA"));
     pg.add_node(l1);
-    pg.add_hits_between_PRG_and_sample (1, "sample1", kmp);
-    EXPECT_EQ(pg.nodes.size(), (uint) 2);
-    EXPECT_EQ(pg.nodes[0]->node_id, (uint) 0);
-    EXPECT_EQ(pg.nodes[0]->prg_id, (uint) 0);
+    pg.add_hits_between_PRG_and_sample(1, "sample1", kmp);
+    EXPECT_EQ(pg.nodes.size(), (uint)2);
+    EXPECT_EQ(pg.nodes[0]->node_id, (uint)0);
+    EXPECT_EQ(pg.nodes[0]->prg_id, (uint)0);
     EXPECT_EQ(pg.nodes[0]->name, "zero");
-    EXPECT_EQ(pg.nodes[0]->covg, (uint) 3);
-    EXPECT_EQ(pg.nodes[0]->reads.size(), (uint) 0);
-    EXPECT_EQ(pg.nodes[0]->samples.size(), (uint) 2);
-    EXPECT_EQ(pg.nodes[1]->node_id, (uint) 1);
-    EXPECT_EQ(pg.nodes[1]->prg_id, (uint) 1);
+    EXPECT_EQ(pg.nodes[0]->covg, (uint)3);
+    EXPECT_EQ(pg.nodes[0]->reads.size(), (uint)0);
+    EXPECT_EQ(pg.nodes[0]->samples.size(), (uint)2);
+    EXPECT_EQ(pg.nodes[1]->node_id, (uint)1);
+    EXPECT_EQ(pg.nodes[1]->prg_id, (uint)1);
     EXPECT_EQ(pg.nodes[1]->name, "one");
-    EXPECT_EQ(pg.nodes[1]->covg, (uint) 1);
-    EXPECT_EQ(pg.nodes[1]->reads.size(), (uint) 0);
-    EXPECT_EQ(pg.nodes[1]->samples.size(), (uint) 1);
+    EXPECT_EQ(pg.nodes[1]->covg, (uint)1);
+    EXPECT_EQ(pg.nodes[1]->reads.size(), (uint)0);
+    EXPECT_EQ(pg.nodes[1]->samples.size(), (uint)1);
 
-    EXPECT_EQ(pg.samples.size(), (uint) 2);
+    EXPECT_EQ(pg.samples.size(), (uint)2);
     EXPECT_EQ(pg.samples["sample"]->name, "sample");
-    EXPECT_EQ(pg.samples["sample"]->paths.size(), (uint) 1);
-    EXPECT_EQ(pg.samples["sample"]->paths[0].size(), (uint) 2);
+    EXPECT_EQ(pg.samples["sample"]->paths.size(), (uint)1);
+    EXPECT_EQ(pg.samples["sample"]->paths[0].size(), (uint)2);
     EXPECT_EQ(pg.samples["sample1"]->name, "sample1");
-    EXPECT_EQ(pg.samples["sample1"]->paths.size(), (uint) 2);
-    EXPECT_EQ(pg.samples["sample1"]->paths[0].size(), (uint) 1);
-    EXPECT_EQ(pg.samples["sample1"]->paths[1].size(), (uint) 1);
+    EXPECT_EQ(pg.samples["sample1"]->paths.size(), (uint)2);
+    EXPECT_EQ(pg.samples["sample1"]->paths[0].size(), (uint)1);
+    EXPECT_EQ(pg.samples["sample1"]->paths[1].size(), (uint)1);
 
-    EXPECT_EQ(pg.reads.size(), (uint) 0);
+    EXPECT_EQ(pg.reads.size(), (uint)0);
 }
 
 /* this test is not needed anymore as we don't have a clear function anymore
@@ -610,8 +674,8 @@ TEST(PangenomeGraphTest, clear) {
 }
  */
 
-
-TEST(PangenomeGraphTest, equals) {
+TEST(PangenomeGraphTest, equals)
+{
     auto l0 = std::make_shared<LocalPRG>(LocalPRG(0, "0", ""));
     auto l1 = std::make_shared<LocalPRG>(LocalPRG(1, "1", ""));
     auto l2 = std::make_shared<LocalPRG>(LocalPRG(2, "2", ""));
@@ -652,7 +716,8 @@ TEST(PangenomeGraphTest, equals) {
     EXPECT_EQ(pg1, pg1);
 }
 
-TEST(PangenomeGraphTest, not_equals) {
+TEST(PangenomeGraphTest, not_equals)
+{
     auto l0 = std::make_shared<LocalPRG>(LocalPRG(0, "0", ""));
     auto l1 = std::make_shared<LocalPRG>(LocalPRG(1, "1", ""));
     auto l2 = std::make_shared<LocalPRG>(LocalPRG(2, "2", ""));
@@ -686,7 +751,8 @@ TEST(PangenomeGraphTest, not_equals) {
     EXPECT_EQ((pg1 != pg1), false);
 }
 
-TEST(PangenomeGraphTest, remove_node) {
+TEST(PangenomeGraphTest, remove_node)
+{
     auto l0 = std::make_shared<LocalPRG>(LocalPRG(0, "0", ""));
     auto l1 = std::make_shared<LocalPRG>(LocalPRG(1, "1", ""));
     auto l2 = std::make_shared<LocalPRG>(LocalPRG(2, "2", ""));
@@ -704,7 +770,6 @@ TEST(PangenomeGraphTest, remove_node) {
     pg1.add_node(l3);
     pg1.add_hits_between_PRG_and_read(l3, 0, dummy_cluster);
 
-
     // read 0: 0->1->3
     pg2.add_node(l0);
     pg1.add_hits_between_PRG_and_read(l0, 0, dummy_cluster);
@@ -717,7 +782,8 @@ TEST(PangenomeGraphTest, remove_node) {
     EXPECT_EQ(pg1, pg2);
 }
 
-TEST(PangenomeGraphTest, remove_read) {
+TEST(PangenomeGraphTest, remove_read)
+{
     auto l0 = std::make_shared<LocalPRG>(LocalPRG(0, "0", ""));
     auto l1 = std::make_shared<LocalPRG>(LocalPRG(1, "1", ""));
     auto l2 = std::make_shared<LocalPRG>(LocalPRG(2, "2", ""));
@@ -771,7 +837,8 @@ TEST(PangenomeGraphTest, remove_read) {
     EXPECT_EQ(pg1, pg3);
 }
 
-TEST(PangenomeGraphTest, remove_low_covg_nodes) {
+TEST(PangenomeGraphTest, remove_low_covg_nodes)
+{
     auto l0 = std::make_shared<LocalPRG>(LocalPRG(0, "0", ""));
     auto l1 = std::make_shared<LocalPRG>(LocalPRG(1, "1", ""));
     auto l2 = std::make_shared<LocalPRG>(LocalPRG(2, "2", ""));
@@ -896,7 +963,8 @@ TEST(PangenomeGraphTest, remove_low_covg_nodes) {
     EXPECT_EQ(pg1, pg3);
 }
 
-TEST(PangenomeGraphTest, split_node_by_reads) {
+TEST(PangenomeGraphTest, split_node_by_reads)
+{
     auto l0 = std::make_shared<LocalPRG>(LocalPRG(0, "0", ""));
     auto l1 = std::make_shared<LocalPRG>(LocalPRG(1, "1", ""));
     auto l2 = std::make_shared<LocalPRG>(LocalPRG(2, "2", ""));
@@ -926,19 +994,19 @@ TEST(PangenomeGraphTest, split_node_by_reads) {
     pg1.add_node(l5);
     pg1.add_hits_between_PRG_and_read(l5, 1, dummy_cluster);
 
-    EXPECT_EQ((uint) 6, pg1.nodes.size());
-    EXPECT_EQ(pg1.nodes[0]->prg_id, (uint) 0);
-    EXPECT_EQ(pg1.nodes[0]->covg, (uint) 2);
-    EXPECT_EQ(pg1.nodes[1]->prg_id, (uint) 1);
-    EXPECT_EQ(pg1.nodes[1]->covg, (uint) 1);
-    EXPECT_EQ(pg1.nodes[2]->prg_id, (uint) 2);
-    EXPECT_EQ(pg1.nodes[2]->covg, (uint) 1);
-    EXPECT_EQ(pg1.nodes[3]->prg_id, (uint) 3);
-    EXPECT_EQ(pg1.nodes[3]->covg, (uint) 1);
-    EXPECT_EQ(pg1.nodes[4]->prg_id, (uint) 4);
-    EXPECT_EQ(pg1.nodes[4]->covg, (uint) 1);
-    EXPECT_EQ(pg1.nodes[5]->prg_id, (uint) 5);
-    EXPECT_EQ(pg1.nodes[5]->covg, (uint) 2);
+    EXPECT_EQ((uint)6, pg1.nodes.size());
+    EXPECT_EQ(pg1.nodes[0]->prg_id, (uint)0);
+    EXPECT_EQ(pg1.nodes[0]->covg, (uint)2);
+    EXPECT_EQ(pg1.nodes[1]->prg_id, (uint)1);
+    EXPECT_EQ(pg1.nodes[1]->covg, (uint)1);
+    EXPECT_EQ(pg1.nodes[2]->prg_id, (uint)2);
+    EXPECT_EQ(pg1.nodes[2]->covg, (uint)1);
+    EXPECT_EQ(pg1.nodes[3]->prg_id, (uint)3);
+    EXPECT_EQ(pg1.nodes[3]->covg, (uint)1);
+    EXPECT_EQ(pg1.nodes[4]->prg_id, (uint)4);
+    EXPECT_EQ(pg1.nodes[4]->covg, (uint)1);
+    EXPECT_EQ(pg1.nodes[5]->prg_id, (uint)5);
+    EXPECT_EQ(pg1.nodes[5]->covg, (uint)2);
 
     // read 0: 0->1->2->3
     pg2.add_node(l0);
@@ -960,27 +1028,27 @@ TEST(PangenomeGraphTest, split_node_by_reads) {
     pg2.add_node(l5);
     pg2.add_hits_between_PRG_and_read(l5, 1, dummy_cluster);
 
-    std::unordered_set<ReadPtr> reads = {pg1.reads[0]};
-    std::vector<uint_least32_t> node_ids = {1, 2, 3};
-    std::vector<uint_least32_t> node_ids_exp = {1, 6, 3};
-    std::vector<bool> node_orients = {0, 0, 0};
+    std::unordered_set<ReadPtr> reads = { pg1.reads[0] };
+    std::vector<uint_least32_t> node_ids = { 1, 2, 3 };
+    std::vector<uint_least32_t> node_ids_exp = { 1, 6, 3 };
+    std::vector<bool> node_orients = { 0, 0, 0 };
     pg1.split_node_by_reads(reads, node_ids, node_orients, 2);
     EXPECT_EQ(pg1, pg2);
     EXPECT_ITERABLE_EQ(std::vector<uint_least32_t>, node_ids_exp, node_ids);
 
-    EXPECT_EQ((uint) 6, pg1.nodes.size());
-    EXPECT_EQ(pg1.nodes[0]->prg_id, (uint) 0);
-    EXPECT_EQ(pg1.nodes[0]->covg, (uint) 2);
-    EXPECT_EQ(pg1.nodes[1]->prg_id, (uint) 1);
-    EXPECT_EQ(pg1.nodes[1]->covg, (uint) 1);
-    EXPECT_EQ(pg1.nodes[6]->prg_id, (uint) 2);
-    EXPECT_EQ(pg1.nodes[6]->covg, (uint) 0);
-    EXPECT_EQ(pg1.nodes[3]->prg_id, (uint) 3);
-    EXPECT_EQ(pg1.nodes[3]->covg, (uint) 1);
-    EXPECT_EQ(pg1.nodes[4]->prg_id, (uint) 4);
-    EXPECT_EQ(pg1.nodes[4]->covg, (uint) 1);
-    EXPECT_EQ(pg1.nodes[5]->prg_id, (uint) 5);
-    EXPECT_EQ(pg1.nodes[5]->covg, (uint) 2);
+    EXPECT_EQ((uint)6, pg1.nodes.size());
+    EXPECT_EQ(pg1.nodes[0]->prg_id, (uint)0);
+    EXPECT_EQ(pg1.nodes[0]->covg, (uint)2);
+    EXPECT_EQ(pg1.nodes[1]->prg_id, (uint)1);
+    EXPECT_EQ(pg1.nodes[1]->covg, (uint)1);
+    EXPECT_EQ(pg1.nodes[6]->prg_id, (uint)2);
+    EXPECT_EQ(pg1.nodes[6]->covg, (uint)0);
+    EXPECT_EQ(pg1.nodes[3]->prg_id, (uint)3);
+    EXPECT_EQ(pg1.nodes[3]->covg, (uint)1);
+    EXPECT_EQ(pg1.nodes[4]->prg_id, (uint)4);
+    EXPECT_EQ(pg1.nodes[4]->covg, (uint)1);
+    EXPECT_EQ(pg1.nodes[5]->prg_id, (uint)5);
+    EXPECT_EQ(pg1.nodes[5]->covg, (uint)2);
 
     // read 0: 0->1->2->3
     pg3.add_node(l0);
@@ -1002,38 +1070,36 @@ TEST(PangenomeGraphTest, split_node_by_reads) {
     pg3.add_node(l5);
     pg3.add_hits_between_PRG_and_read(l5, 1, dummy_cluster);
 
-    reads = {pg1.reads[1]};
-    node_ids = {5, 0, 5};
-    node_ids_exp = {7, 0, 5};
+    reads = { pg1.reads[1] };
+    node_ids = { 5, 0, 5 };
+    node_ids_exp = { 7, 0, 5 };
     pg1.split_node_by_reads(reads, node_ids, node_orients, 5);
     EXPECT_EQ(pg1, pg3);
     EXPECT_ITERABLE_EQ(std::vector<uint_least32_t>, node_ids_exp, node_ids);
 
-    EXPECT_EQ((uint) 7, pg1.nodes.size());
-    EXPECT_EQ(pg1.nodes[0]->prg_id, (uint) 0);
-    EXPECT_EQ(pg1.nodes[0]->covg, (uint) 2);
-    EXPECT_EQ(pg1.nodes[1]->prg_id, (uint) 1);
-    EXPECT_EQ(pg1.nodes[1]->covg, (uint) 1);
-    EXPECT_EQ(pg1.nodes[6]->prg_id, (uint) 2);
-    EXPECT_EQ(pg1.nodes[6]->covg, (uint) 0);
-    EXPECT_EQ(pg1.nodes[3]->prg_id, (uint) 3);
-    EXPECT_EQ(pg1.nodes[3]->covg, (uint) 1);
-    EXPECT_EQ(pg1.nodes[4]->prg_id, (uint) 4);
-    EXPECT_EQ(pg1.nodes[4]->covg, (uint) 1);
-    EXPECT_EQ(pg1.nodes[5]->prg_id, (uint) 5);
-    EXPECT_EQ(pg1.nodes[5]->covg, (uint) 1);
-    EXPECT_EQ(pg1.nodes[7]->prg_id, (uint) 5);
-    EXPECT_EQ(pg1.nodes[7]->covg, (uint) 0);
-
+    EXPECT_EQ((uint)7, pg1.nodes.size());
+    EXPECT_EQ(pg1.nodes[0]->prg_id, (uint)0);
+    EXPECT_EQ(pg1.nodes[0]->covg, (uint)2);
+    EXPECT_EQ(pg1.nodes[1]->prg_id, (uint)1);
+    EXPECT_EQ(pg1.nodes[1]->covg, (uint)1);
+    EXPECT_EQ(pg1.nodes[6]->prg_id, (uint)2);
+    EXPECT_EQ(pg1.nodes[6]->covg, (uint)0);
+    EXPECT_EQ(pg1.nodes[3]->prg_id, (uint)3);
+    EXPECT_EQ(pg1.nodes[3]->covg, (uint)1);
+    EXPECT_EQ(pg1.nodes[4]->prg_id, (uint)4);
+    EXPECT_EQ(pg1.nodes[4]->covg, (uint)1);
+    EXPECT_EQ(pg1.nodes[5]->prg_id, (uint)5);
+    EXPECT_EQ(pg1.nodes[5]->covg, (uint)1);
+    EXPECT_EQ(pg1.nodes[7]->prg_id, (uint)5);
+    EXPECT_EQ(pg1.nodes[7]->covg, (uint)0);
 }
 
-TEST(PangenomeGraphTest, add_hits_to_kmergraph) {
-}
+TEST(PangenomeGraphTest, add_hits_to_kmergraph) {}
 
-
-TEST(PangenomeGraphTest, save_matrix) {
+TEST(PangenomeGraphTest, save_matrix)
+{
     // add node and check it's there
-    std::vector<std::string> names = {"sample1", "sample2", "sample3", "sample4"};
+    std::vector<std::string> names = { "sample1", "sample2", "sample3", "sample4" };
     PGraphTester pg(names);
 
     auto l0 = std::make_shared<LocalPRG>(LocalPRG(0, "zero", "AGCTGCTAGCTTCGGACGCACA"));
@@ -1054,7 +1120,8 @@ TEST(PangenomeGraphTest, save_matrix) {
     pg.save_matrix("../../test/test_cases/pangraph_test_save.matrix", names);
 }
 
-TEST(PangenomeGraphTest, save_mapped_read_strings) {
+TEST(PangenomeGraphTest, save_mapped_read_strings)
+{
     PGraphTester pg;
     pangenome::ReadPtr pr;
     MinimizerHits mhits;
@@ -1063,19 +1130,19 @@ TEST(PangenomeGraphTest, save_mapped_read_strings) {
 
     // read1
     Minimizer m1(0, 1, 6, 0); // kmer, start, end, strand
-    d = {Interval(7, 8), Interval(10, 14)};
+    d = { Interval(7, 8), Interval(10, 14) };
     p.initialize(d);
     MiniRecord mr1(0, p, 0, 0);
     mhits.add_hit(1, m1, mr1); // read 1
 
     Minimizer m2(0, 0, 5, 0);
-    d = {Interval(6, 10), Interval(11, 12)};
+    d = { Interval(6, 10), Interval(11, 12) };
     p.initialize(d);
     MiniRecord mr2(0, p, 0, 0);
     mhits.add_hit(1, m2, mr2);
 
     Minimizer m3(0, 0, 5, 0);
-    d = {Interval(6, 10), Interval(12, 13)};
+    d = { Interval(6, 10), Interval(12, 13) };
     p.initialize(d);
     MiniRecord mr3(0, p, 0, 0);
     mhits.add_hit(1, m3, mr3);
@@ -1085,226 +1152,275 @@ TEST(PangenomeGraphTest, save_mapped_read_strings) {
     pg.add_hits_between_PRG_and_read(l0, 1, mhits.hits);
     mhits.clear();
 
-    //read 2
+    // read 2
     Minimizer m4(0, 2, 7, 1);
-    d = {Interval(6, 10), Interval(11, 12)};
+    d = { Interval(6, 10), Interval(11, 12) };
     p.initialize(d);
     MiniRecord mr4(0, p, 0, 0);
     mhits.add_hit(2, m4, mr4);
 
     Minimizer m5(0, 5, 10, 1);
-    d = {Interval(6, 10), Interval(12, 13)};
+    d = { Interval(6, 10), Interval(12, 13) };
     p.initialize(d);
     MiniRecord mr5(0, p, 0, 0);
     mhits.add_hit(2, m5, mr5);
 
     pg.add_hits_between_PRG_and_read(l0, 2, mhits.hits);
 
-    std::string expected1 = ">read1 pandora: 1 0:6 + \nshould\n>read2 pandora: 2 2:10 - \nis time \n";
-    std::string expected2 = ">read2 pandora: 2 2:10 - \nis time \n>read1 pandora: 1 0:6 + \nshould\n";
+    std::string expected1
+        = ">read1 pandora: 1 0:6 + \nshould\n>read2 pandora: 2 2:10 - \nis time \n";
+    std::string expected2
+        = ">read2 pandora: 2 2:10 - \nis time \n>read1 pandora: 1 0:6 + \nshould\n";
 
-    pg.save_mapped_read_strings("../../test/test_cases/reads.fa", "save_mapped_read_strings");
+    pg.save_mapped_read_strings(
+        "../../test/test_cases/reads.fa", "save_mapped_read_strings");
     std::ifstream ifs("save_mapped_read_strings/zero/zero.reads.fa");
-    std::string content((std::istreambuf_iterator<char>(ifs)), (std::istreambuf_iterator<char>()));
+    std::string content(
+        (std::istreambuf_iterator<char>(ifs)), (std::istreambuf_iterator<char>()));
     EXPECT_TRUE((content == expected1) or (content == expected2));
 
     pg.save_mapped_read_strings("../../test/test_cases/reads.fa", ".");
     std::ifstream ifs2("zero/zero.reads.fa");
-    std::string content2((std::istreambuf_iterator<char>(ifs2)), (std::istreambuf_iterator<char>()));
+    std::string content2(
+        (std::istreambuf_iterator<char>(ifs2)), (std::istreambuf_iterator<char>()));
     EXPECT_TRUE((content2 == expected1) or (content2 == expected2));
 }
 
-TEST(PangenomeGraphTest, get_node_closest_vcf_reference_no_paths) {
-    uint32_t prg_id = 3, w=1, k=3, max_num_kmers_to_average=100;
+TEST(PangenomeGraphTest, get_node_closest_vcf_reference_no_paths)
+{
+    uint32_t prg_id = 3, w = 1, k = 3, max_num_kmers_to_average = 100;
     std::string prg_name = "nested varsite";
-    auto l3 = std::make_shared<LocalPRG>(prg_id, prg_name , "A 5 G 7 C 8 T 7  6 G 5 T");
+    auto l3 = std::make_shared<LocalPRG>(prg_id, prg_name, "A 5 G 7 C 8 T 7  6 G 5 T");
     auto index = std::make_shared<Index>();
     l3->minimizer_sketch(index, w, k);
 
     std::string sample_name = "null_test_sample";
-    pangenome::Graph pangraph({sample_name});
+    pangenome::Graph pangraph({ sample_name });
     std::vector<KmerNodePtr> sample_kmer_path = {};
 
     pangraph.add_node(l3);
     pangraph.add_hits_between_PRG_and_sample(prg_id, sample_name, sample_kmer_path);
-    auto path = pangraph.get_node_closest_vcf_reference(*pangraph.nodes[prg_id], w, *l3,max_num_kmers_to_average);
+    auto path = pangraph.get_node_closest_vcf_reference(
+        *pangraph.nodes[prg_id], w, *l3, max_num_kmers_to_average);
     EXPECT_ITERABLE_EQ(std::vector<LocalNodePtr>, path, l3->prg.top_path());
 }
 
-TEST(PangenomeGraphTest, get_node_closest_vcf_reference_one_path) {
-    uint32_t prg_id = 3, w=1, k=3, max_num_kmers_to_average=100;
+TEST(PangenomeGraphTest, get_node_closest_vcf_reference_one_path)
+{
+    uint32_t prg_id = 3, w = 1, k = 3, max_num_kmers_to_average = 100;
     std::string prg_name = "nested varsite";
-    auto l3 = std::make_shared<LocalPRG>(prg_id, prg_name , "A 5 G 7 C 8 T 7  6 G 5 T");
+    auto l3 = std::make_shared<LocalPRG>(prg_id, prg_name, "A 5 G 7 C 8 T 7  6 G 5 T");
     auto index = std::make_shared<Index>();
     l3->minimizer_sketch(index, w, k);
 
     std::string sample_name = "single_test_sample";
-    pangenome::Graph pangraph({sample_name});
+    pangenome::Graph pangraph({ sample_name });
 
-    auto &kg = l3->kmer_prg;
-    std::vector<KmerNodePtr> sample_kmer_path = {kg.nodes[0], kg.nodes[2], kg.nodes[5], kg.nodes[6]};
+    auto& kg = l3->kmer_prg;
+    std::vector<KmerNodePtr> sample_kmer_path
+        = { kg.nodes[0], kg.nodes[2], kg.nodes[5], kg.nodes[6] };
 
     pangraph.add_node(l3);
     pangraph.add_hits_between_PRG_and_sample(prg_id, sample_name, sample_kmer_path);
-    auto &node = *pangraph.nodes[prg_id];
+    auto& node = *pangraph.nodes[prg_id];
 
-    auto path = pangraph.get_node_closest_vcf_reference(node, w, *l3,max_num_kmers_to_average);
-    std::vector<LocalNodePtr> exp_path = {l3->prg.nodes[0], l3->prg.nodes[1], l3->prg.nodes[3], l3->prg.nodes[4], l3->prg.nodes[6]};
+    auto path = pangraph.get_node_closest_vcf_reference(
+        node, w, *l3, max_num_kmers_to_average);
+    std::vector<LocalNodePtr> exp_path = { l3->prg.nodes[0], l3->prg.nodes[1],
+        l3->prg.nodes[3], l3->prg.nodes[4], l3->prg.nodes[6] };
 
     EXPECT_ITERABLE_EQ(std::vector<LocalNodePtr>, path, exp_path);
 }
 
-TEST(PangenomeGraphTest, get_node_closest_vcf_reference_three_paths) {
-    uint32_t prg_id = 3, w=1, k=3, max_num_kmers_to_average=100;
+TEST(PangenomeGraphTest, get_node_closest_vcf_reference_three_paths)
+{
+    uint32_t prg_id = 3, w = 1, k = 3, max_num_kmers_to_average = 100;
     std::string prg_name = "nested varsite";
-    auto l3 = std::make_shared<LocalPRG>(prg_id, prg_name , "A 5 G 7 C 8 T 7  6 G 5 T");
+    auto l3 = std::make_shared<LocalPRG>(prg_id, prg_name, "A 5 G 7 C 8 T 7  6 G 5 T");
     auto index = std::make_shared<Index>();
     l3->minimizer_sketch(index, w, k);
 
-    pangenome::Graph pangraph({"test_sample1", "test_sample1_again", "test_sample2"});
-    auto &kg = l3->kmer_prg;
+    pangenome::Graph pangraph({ "test_sample1", "test_sample1_again", "test_sample2" });
+    auto& kg = l3->kmer_prg;
 
     std::string sample_name = "test_sample1";
-    std::vector<KmerNodePtr> sample_kmer_path = {kg.nodes[0], kg.nodes[2], kg.nodes[5], kg.nodes[6]};
+    std::vector<KmerNodePtr> sample_kmer_path
+        = { kg.nodes[0], kg.nodes[2], kg.nodes[5], kg.nodes[6] };
     pangraph.add_node(l3);
     pangraph.add_hits_between_PRG_and_sample(prg_id, sample_name, sample_kmer_path);
 
     sample_name = "test_sample1_again";
-    sample_kmer_path = {kg.nodes[0], kg.nodes[2], kg.nodes[5], kg.nodes[6]};
+    sample_kmer_path = { kg.nodes[0], kg.nodes[2], kg.nodes[5], kg.nodes[6] };
     pangraph.add_hits_between_PRG_and_sample(prg_id, sample_name, sample_kmer_path);
 
     sample_name = "test_sample2";
-    sample_kmer_path = {kg.nodes[0], kg.nodes[4], kg.nodes[6]};
+    sample_kmer_path = { kg.nodes[0], kg.nodes[4], kg.nodes[6] };
     pangraph.add_hits_between_PRG_and_sample(prg_id, sample_name, sample_kmer_path);
 
-    auto &node = *pangraph.nodes[prg_id];
-    auto path = pangraph.get_node_closest_vcf_reference(node, w, *l3, max_num_kmers_to_average);
-    std::vector<LocalNodePtr> exp_path = {l3->prg.nodes[0], l3->prg.nodes[1], l3->prg.nodes[3], l3->prg.nodes[4], l3->prg.nodes[6]};
+    auto& node = *pangraph.nodes[prg_id];
+    auto path = pangraph.get_node_closest_vcf_reference(
+        node, w, *l3, max_num_kmers_to_average);
+    std::vector<LocalNodePtr> exp_path = { l3->prg.nodes[0], l3->prg.nodes[1],
+        l3->prg.nodes[3], l3->prg.nodes[4], l3->prg.nodes[6] };
 
     EXPECT_ITERABLE_EQ(std::vector<LocalNodePtr>, path, exp_path);
 }
 
-TEST(PangenomeGraphTest, copy_coverages_to_kmergraphs){
-    uint32_t prg_id = 3, w=1, k=3;
+TEST(PangenomeGraphTest, copy_coverages_to_kmergraphs)
+{
+    uint32_t prg_id = 3, w = 1, k = 3;
     std::string prg_name = "nested varsite", sample_name = "sample";
-    auto l3 = std::make_shared<LocalPRG>(prg_id, prg_name , "A 5 G 7 C 8 T 7  6 G 5 T");
+    auto l3 = std::make_shared<LocalPRG>(prg_id, prg_name, "A 5 G 7 C 8 T 7  6 G 5 T");
     auto index = std::make_shared<Index>();
     l3->minimizer_sketch(index, w, k);
 
-    pangenome::Graph ref_pangraph({sample_name});
+    pangenome::Graph ref_pangraph({ sample_name });
     auto sample_id = 0;
     std::vector<KmerNodePtr> empty = {};
     ref_pangraph.add_node(l3);
     ref_pangraph.add_hits_between_PRG_and_sample(prg_id, sample_name, empty);
 
     EXPECT_TRUE(ref_pangraph.nodes.find(prg_id) != ref_pangraph.nodes.end());
-    auto &kg = *(ref_pangraph.nodes[prg_id]->kmer_prg_with_coverage.kmer_prg);
+    auto& kg = *(ref_pangraph.nodes[prg_id]->kmer_prg_with_coverage.kmer_prg);
     EXPECT_EQ(kg.nodes.size(), (uint)7);
-    auto &kgWithCoverage = ref_pangraph.nodes[prg_id]->kmer_prg_with_coverage;
+    auto& kgWithCoverage = ref_pangraph.nodes[prg_id]->kmer_prg_with_coverage;
     kgWithCoverage.set_covg(2, 5, 1, sample_id);
     kgWithCoverage.set_covg(4, 8, 0, sample_id);
     kgWithCoverage.set_covg(5, 2, 1, sample_id);
     kgWithCoverage.set_covg(6, 5, 0, sample_id);
 
-    pangenome::Graph pangraph({"sample_0", "sample_1", "sample_2", "sample_3"});
+    pangenome::Graph pangraph({ "sample_0", "sample_1", "sample_2", "sample_3" });
     sample_id = 3;
     pangraph.add_node(l3);
     pangraph.add_hits_between_PRG_and_sample(prg_id, "sample_3", empty);
 
     pangraph.copy_coverages_to_kmergraphs(ref_pangraph, sample_id);
 
-    for (uint32_t id = 0; id < 3; ++id){
-        for (const auto &node : pangraph.nodes[prg_id]->kmer_prg_with_coverage.kmer_prg->nodes){
-            EXPECT_EQ(pangraph.nodes[prg_id]->kmer_prg_with_coverage.get_covg(node->id, 0,id), (uint)0);
-            EXPECT_EQ(pangraph.nodes[prg_id]->kmer_prg_with_coverage.get_covg(node->id, 1,id), (uint)0);
+    for (uint32_t id = 0; id < 3; ++id) {
+        for (const auto& node :
+            pangraph.nodes[prg_id]->kmer_prg_with_coverage.kmer_prg->nodes) {
+            EXPECT_EQ(pangraph.nodes[prg_id]->kmer_prg_with_coverage.get_covg(
+                          node->id, 0, id),
+                (uint)0);
+            EXPECT_EQ(pangraph.nodes[prg_id]->kmer_prg_with_coverage.get_covg(
+                          node->id, 1, id),
+                (uint)0);
         }
     }
     auto id = sample_id;
-    EXPECT_EQ(pangraph.nodes[prg_id]->kmer_prg_with_coverage.get_covg(0, 0,id), (uint)0);
-    EXPECT_EQ(pangraph.nodes[prg_id]->kmer_prg_with_coverage.get_covg(0, 1,id), (uint)0);
-    EXPECT_EQ(pangraph.nodes[prg_id]->kmer_prg_with_coverage.get_covg(1, 0,id), (uint)0);
-    EXPECT_EQ(pangraph.nodes[prg_id]->kmer_prg_with_coverage.get_covg(1, 1,id), (uint)0);
-    EXPECT_EQ(pangraph.nodes[prg_id]->kmer_prg_with_coverage.get_covg(2, 0,id), (uint)0);
-    EXPECT_EQ(pangraph.nodes[prg_id]->kmer_prg_with_coverage.get_covg(2, 1,id), (uint)5);
-    EXPECT_EQ(pangraph.nodes[prg_id]->kmer_prg_with_coverage.get_covg(3, 0,id), (uint)0);
-    EXPECT_EQ(pangraph.nodes[prg_id]->kmer_prg_with_coverage.get_covg(3, 1,id), (uint)0);
-    EXPECT_EQ(pangraph.nodes[prg_id]->kmer_prg_with_coverage.get_covg(4, 0,id), (uint)8);
-    EXPECT_EQ(pangraph.nodes[prg_id]->kmer_prg_with_coverage.get_covg(4, 1,id), (uint)0);
-    EXPECT_EQ(pangraph.nodes[prg_id]->kmer_prg_with_coverage.get_covg(5, 0,id), (uint)0);
-    EXPECT_EQ(pangraph.nodes[prg_id]->kmer_prg_with_coverage.get_covg(5, 1,id), (uint)2);
-    EXPECT_EQ(pangraph.nodes[prg_id]->kmer_prg_with_coverage.get_covg(6, 0,id), (uint)5);
-    EXPECT_EQ(pangraph.nodes[prg_id]->kmer_prg_with_coverage.get_covg(6, 1,id), (uint)0);
+    EXPECT_EQ(
+        pangraph.nodes[prg_id]->kmer_prg_with_coverage.get_covg(0, 0, id), (uint)0);
+    EXPECT_EQ(
+        pangraph.nodes[prg_id]->kmer_prg_with_coverage.get_covg(0, 1, id), (uint)0);
+    EXPECT_EQ(
+        pangraph.nodes[prg_id]->kmer_prg_with_coverage.get_covg(1, 0, id), (uint)0);
+    EXPECT_EQ(
+        pangraph.nodes[prg_id]->kmer_prg_with_coverage.get_covg(1, 1, id), (uint)0);
+    EXPECT_EQ(
+        pangraph.nodes[prg_id]->kmer_prg_with_coverage.get_covg(2, 0, id), (uint)0);
+    EXPECT_EQ(
+        pangraph.nodes[prg_id]->kmer_prg_with_coverage.get_covg(2, 1, id), (uint)5);
+    EXPECT_EQ(
+        pangraph.nodes[prg_id]->kmer_prg_with_coverage.get_covg(3, 0, id), (uint)0);
+    EXPECT_EQ(
+        pangraph.nodes[prg_id]->kmer_prg_with_coverage.get_covg(3, 1, id), (uint)0);
+    EXPECT_EQ(
+        pangraph.nodes[prg_id]->kmer_prg_with_coverage.get_covg(4, 0, id), (uint)8);
+    EXPECT_EQ(
+        pangraph.nodes[prg_id]->kmer_prg_with_coverage.get_covg(4, 1, id), (uint)0);
+    EXPECT_EQ(
+        pangraph.nodes[prg_id]->kmer_prg_with_coverage.get_covg(5, 0, id), (uint)0);
+    EXPECT_EQ(
+        pangraph.nodes[prg_id]->kmer_prg_with_coverage.get_covg(5, 1, id), (uint)2);
+    EXPECT_EQ(
+        pangraph.nodes[prg_id]->kmer_prg_with_coverage.get_covg(6, 0, id), (uint)5);
+    EXPECT_EQ(
+        pangraph.nodes[prg_id]->kmer_prg_with_coverage.get_covg(6, 1, id), (uint)0);
 }
 
 TEST(PangenomeGraphTest, infer_node_vcf_reference_path_no_file_strings)
 {
     std::vector<std::shared_ptr<LocalPRG>> prgs;
     std::vector<std::string> prg_strings;
-    prg_strings.push_back("ATGCCGGTAATTAAAGTACGTGAAAAGAAACTGGCTC 5 A 6 G 5 CGAAAACGCACGCCGCACTCGTCTGTAC");
+    prg_strings.push_back(
+        "ATGCCGGTAATTAAAGTACGTGAAAAGAAACTGGCTC 5 A 6 G 5 CGAAAACGCACGCCGCACTCGTCTGTAC");
     prg_strings.push_back("A 5 G 7 C 8 T 7  6 G 5 T");
     prg_strings.push_back("TC 5 ACTC 7 TAGTCA 8 TTGTGA 7  6 AACTAG 5 AG");
     prg_strings.push_back("A 5 G 7 C 8 T 7 T 9 CCG 10 CGG 9  6 G 5 TAT");
 
     std::string sample_name = "sample";
-    pangenome::Graph pangraph({sample_name});
+    pangenome::Graph pangraph({ sample_name });
     std::vector<KmerNodePtr> empty;
     auto index = std::make_shared<Index>();
-    uint32_t prg_id = 0, sample_id = 0, w = 1, k = 3, max_num_kmers_to_average=100;
+    uint32_t prg_id = 0, sample_id = 0, w = 1, k = 3, max_num_kmers_to_average = 100;
     std::unordered_map<std::string, std::string> vcf_refs;
     std::vector<std::vector<LocalNodePtr>> vcf_ref_paths;
-    for (const auto &prg_string : prg_strings){
+    for (const auto& prg_string : prg_strings) {
         std::string prg_name = "prg" + std::to_string(prg_id);
-        prgs.emplace_back(std::make_shared<LocalPRG>(LocalPRG(prg_id, prg_name, prg_string)));
+        prgs.emplace_back(
+            std::make_shared<LocalPRG>(LocalPRG(prg_id, prg_name, prg_string)));
         prgs.back()->minimizer_sketch(index, w, k);
         pangraph.add_node(prgs.back());
         pangraph.add_hits_between_PRG_and_sample(prg_id, sample_name, empty);
-        vcf_ref_paths.emplace_back(pangraph.infer_node_vcf_reference_path(*pangraph.nodes[prg_id], prgs.back(), w,
-                                                                          vcf_refs, max_num_kmers_to_average));
+        vcf_ref_paths.emplace_back(
+            pangraph.infer_node_vcf_reference_path(*pangraph.nodes[prg_id], prgs.back(),
+                w, vcf_refs, max_num_kmers_to_average));
         prg_id++;
     }
 
     EXPECT_EQ(vcf_ref_paths.size(), (uint)4);
-    for (uint j=0; j<vcf_ref_paths.size(); ++j)
-        EXPECT_ITERABLE_EQ(std::vector<LocalNodePtr>, vcf_ref_paths[j], prgs[j]->prg.top_path());
+    for (uint j = 0; j < vcf_ref_paths.size(); ++j)
+        EXPECT_ITERABLE_EQ(
+            std::vector<LocalNodePtr>, vcf_ref_paths[j], prgs[j]->prg.top_path());
 }
 
 TEST(PangenomeGraphTest, infer_node_vcf_reference_path_with_file_strings)
 {
     std::vector<std::shared_ptr<LocalPRG>> prgs;
     std::vector<std::string> prg_strings;
-    prg_strings.push_back("ATGCCGGTAATTAAAGTACGTGAAAAGAAACTGGCTC 5 A 6 G 5 CGAAAACGCACGCCGCACTCGTCTGTAC");
+    prg_strings.push_back(
+        "ATGCCGGTAATTAAAGTACGTGAAAAGAAACTGGCTC 5 A 6 G 5 CGAAAACGCACGCCGCACTCGTCTGTAC");
     prg_strings.push_back("A 5 G 7 C 8 T 7  6 G 5 T");
     prg_strings.push_back("TC 5 ACTC 7 TAGTCA 8 TTGTGA 7  6 AACTAG 5 AG");
-    prg_strings.push_back("AATTTTTTTGGGGTTGGTTTTAAA 5 GGGGG 7 CCCCCC 8 TTTTTT 7 TTTTTT 9 CCGCCGCCGCCG 10 CGGCCGCCG 9  6 GGGGG 5 TATAAAAATTTTTT");
+    prg_strings.push_back("AATTTTTTTGGGGTTGGTTTTAAA 5 GGGGG 7 CCCCCC 8 TTTTTT 7 TTTTTT "
+                          "9 CCGCCGCCGCCG 10 CGGCCGCCG 9  6 GGGGG 5 TATAAAAATTTTTT");
     std::unordered_map<std::string, std::string> vcf_ref_strings;
-    vcf_ref_strings["prg0"] = "ATGCCGGTAATTAAAGTACGTGAAAAGAAACTGGCTCGCGAAAACGCACGCCGCACTCGTCTGTAC"; // valid
-    vcf_ref_strings["prg1"] = "AGT"; //invalid, too short
-    vcf_ref_strings["prg2"] = "ATGCCGGTAATTAAAGTACGTGAAAAGAAACTGGCTCGCGAAAACGCACGCCGCACTCGTCTGTAC"; //invalid, is not a path through prg
-    vcf_ref_strings["prg3"] = "AATTTTTTTGGGGTTGGTTTTAAAGGGGGTTTTTTTTTTTTCCGCCGCCGCCGTATAAAAATTTTTT"; //valid
+    vcf_ref_strings["prg0"]
+        = "ATGCCGGTAATTAAAGTACGTGAAAAGAAACTGGCTCGCGAAAACGCACGCCGCACTCGTCTGTAC"; // valid
+    vcf_ref_strings["prg1"] = "AGT"; // invalid, too short
+    vcf_ref_strings["prg2"] = "ATGCCGGTAATTAAAGTACGTGAAAAGAAACTGGCTCGCGAAAACGCACGCCGCAC"
+                              "TCGTCTGTAC"; // invalid, is not a path through prg
+    vcf_ref_strings["prg3"] = "AATTTTTTTGGGGTTGGTTTTAAAGGGGGTTTTTTTTTTTTCCGCCGCCGCCGTAT"
+                              "AAAAATTTTTT"; // valid
 
     std::string sample_name = "sample";
-    pangenome::Graph pangraph({sample_name});
+    pangenome::Graph pangraph({ sample_name });
     std::vector<KmerNodePtr> empty;
     auto index = std::make_shared<Index>();
-    uint32_t prg_id = 0, sample_id = 0, w = 1, k = 3, max_num_kmers_to_average=100;
+    uint32_t prg_id = 0, sample_id = 0, w = 1, k = 3, max_num_kmers_to_average = 100;
     std::vector<std::vector<LocalNodePtr>> vcf_ref_paths;
-    for (const auto &prg_string : prg_strings){
+    for (const auto& prg_string : prg_strings) {
         std::string prg_name = "prg" + std::to_string(prg_id);
-        prgs.emplace_back(std::make_shared<LocalPRG>(LocalPRG(prg_id, prg_name, prg_string)));
+        prgs.emplace_back(
+            std::make_shared<LocalPRG>(LocalPRG(prg_id, prg_name, prg_string)));
         prgs.back()->minimizer_sketch(index, w, k);
         pangraph.add_node(prgs.back());
         pangraph.add_hits_between_PRG_and_sample(prg_id, sample_name, empty);
-        vcf_ref_paths.emplace_back(pangraph.infer_node_vcf_reference_path(*pangraph.nodes[prg_id], prgs.back(),
-                                                                          w, vcf_ref_strings, max_num_kmers_to_average));
+        vcf_ref_paths.emplace_back(
+            pangraph.infer_node_vcf_reference_path(*pangraph.nodes[prg_id], prgs.back(),
+                w, vcf_ref_strings, max_num_kmers_to_average));
         prg_id++;
     }
 
-    std::vector<LocalNodePtr> exp_path0 = {prgs[0]->prg.nodes[0], prgs[0]->prg.nodes[2], prgs[0]->prg.nodes[3]};
+    std::vector<LocalNodePtr> exp_path0
+        = { prgs[0]->prg.nodes[0], prgs[0]->prg.nodes[2], prgs[0]->prg.nodes[3] };
     EXPECT_ITERABLE_EQ(std::vector<LocalNodePtr>, vcf_ref_paths[0], exp_path0);
-    EXPECT_ITERABLE_EQ(std::vector<LocalNodePtr>, vcf_ref_paths[1], prgs[1]->prg.top_path());
-    EXPECT_ITERABLE_EQ(std::vector<LocalNodePtr>, vcf_ref_paths[2], prgs[2]->prg.top_path());
-    std::vector<LocalNodePtr> exp_path3 = {prgs[3]->prg.nodes[0], prgs[3]->prg.nodes[1], prgs[3]->prg.nodes[3],
-                                           prgs[3]->prg.nodes[4], prgs[3]->prg.nodes[5], prgs[3]->prg.nodes[7],
-                                           prgs[3]->prg.nodes[9]};
+    EXPECT_ITERABLE_EQ(
+        std::vector<LocalNodePtr>, vcf_ref_paths[1], prgs[1]->prg.top_path());
+    EXPECT_ITERABLE_EQ(
+        std::vector<LocalNodePtr>, vcf_ref_paths[2], prgs[2]->prg.top_path());
+    std::vector<LocalNodePtr> exp_path3 = { prgs[3]->prg.nodes[0],
+        prgs[3]->prg.nodes[1], prgs[3]->prg.nodes[3], prgs[3]->prg.nodes[4],
+        prgs[3]->prg.nodes[5], prgs[3]->prg.nodes[7], prgs[3]->prg.nodes[9] };
     EXPECT_ITERABLE_EQ(std::vector<LocalNodePtr>, vcf_ref_paths[3], exp_path3);
 }

--- a/test/pannode_test.cpp
+++ b/test/pannode_test.cpp
@@ -1,30 +1,31 @@
-#include <cstdint>
-#include "gtest/gtest.h"
-#include "test_macro.cpp"
-#include "pangenome/ns.cpp"
-#include "pangenome/pannode.h"
-#include "pangenome/pansample.h"
-#include "pangenome/pangraph.h"
-#include "pangenome/panread.h"
-#include "minihit.h"
 #include "localPRG.h"
-
+#include "minihit.h"
+#include "pangenome/ns.cpp"
+#include "pangenome/pangraph.h"
+#include "pangenome/pannode.h"
+#include "pangenome/panread.h"
+#include "pangenome/pansample.h"
+#include "test_macro.cpp"
+#include "gtest/gtest.h"
+#include <cstdint>
 
 using namespace pangenome;
 
-TEST(PangenomeNodeTest, create) {
+TEST(PangenomeNodeTest, create)
+{
     auto local_graph_ptr { std::make_shared<LocalPRG>(4, "3", "") };
     pangenome::Node pan_node(local_graph_ptr, 3);
     uint32_t j = 3;
     EXPECT_EQ(j, pan_node.node_id);
-    EXPECT_EQ((uint) 4, pan_node.prg_id);
+    EXPECT_EQ((uint)4, pan_node.prg_id);
     EXPECT_EQ("3", pan_node.name);
-    EXPECT_EQ((uint) 0, pan_node.covg);
-    EXPECT_EQ((uint) 0, pan_node.reads.size());
-    EXPECT_EQ((uint) 0, pan_node.samples.size());
+    EXPECT_EQ((uint)0, pan_node.covg);
+    EXPECT_EQ((uint)0, pan_node.reads.size());
+    EXPECT_EQ((uint)0, pan_node.samples.size());
 }
 
-TEST(PangenomeNodeTest, get_name) {
+TEST(PangenomeNodeTest, get_name)
+{
     auto l1 { std::make_shared<LocalPRG>(3, "3", "") };
     auto l2 { std::make_shared<LocalPRG>(2, "2", "") };
     pangenome::Node pn1(l1);
@@ -36,61 +37,62 @@ TEST(PangenomeNodeTest, get_name) {
     EXPECT_EQ(pn3.get_name(), "2.4");
 }
 
-TEST(PangenomeNodeTest, add_path) {
-    //setup the KmerGraph
+TEST(PangenomeNodeTest, add_path)
+{
+    // setup the KmerGraph
     auto local_prg_ptr { std::make_shared<LocalPRG>(3, "3", "") };
-    std::deque<Interval> d = {Interval(0, 0)};
+    std::deque<Interval> d = { Interval(0, 0) };
     prg::Path p;
     p.initialize(d);
     local_prg_ptr->kmer_prg.add_node(p);
-    d = {Interval(0, 1), Interval(4, 5), Interval(8, 9)};
+    d = { Interval(0, 1), Interval(4, 5), Interval(8, 9) };
     p.initialize(d);
     local_prg_ptr->kmer_prg.add_node(p);
-    d = {Interval(4, 5), Interval(8, 9), Interval(16, 16), Interval(23, 24)};
+    d = { Interval(4, 5), Interval(8, 9), Interval(16, 16), Interval(23, 24) };
     p.initialize(d);
     local_prg_ptr->kmer_prg.add_node(p);
-    d = {Interval(0, 1), Interval(4, 5), Interval(12, 13)};
+    d = { Interval(0, 1), Interval(4, 5), Interval(12, 13) };
     p.initialize(d);
     local_prg_ptr->kmer_prg.add_node(p);
-    d = {Interval(4, 5), Interval(12, 13), Interval(16, 16), Interval(23, 24)};
+    d = { Interval(4, 5), Interval(12, 13), Interval(16, 16), Interval(23, 24) };
     p.initialize(d);
     local_prg_ptr->kmer_prg.add_node(p);
-    d = {Interval(0, 1), Interval(19, 20), Interval(23, 24)};
+    d = { Interval(0, 1), Interval(19, 20), Interval(23, 24) };
     p.initialize(d);
     local_prg_ptr->kmer_prg.add_node(p);
-    d = {Interval(24, 24)};
+    d = { Interval(24, 24) };
     p.initialize(d);
     local_prg_ptr->kmer_prg.add_node(p);
-    EXPECT_EQ((uint) 7, local_prg_ptr->kmer_prg.nodes.size());
+    EXPECT_EQ((uint)7, local_prg_ptr->kmer_prg.nodes.size());
 
-    //setup the Node
+    // setup the Node
     pangenome::Node pn1(local_prg_ptr);
     std::vector<KmerNodePtr> kmp;
     pn1.add_path(kmp, 0);
 
-
-    //do the tests
-    EXPECT_EQ((uint) 7, pn1.kmer_prg_with_coverage.kmer_prg->nodes.size());
+    // do the tests
+    EXPECT_EQ((uint)7, pn1.kmer_prg_with_coverage.kmer_prg->nodes.size());
     const auto& nodes = pn1.kmer_prg_with_coverage.kmer_prg->nodes;
-    kmp = {nodes[0], nodes[3], nodes[4], nodes[6]};
+    kmp = { nodes[0], nodes[3], nodes[4], nodes[6] };
     pn1.add_path(kmp, 0);
-    EXPECT_EQ((uint) 1, pn1.kmer_prg_with_coverage.get_covg(0, 0, 0));
-    EXPECT_EQ((uint) 0, pn1.kmer_prg_with_coverage.get_covg(1, 0, 0));
-    EXPECT_EQ((uint) 0, pn1.kmer_prg_with_coverage.get_covg(2, 0, 0));
-    EXPECT_EQ((uint) 1, pn1.kmer_prg_with_coverage.get_covg(3, 0, 0));
-    EXPECT_EQ((uint) 1, pn1.kmer_prg_with_coverage.get_covg(4, 0, 0));
-    EXPECT_EQ((uint) 0, pn1.kmer_prg_with_coverage.get_covg(5, 0, 0));
-    EXPECT_EQ((uint) 1, pn1.kmer_prg_with_coverage.get_covg(6, 0, 0));
-    EXPECT_EQ((uint) 1, pn1.kmer_prg_with_coverage.get_covg(0, 1, 0));
-    EXPECT_EQ((uint) 0, pn1.kmer_prg_with_coverage.get_covg(1, 1, 0));
-    EXPECT_EQ((uint) 0, pn1.kmer_prg_with_coverage.get_covg(2, 1, 0));
-    EXPECT_EQ((uint) 1, pn1.kmer_prg_with_coverage.get_covg(3, 1, 0));
-    EXPECT_EQ((uint) 1, pn1.kmer_prg_with_coverage.get_covg(4, 1, 0));
-    EXPECT_EQ((uint) 0, pn1.kmer_prg_with_coverage.get_covg(5, 1, 0));
-    EXPECT_EQ((uint) 1, pn1.kmer_prg_with_coverage.get_covg(6, 1, 0));
+    EXPECT_EQ((uint)1, pn1.kmer_prg_with_coverage.get_covg(0, 0, 0));
+    EXPECT_EQ((uint)0, pn1.kmer_prg_with_coverage.get_covg(1, 0, 0));
+    EXPECT_EQ((uint)0, pn1.kmer_prg_with_coverage.get_covg(2, 0, 0));
+    EXPECT_EQ((uint)1, pn1.kmer_prg_with_coverage.get_covg(3, 0, 0));
+    EXPECT_EQ((uint)1, pn1.kmer_prg_with_coverage.get_covg(4, 0, 0));
+    EXPECT_EQ((uint)0, pn1.kmer_prg_with_coverage.get_covg(5, 0, 0));
+    EXPECT_EQ((uint)1, pn1.kmer_prg_with_coverage.get_covg(6, 0, 0));
+    EXPECT_EQ((uint)1, pn1.kmer_prg_with_coverage.get_covg(0, 1, 0));
+    EXPECT_EQ((uint)0, pn1.kmer_prg_with_coverage.get_covg(1, 1, 0));
+    EXPECT_EQ((uint)0, pn1.kmer_prg_with_coverage.get_covg(2, 1, 0));
+    EXPECT_EQ((uint)1, pn1.kmer_prg_with_coverage.get_covg(3, 1, 0));
+    EXPECT_EQ((uint)1, pn1.kmer_prg_with_coverage.get_covg(4, 1, 0));
+    EXPECT_EQ((uint)0, pn1.kmer_prg_with_coverage.get_covg(5, 1, 0));
+    EXPECT_EQ((uint)1, pn1.kmer_prg_with_coverage.get_covg(6, 1, 0));
 }
 
-TEST(PangenomeNodeTest, get_read_overlap_coordinates) {
+TEST(PangenomeNodeTest, get_read_overlap_coordinates)
+{
     auto local_prg_ptr { std::make_shared<LocalPRG>(3, "3", "") };
     auto pan_node_ptr = std::make_shared<pangenome::Node>(local_prg_ptr);
     pangenome::ReadPtr pr;
@@ -101,19 +103,19 @@ TEST(PangenomeNodeTest, get_read_overlap_coordinates) {
 
     // read1
     Minimizer m1(0, 1, 6, 0); // kmer, start, end, strand
-    d = {Interval(7, 8), Interval(10, 14)};
+    d = { Interval(7, 8), Interval(10, 14) };
     p.initialize(d);
     MiniRecord mr1(3, p, 0, 0);
     mhits.add_hit(1, m1, mr1); // read 1
 
     Minimizer m2(0, 0, 5, 0);
-    d = {Interval(6, 10), Interval(11, 12)};
+    d = { Interval(6, 10), Interval(11, 12) };
     p.initialize(d);
     MiniRecord mr2(3, p, 0, 0);
     mhits.add_hit(1, m2, mr2);
 
     Minimizer m3(0, 0, 5, 0);
-    d = {Interval(6, 10), Interval(12, 13)};
+    d = { Interval(6, 10), Interval(12, 13) };
     p.initialize(d);
     MiniRecord mr3(3, p, 0, 0);
     mhits.add_hit(1, m3, mr3);
@@ -123,15 +125,15 @@ TEST(PangenomeNodeTest, get_read_overlap_coordinates) {
     pan_node_ptr->reads.insert(pr);
     mhits.clear();
 
-    //read 2
+    // read 2
     Minimizer m4(0, 2, 7, 1);
-    d = {Interval(6, 10), Interval(11, 12)};
+    d = { Interval(6, 10), Interval(11, 12) };
     p.initialize(d);
     MiniRecord mr4(3, p, 0, 0);
     mhits.add_hit(2, m4, mr4);
 
     Minimizer m5(0, 5, 10, 1);
-    d = {Interval(6, 10), Interval(12, 13)};
+    d = { Interval(6, 10), Interval(12, 13) };
     p.initialize(d);
     MiniRecord mr5(3, p, 0, 0);
     mhits.add_hit(2, m5, mr5);
@@ -143,63 +145,70 @@ TEST(PangenomeNodeTest, get_read_overlap_coordinates) {
 
     std::vector<std::vector<uint32_t>> read_overlap_coordinates;
     pan_node_ptr->get_read_overlap_coordinates(read_overlap_coordinates);
-    std::vector<std::vector<uint32_t>> expected_read_overlap_coordinates = {{1, 0, 6,  1},
-                                                                            {2, 2, 10, 0}};
-    for (const auto &coord : read_overlap_coordinates) {
+    std::vector<std::vector<uint32_t>> expected_read_overlap_coordinates
+        = { { 1, 0, 6, 1 }, { 2, 2, 10, 0 } };
+    for (const auto& coord : read_overlap_coordinates) {
         if (coord[0] == 1) {
-            EXPECT_ITERABLE_EQ(std::vector<uint32_t>, expected_read_overlap_coordinates[0], coord);
+            EXPECT_ITERABLE_EQ(
+                std::vector<uint32_t>, expected_read_overlap_coordinates[0], coord);
         } else {
-            EXPECT_ITERABLE_EQ(std::vector<uint32_t>, expected_read_overlap_coordinates[1], coord);
+            EXPECT_ITERABLE_EQ(
+                std::vector<uint32_t>, expected_read_overlap_coordinates[1], coord);
         }
     }
 }
 
-TEST(PangenomeNodeTest,construct_multisample_vcf_single_prg)
+TEST(PangenomeNodeTest, construct_multisample_vcf_single_prg)
 {
-    uint32_t prg_id = 3, w=1, k=3, min_kmer_covg=0;
+    uint32_t prg_id = 3, w = 1, k = 3, min_kmer_covg = 0;
     std::string prg_name = "nested varsite";
-    LocalPRG local_prg(prg_id, prg_name , "A 5 G 7 C 8 T 8 CT 7  6 G 5 T");
+    LocalPRG local_prg(prg_id, prg_name, "A 5 G 7 C 8 T 8 CT 7  6 G 5 T");
 
     auto index = std::make_shared<Index>();
     local_prg.minimizer_sketch(index, w, k);
     auto prg_ptr = std::make_shared<LocalPRG>(local_prg);
-    auto &kg = local_prg.kmer_prg;
+    auto& kg = local_prg.kmer_prg;
 
-    std::vector<std::string> sample_names = {"sample1", "sample2", "sample3", "sample4"};
+    std::vector<std::string> sample_names
+        = { "sample1", "sample2", "sample3", "sample4" };
     pangenome::Graph pangraph(sample_names);
 
-    //sample1
-    std::vector<KmerNodePtr> sample_kmer_path = {kg.nodes[0], kg.nodes[2], kg.nodes[6], kg.nodes[9]};
+    // sample1
+    std::vector<KmerNodePtr> sample_kmer_path
+        = { kg.nodes[0], kg.nodes[2], kg.nodes[6], kg.nodes[9] };
     pangraph.add_node(prg_ptr);
     pangraph.add_hits_between_PRG_and_sample(prg_id, sample_names[0], sample_kmer_path);
 
-    //sample2 identical to sample1
-    sample_kmer_path = {kg.nodes[0], kg.nodes[2], kg.nodes[6], kg.nodes[9]};
+    // sample2 identical to sample1
+    sample_kmer_path = { kg.nodes[0], kg.nodes[2], kg.nodes[6], kg.nodes[9] };
     pangraph.add_node(prg_ptr);
     pangraph.add_hits_between_PRG_and_sample(prg_id, sample_names[1], sample_kmer_path);
 
-    //sample3 with top path
-    sample_kmer_path = {kg.nodes[0], kg.nodes[1], kg.nodes[5], kg.nodes[9]};
+    // sample3 with top path
+    sample_kmer_path = { kg.nodes[0], kg.nodes[1], kg.nodes[5], kg.nodes[9] };
     pangraph.add_node(prg_ptr);
     pangraph.add_hits_between_PRG_and_sample(prg_id, sample_names[2], sample_kmer_path);
 
-    //sample4 with bottom path
-    sample_kmer_path = {kg.nodes[0], kg.nodes[4], kg.nodes[9]};
+    // sample4 with bottom path
+    sample_kmer_path = { kg.nodes[0], kg.nodes[4], kg.nodes[9] };
     pangraph.add_node(prg_ptr);
     pangraph.add_hits_between_PRG_and_sample(prg_id, sample_names[3], sample_kmer_path);
 
-
     VCF master_vcf;
-    std::vector<LocalNodePtr> vcf_reference_path = {local_prg.prg.nodes[0], local_prg.prg.nodes[1], local_prg.prg.nodes[3], local_prg.prg.nodes[5], local_prg.prg.nodes[7]};
-    auto &pannode = *pangraph.nodes[prg_id];
-    pannode.construct_multisample_vcf(master_vcf, vcf_reference_path, prg_ptr, w, min_kmer_covg);
+    std::vector<LocalNodePtr> vcf_reference_path
+        = { local_prg.prg.nodes[0], local_prg.prg.nodes[1], local_prg.prg.nodes[3],
+              local_prg.prg.nodes[5], local_prg.prg.nodes[7] };
+    auto& pannode = *pangraph.nodes[prg_id];
+    pannode.construct_multisample_vcf(
+        master_vcf, vcf_reference_path, prg_ptr, w, min_kmer_covg);
 
     EXPECT_EQ((uint)2, master_vcf.records.size());
     EXPECT_EQ((uint)4, master_vcf.samples.size());
 
-    //NB samples order changes to get index of each sample so can compare
-    //samples 1 and 2 are ref, sample 3 is top path and sample 4 is bottom path
-    auto iter = std::find(master_vcf.samples.begin(), master_vcf.samples.end(), "sample1");
+    // NB samples order changes to get index of each sample so can compare
+    // samples 1 and 2 are ref, sample 3 is top path and sample 4 is bottom path
+    auto iter
+        = std::find(master_vcf.samples.begin(), master_vcf.samples.end(), "sample1");
     auto sample1_index = std::distance(master_vcf.samples.begin(), iter);
     iter = std::find(master_vcf.samples.begin(), master_vcf.samples.end(), "sample2");
     auto sample2_index = std::distance(master_vcf.samples.begin(), iter);
@@ -207,36 +216,50 @@ TEST(PangenomeNodeTest,construct_multisample_vcf_single_prg)
     auto sample3_index = std::distance(master_vcf.samples.begin(), iter);
     iter = std::find(master_vcf.samples.begin(), master_vcf.samples.end(), "sample4");
     auto sample4_index = std::distance(master_vcf.samples.begin(), iter);
-    std::vector<uint16_t> alt_gt = {1};
-    std::vector<uint16_t> ref_gt = {0};
-    std::vector<uint16_t> no_covg2 = {0,0};
-    std::vector<uint16_t> no_covg3 = {0,0,0};
+    std::vector<uint16_t> alt_gt = { 1 };
+    std::vector<uint16_t> ref_gt = { 0 };
+    std::vector<uint16_t> no_covg2 = { 0, 0 };
+    std::vector<uint16_t> no_covg3 = { 0, 0, 0 };
 
     EXPECT_EQ((uint)1, master_vcf.records[0]->pos);
     EXPECT_EQ("GT", master_vcf.records[0]->ref);
     EXPECT_EQ((uint)1, master_vcf.records[0]->alt.size());
     EXPECT_EQ("G", master_vcf.records[0]->alt[0]);
     EXPECT_EQ((uint)4, master_vcf.records[0]->samples.size());
-    EXPECT_FALSE(master_vcf.records[0]->samples[sample4_index].find("GT") == master_vcf.records[0]->samples[sample4_index].end()) ;
-    EXPECT_TRUE(master_vcf.records[0]->samples[sample3_index].find("GT") == master_vcf.records[0]->samples[sample3_index].end()) ;
-    EXPECT_FALSE(master_vcf.records[0]->samples[sample2_index].find("GT") == master_vcf.records[0]->samples[sample2_index].end()) ;
-    EXPECT_FALSE(master_vcf.records[0]->samples[sample1_index].find("GT") == master_vcf.records[0]->samples[sample1_index].end()) ;
-    EXPECT_ITERABLE_EQ(std::vector<uint16_t>, master_vcf.records[0]->samples[sample4_index]["GT"], alt_gt);
-    EXPECT_ITERABLE_EQ(std::vector<uint16_t>, master_vcf.records[0]->samples[sample2_index]["GT"], ref_gt);
-    EXPECT_ITERABLE_EQ(std::vector<uint16_t>, master_vcf.records[0]->samples[sample1_index]["GT"], ref_gt);
-    std::vector<std::string> formats = {"MEAN_FWD_COVG", "MEAN_REV_COVG", "MED_FWD_COVG", "MED_REV_COVG",
-                              "SUM_FWD_COVG", "SUM_REV_COVG"};
-    for (const auto format : formats){
-        EXPECT_FALSE(master_vcf.records[0]->samples[sample1_index].find(format) == master_vcf.records[0]->samples[sample1_index].end());
-        EXPECT_FALSE(master_vcf.records[0]->samples[sample2_index].find(format) == master_vcf.records[0]->samples[sample2_index].end());
-        EXPECT_FALSE(master_vcf.records[0]->samples[sample3_index].find(format) == master_vcf.records[0]->samples[sample3_index].end());
-        EXPECT_FALSE(master_vcf.records[0]->samples[sample4_index].find(format) == master_vcf.records[0]->samples[sample4_index].end());
-        EXPECT_ITERABLE_EQ(std::vector<uint16_t>, master_vcf.records[0]->samples[sample1_index][format], no_covg2);
-        EXPECT_ITERABLE_EQ(std::vector<uint16_t>, master_vcf.records[0]->samples[sample2_index][format], no_covg2);
-        EXPECT_ITERABLE_EQ(std::vector<uint16_t>, master_vcf.records[0]->samples[sample3_index][format], no_covg2);
-        EXPECT_ITERABLE_EQ(std::vector<uint16_t>, master_vcf.records[0]->samples[sample4_index][format], no_covg2);
+    EXPECT_FALSE(master_vcf.records[0]->samples[sample4_index].find("GT")
+        == master_vcf.records[0]->samples[sample4_index].end());
+    EXPECT_TRUE(master_vcf.records[0]->samples[sample3_index].find("GT")
+        == master_vcf.records[0]->samples[sample3_index].end());
+    EXPECT_FALSE(master_vcf.records[0]->samples[sample2_index].find("GT")
+        == master_vcf.records[0]->samples[sample2_index].end());
+    EXPECT_FALSE(master_vcf.records[0]->samples[sample1_index].find("GT")
+        == master_vcf.records[0]->samples[sample1_index].end());
+    EXPECT_ITERABLE_EQ(std::vector<uint16_t>,
+        master_vcf.records[0]->samples[sample4_index]["GT"], alt_gt);
+    EXPECT_ITERABLE_EQ(std::vector<uint16_t>,
+        master_vcf.records[0]->samples[sample2_index]["GT"], ref_gt);
+    EXPECT_ITERABLE_EQ(std::vector<uint16_t>,
+        master_vcf.records[0]->samples[sample1_index]["GT"], ref_gt);
+    std::vector<std::string> formats = { "MEAN_FWD_COVG", "MEAN_REV_COVG",
+        "MED_FWD_COVG", "MED_REV_COVG", "SUM_FWD_COVG", "SUM_REV_COVG" };
+    for (const auto format : formats) {
+        EXPECT_FALSE(master_vcf.records[0]->samples[sample1_index].find(format)
+            == master_vcf.records[0]->samples[sample1_index].end());
+        EXPECT_FALSE(master_vcf.records[0]->samples[sample2_index].find(format)
+            == master_vcf.records[0]->samples[sample2_index].end());
+        EXPECT_FALSE(master_vcf.records[0]->samples[sample3_index].find(format)
+            == master_vcf.records[0]->samples[sample3_index].end());
+        EXPECT_FALSE(master_vcf.records[0]->samples[sample4_index].find(format)
+            == master_vcf.records[0]->samples[sample4_index].end());
+        EXPECT_ITERABLE_EQ(std::vector<uint16_t>,
+            master_vcf.records[0]->samples[sample1_index][format], no_covg2);
+        EXPECT_ITERABLE_EQ(std::vector<uint16_t>,
+            master_vcf.records[0]->samples[sample2_index][format], no_covg2);
+        EXPECT_ITERABLE_EQ(std::vector<uint16_t>,
+            master_vcf.records[0]->samples[sample3_index][format], no_covg2);
+        EXPECT_ITERABLE_EQ(std::vector<uint16_t>,
+            master_vcf.records[0]->samples[sample4_index][format], no_covg2);
     }
-
 
     EXPECT_EQ((uint)2, master_vcf.records[1]->pos);
     EXPECT_EQ("T", master_vcf.records[1]->ref);
@@ -244,92 +267,122 @@ TEST(PangenomeNodeTest,construct_multisample_vcf_single_prg)
     EXPECT_EQ("C", master_vcf.records[1]->alt[0]);
     EXPECT_EQ("CT", master_vcf.records[1]->alt[1]);
     EXPECT_EQ((uint)4, master_vcf.records[0]->samples.size());
-    EXPECT_TRUE(master_vcf.records[1]->samples[sample4_index].find("GT") == master_vcf.records[1]->samples[sample4_index].end()) ;
-    EXPECT_FALSE(master_vcf.records[1]->samples[sample3_index].find("GT") == master_vcf.records[1]->samples[sample3_index].end()) ;
-    EXPECT_FALSE(master_vcf.records[1]->samples[sample2_index].find("GT") == master_vcf.records[1]->samples[sample2_index].end()) ;
-    EXPECT_FALSE(master_vcf.records[1]->samples[sample1_index].find("GT") == master_vcf.records[1]->samples[sample1_index].end()) ;
-    EXPECT_ITERABLE_EQ(std::vector<uint16_t>, master_vcf.records[1]->samples[sample3_index]["GT"], alt_gt);
-    EXPECT_ITERABLE_EQ(std::vector<uint16_t>, master_vcf.records[1]->samples[sample2_index]["GT"], ref_gt);
-    EXPECT_ITERABLE_EQ(std::vector<uint16_t>, master_vcf.records[1]->samples[sample1_index]["GT"], ref_gt);
+    EXPECT_TRUE(master_vcf.records[1]->samples[sample4_index].find("GT")
+        == master_vcf.records[1]->samples[sample4_index].end());
+    EXPECT_FALSE(master_vcf.records[1]->samples[sample3_index].find("GT")
+        == master_vcf.records[1]->samples[sample3_index].end());
+    EXPECT_FALSE(master_vcf.records[1]->samples[sample2_index].find("GT")
+        == master_vcf.records[1]->samples[sample2_index].end());
+    EXPECT_FALSE(master_vcf.records[1]->samples[sample1_index].find("GT")
+        == master_vcf.records[1]->samples[sample1_index].end());
+    EXPECT_ITERABLE_EQ(std::vector<uint16_t>,
+        master_vcf.records[1]->samples[sample3_index]["GT"], alt_gt);
+    EXPECT_ITERABLE_EQ(std::vector<uint16_t>,
+        master_vcf.records[1]->samples[sample2_index]["GT"], ref_gt);
+    EXPECT_ITERABLE_EQ(std::vector<uint16_t>,
+        master_vcf.records[1]->samples[sample1_index]["GT"], ref_gt);
 
-    for (const auto format : formats){
-        EXPECT_FALSE(master_vcf.records[1]->samples[sample1_index].find(format) == master_vcf.records[1]->samples[sample1_index].end());
-        EXPECT_FALSE(master_vcf.records[1]->samples[sample2_index].find(format) == master_vcf.records[1]->samples[sample2_index].end());
-        EXPECT_FALSE(master_vcf.records[1]->samples[sample3_index].find(format) == master_vcf.records[1]->samples[sample3_index].end());
-        EXPECT_FALSE(master_vcf.records[1]->samples[sample4_index].find(format) == master_vcf.records[1]->samples[sample4_index].end());
-        EXPECT_ITERABLE_EQ(std::vector<uint16_t>, master_vcf.records[1]->samples[sample1_index][format], no_covg3);
-        EXPECT_ITERABLE_EQ(std::vector<uint16_t>, master_vcf.records[1]->samples[sample2_index][format], no_covg3);
-        EXPECT_ITERABLE_EQ(std::vector<uint16_t>, master_vcf.records[1]->samples[sample3_index][format], no_covg3);
-        EXPECT_ITERABLE_EQ(std::vector<uint16_t>, master_vcf.records[1]->samples[sample4_index][format], no_covg3);
+    for (const auto format : formats) {
+        EXPECT_FALSE(master_vcf.records[1]->samples[sample1_index].find(format)
+            == master_vcf.records[1]->samples[sample1_index].end());
+        EXPECT_FALSE(master_vcf.records[1]->samples[sample2_index].find(format)
+            == master_vcf.records[1]->samples[sample2_index].end());
+        EXPECT_FALSE(master_vcf.records[1]->samples[sample3_index].find(format)
+            == master_vcf.records[1]->samples[sample3_index].end());
+        EXPECT_FALSE(master_vcf.records[1]->samples[sample4_index].find(format)
+            == master_vcf.records[1]->samples[sample4_index].end());
+        EXPECT_ITERABLE_EQ(std::vector<uint16_t>,
+            master_vcf.records[1]->samples[sample1_index][format], no_covg3);
+        EXPECT_ITERABLE_EQ(std::vector<uint16_t>,
+            master_vcf.records[1]->samples[sample2_index][format], no_covg3);
+        EXPECT_ITERABLE_EQ(std::vector<uint16_t>,
+            master_vcf.records[1]->samples[sample3_index][format], no_covg3);
+        EXPECT_ITERABLE_EQ(std::vector<uint16_t>,
+            master_vcf.records[1]->samples[sample4_index][format], no_covg3);
     }
 }
 
-TEST(PangenomeNodeTest,construct_multisample_vcf_two_prg)
+TEST(PangenomeNodeTest, construct_multisample_vcf_two_prg)
 {
-    uint32_t prg_id1 = 3, w=1, k=3, min_kmer_covg=0;
+    uint32_t prg_id1 = 3, w = 1, k = 3, min_kmer_covg = 0;
     std::string prg_name1 = "nested varsite";
-    LocalPRG local_prg1(prg_id1, prg_name1 , "A 5 G 7 C 8 T 8 CT 7  6 G 5 T");
+    LocalPRG local_prg1(prg_id1, prg_name1, "A 5 G 7 C 8 T 8 CT 7  6 G 5 T");
     uint32_t prg_id2 = 5;
     std::string prg_name2 = "modified";
-    LocalPRG local_prg2(prg_id2, prg_name2 , "A 5 G 7 G 8 A 8 GA 7  6 G 5 T");
+    LocalPRG local_prg2(prg_id2, prg_name2, "A 5 G 7 G 8 A 8 GA 7  6 G 5 T");
 
     auto index = std::make_shared<Index>();
     local_prg1.minimizer_sketch(index, w, k);
     auto prg_ptr1 = std::make_shared<LocalPRG>(local_prg1);
-    auto &kg1 = local_prg1.kmer_prg;
+    auto& kg1 = local_prg1.kmer_prg;
     local_prg2.minimizer_sketch(index, w, k);
     auto prg_ptr2 = std::make_shared<LocalPRG>(local_prg2);
-    auto &kg2 = local_prg2.kmer_prg;
+    auto& kg2 = local_prg2.kmer_prg;
 
-    std::vector<std::string> sample_names = {"sample1", "sample2", "sample3", "sample4"};
+    std::vector<std::string> sample_names
+        = { "sample1", "sample2", "sample3", "sample4" };
     pangenome::Graph pangraph(sample_names);
 
-    //sample1
-    std::vector<KmerNodePtr> sample_kmer_path = {kg1.nodes[0], kg1.nodes[2], kg1.nodes[6], kg1.nodes[9]};
+    // sample1
+    std::vector<KmerNodePtr> sample_kmer_path
+        = { kg1.nodes[0], kg1.nodes[2], kg1.nodes[6], kg1.nodes[9] };
     pangraph.add_node(prg_ptr1);
-    pangraph.add_hits_between_PRG_and_sample(prg_id1, sample_names[0], sample_kmer_path);
-    sample_kmer_path = {kg2.nodes[0], kg2.nodes[1], kg2.nodes[5], kg2.nodes[9]};
+    pangraph.add_hits_between_PRG_and_sample(
+        prg_id1, sample_names[0], sample_kmer_path);
+    sample_kmer_path = { kg2.nodes[0], kg2.nodes[1], kg2.nodes[5], kg2.nodes[9] };
     pangraph.add_node(prg_ptr2);
-    pangraph.add_hits_between_PRG_and_sample(prg_id2, sample_names[0], sample_kmer_path);
+    pangraph.add_hits_between_PRG_and_sample(
+        prg_id2, sample_names[0], sample_kmer_path);
 
-    //sample2 identical to sample1 in prg1, no prg2
-    sample_kmer_path = {kg1.nodes[0], kg1.nodes[2], kg1.nodes[6], kg1.nodes[9]};
+    // sample2 identical to sample1 in prg1, no prg2
+    sample_kmer_path = { kg1.nodes[0], kg1.nodes[2], kg1.nodes[6], kg1.nodes[9] };
     pangraph.add_node(prg_ptr1);
-    pangraph.add_hits_between_PRG_and_sample(prg_id1, sample_names[1], sample_kmer_path);
+    pangraph.add_hits_between_PRG_and_sample(
+        prg_id1, sample_names[1], sample_kmer_path);
 
-    //sample3 with top path
-    sample_kmer_path = {kg1.nodes[0], kg1.nodes[1], kg1.nodes[5], kg1.nodes[9]};
+    // sample3 with top path
+    sample_kmer_path = { kg1.nodes[0], kg1.nodes[1], kg1.nodes[5], kg1.nodes[9] };
     pangraph.add_node(prg_ptr1);
-    pangraph.add_hits_between_PRG_and_sample(prg_id1, sample_names[2], sample_kmer_path);
-    sample_kmer_path = {kg2.nodes[0], kg2.nodes[4], kg2.nodes[9]};
+    pangraph.add_hits_between_PRG_and_sample(
+        prg_id1, sample_names[2], sample_kmer_path);
+    sample_kmer_path = { kg2.nodes[0], kg2.nodes[4], kg2.nodes[9] };
     pangraph.add_node(prg_ptr2);
-    pangraph.add_hits_between_PRG_and_sample(prg_id2, sample_names[2], sample_kmer_path);
+    pangraph.add_hits_between_PRG_and_sample(
+        prg_id2, sample_names[2], sample_kmer_path);
 
-
-    //sample4 with bottom path
-    sample_kmer_path = {kg1.nodes[0], kg1.nodes[4], kg1.nodes[9]};
+    // sample4 with bottom path
+    sample_kmer_path = { kg1.nodes[0], kg1.nodes[4], kg1.nodes[9] };
     pangraph.add_node(prg_ptr1);
-    pangraph.add_hits_between_PRG_and_sample(prg_id1, sample_names[3], sample_kmer_path);
-    sample_kmer_path = {kg2.nodes[0], kg2.nodes[3], kg2.nodes[7], kg2.nodes[8], kg2.nodes[9]};
+    pangraph.add_hits_between_PRG_and_sample(
+        prg_id1, sample_names[3], sample_kmer_path);
+    sample_kmer_path
+        = { kg2.nodes[0], kg2.nodes[3], kg2.nodes[7], kg2.nodes[8], kg2.nodes[9] };
     pangraph.add_node(prg_ptr2);
-    pangraph.add_hits_between_PRG_and_sample(prg_id2, sample_names[3], sample_kmer_path);
-
+    pangraph.add_hits_between_PRG_and_sample(
+        prg_id2, sample_names[3], sample_kmer_path);
 
     VCF master_vcf;
-    std::vector<LocalNodePtr> vcf_reference_path1 = {local_prg1.prg.nodes[0], local_prg1.prg.nodes[1], local_prg1.prg.nodes[3], local_prg1.prg.nodes[5], local_prg1.prg.nodes[7]};
-    std::vector<LocalNodePtr> vcf_reference_path2 = {local_prg2.prg.nodes[0], local_prg2.prg.nodes[1], local_prg2.prg.nodes[3], local_prg2.prg.nodes[5], local_prg2.prg.nodes[7]};
+    std::vector<LocalNodePtr> vcf_reference_path1
+        = { local_prg1.prg.nodes[0], local_prg1.prg.nodes[1], local_prg1.prg.nodes[3],
+              local_prg1.prg.nodes[5], local_prg1.prg.nodes[7] };
+    std::vector<LocalNodePtr> vcf_reference_path2
+        = { local_prg2.prg.nodes[0], local_prg2.prg.nodes[1], local_prg2.prg.nodes[3],
+              local_prg2.prg.nodes[5], local_prg2.prg.nodes[7] };
 
-    auto &pannode1 = *pangraph.nodes[prg_id1];
-    pannode1.construct_multisample_vcf(master_vcf, vcf_reference_path1, prg_ptr1, w, min_kmer_covg);
-    auto &pannode2 = *pangraph.nodes[prg_id2];
-    pannode2.construct_multisample_vcf(master_vcf, vcf_reference_path2, prg_ptr2, w, min_kmer_covg);
+    auto& pannode1 = *pangraph.nodes[prg_id1];
+    pannode1.construct_multisample_vcf(
+        master_vcf, vcf_reference_path1, prg_ptr1, w, min_kmer_covg);
+    auto& pannode2 = *pangraph.nodes[prg_id2];
+    pannode2.construct_multisample_vcf(
+        master_vcf, vcf_reference_path2, prg_ptr2, w, min_kmer_covg);
 
     EXPECT_EQ((uint)4, master_vcf.records.size());
     EXPECT_EQ((uint)4, master_vcf.samples.size());
 
-    //NB samples order changes to get index of each sample so can compare
-    //samples 1 and 2 are ref, sample 3 is top path and sample 4 is bottom path
-    auto iter = std::find(master_vcf.samples.begin(), master_vcf.samples.end(), "sample1");
+    // NB samples order changes to get index of each sample so can compare
+    // samples 1 and 2 are ref, sample 3 is top path and sample 4 is bottom path
+    auto iter
+        = std::find(master_vcf.samples.begin(), master_vcf.samples.end(), "sample1");
     auto sample1_index = std::distance(master_vcf.samples.begin(), iter);
     iter = std::find(master_vcf.samples.begin(), master_vcf.samples.end(), "sample2");
     auto sample2_index = std::distance(master_vcf.samples.begin(), iter);
@@ -337,37 +390,51 @@ TEST(PangenomeNodeTest,construct_multisample_vcf_two_prg)
     auto sample3_index = std::distance(master_vcf.samples.begin(), iter);
     iter = std::find(master_vcf.samples.begin(), master_vcf.samples.end(), "sample4");
     auto sample4_index = std::distance(master_vcf.samples.begin(), iter);
-    std::vector<uint16_t> alt_gt = {1};
-    std::vector<uint16_t> ref_gt = {0};
-    std::vector<uint16_t> alt2_gt = {2};
-    std::vector<uint16_t> no_covg2 = {0,0};
-    std::vector<uint16_t> no_covg3 = {0,0,0};
+    std::vector<uint16_t> alt_gt = { 1 };
+    std::vector<uint16_t> ref_gt = { 0 };
+    std::vector<uint16_t> alt2_gt = { 2 };
+    std::vector<uint16_t> no_covg2 = { 0, 0 };
+    std::vector<uint16_t> no_covg3 = { 0, 0, 0 };
 
     EXPECT_EQ((uint)1, master_vcf.records[0]->pos);
     EXPECT_EQ("GT", master_vcf.records[0]->ref);
     EXPECT_EQ((uint)1, master_vcf.records[0]->alt.size());
     EXPECT_EQ("G", master_vcf.records[0]->alt[0]);
     EXPECT_EQ((uint)4, master_vcf.records[0]->samples.size());
-    EXPECT_FALSE(master_vcf.records[0]->samples[sample4_index].find("GT") == master_vcf.records[0]->samples[sample4_index].end()) ;
-    EXPECT_TRUE(master_vcf.records[0]->samples[sample3_index].find("GT") == master_vcf.records[0]->samples[sample3_index].end()) ;
-    EXPECT_FALSE(master_vcf.records[0]->samples[sample2_index].find("GT") == master_vcf.records[0]->samples[sample2_index].end()) ;
-    EXPECT_FALSE(master_vcf.records[0]->samples[sample1_index].find("GT") == master_vcf.records[0]->samples[sample1_index].end()) ;
-    EXPECT_ITERABLE_EQ(std::vector<uint16_t>, master_vcf.records[0]->samples[sample4_index]["GT"], alt_gt);
-    EXPECT_ITERABLE_EQ(std::vector<uint16_t>, master_vcf.records[0]->samples[sample2_index]["GT"], ref_gt);
-    EXPECT_ITERABLE_EQ(std::vector<uint16_t>, master_vcf.records[0]->samples[sample1_index]["GT"], ref_gt);
-    std::vector<std::string> formats = {"MEAN_FWD_COVG", "MEAN_REV_COVG", "MED_FWD_COVG", "MED_REV_COVG",
-                                        "SUM_FWD_COVG", "SUM_REV_COVG"};
-    for (const auto format : formats){
-        EXPECT_FALSE(master_vcf.records[0]->samples[sample1_index].find(format) == master_vcf.records[0]->samples[sample1_index].end());
-        EXPECT_FALSE(master_vcf.records[0]->samples[sample2_index].find(format) == master_vcf.records[0]->samples[sample2_index].end());
-        EXPECT_FALSE(master_vcf.records[0]->samples[sample3_index].find(format) == master_vcf.records[0]->samples[sample3_index].end());
-        EXPECT_FALSE(master_vcf.records[0]->samples[sample4_index].find(format) == master_vcf.records[0]->samples[sample4_index].end());
-        EXPECT_ITERABLE_EQ(std::vector<uint16_t>, master_vcf.records[0]->samples[sample1_index][format], no_covg2);
-        EXPECT_ITERABLE_EQ(std::vector<uint16_t>, master_vcf.records[0]->samples[sample2_index][format], no_covg2);
-        EXPECT_ITERABLE_EQ(std::vector<uint16_t>, master_vcf.records[0]->samples[sample3_index][format], no_covg2);
-        EXPECT_ITERABLE_EQ(std::vector<uint16_t>, master_vcf.records[0]->samples[sample4_index][format], no_covg2);
+    EXPECT_FALSE(master_vcf.records[0]->samples[sample4_index].find("GT")
+        == master_vcf.records[0]->samples[sample4_index].end());
+    EXPECT_TRUE(master_vcf.records[0]->samples[sample3_index].find("GT")
+        == master_vcf.records[0]->samples[sample3_index].end());
+    EXPECT_FALSE(master_vcf.records[0]->samples[sample2_index].find("GT")
+        == master_vcf.records[0]->samples[sample2_index].end());
+    EXPECT_FALSE(master_vcf.records[0]->samples[sample1_index].find("GT")
+        == master_vcf.records[0]->samples[sample1_index].end());
+    EXPECT_ITERABLE_EQ(std::vector<uint16_t>,
+        master_vcf.records[0]->samples[sample4_index]["GT"], alt_gt);
+    EXPECT_ITERABLE_EQ(std::vector<uint16_t>,
+        master_vcf.records[0]->samples[sample2_index]["GT"], ref_gt);
+    EXPECT_ITERABLE_EQ(std::vector<uint16_t>,
+        master_vcf.records[0]->samples[sample1_index]["GT"], ref_gt);
+    std::vector<std::string> formats = { "MEAN_FWD_COVG", "MEAN_REV_COVG",
+        "MED_FWD_COVG", "MED_REV_COVG", "SUM_FWD_COVG", "SUM_REV_COVG" };
+    for (const auto format : formats) {
+        EXPECT_FALSE(master_vcf.records[0]->samples[sample1_index].find(format)
+            == master_vcf.records[0]->samples[sample1_index].end());
+        EXPECT_FALSE(master_vcf.records[0]->samples[sample2_index].find(format)
+            == master_vcf.records[0]->samples[sample2_index].end());
+        EXPECT_FALSE(master_vcf.records[0]->samples[sample3_index].find(format)
+            == master_vcf.records[0]->samples[sample3_index].end());
+        EXPECT_FALSE(master_vcf.records[0]->samples[sample4_index].find(format)
+            == master_vcf.records[0]->samples[sample4_index].end());
+        EXPECT_ITERABLE_EQ(std::vector<uint16_t>,
+            master_vcf.records[0]->samples[sample1_index][format], no_covg2);
+        EXPECT_ITERABLE_EQ(std::vector<uint16_t>,
+            master_vcf.records[0]->samples[sample2_index][format], no_covg2);
+        EXPECT_ITERABLE_EQ(std::vector<uint16_t>,
+            master_vcf.records[0]->samples[sample3_index][format], no_covg2);
+        EXPECT_ITERABLE_EQ(std::vector<uint16_t>,
+            master_vcf.records[0]->samples[sample4_index][format], no_covg2);
     }
-
 
     EXPECT_EQ((uint)2, master_vcf.records[1]->pos);
     EXPECT_EQ("T", master_vcf.records[1]->ref);
@@ -375,23 +442,38 @@ TEST(PangenomeNodeTest,construct_multisample_vcf_two_prg)
     EXPECT_EQ("C", master_vcf.records[1]->alt[0]);
     EXPECT_EQ("CT", master_vcf.records[1]->alt[1]);
     EXPECT_EQ((uint)4, master_vcf.records[1]->samples.size());
-    EXPECT_TRUE(master_vcf.records[1]->samples[sample4_index].find("GT") == master_vcf.records[1]->samples[sample4_index].end()) ;
-    EXPECT_FALSE(master_vcf.records[1]->samples[sample3_index].find("GT") == master_vcf.records[1]->samples[sample3_index].end()) ;
-    EXPECT_FALSE(master_vcf.records[1]->samples[sample2_index].find("GT") == master_vcf.records[1]->samples[sample2_index].end()) ;
-    EXPECT_FALSE(master_vcf.records[1]->samples[sample1_index].find("GT") == master_vcf.records[1]->samples[sample1_index].end()) ;
-    EXPECT_ITERABLE_EQ(std::vector<uint16_t>, master_vcf.records[1]->samples[sample3_index]["GT"], alt_gt);
-    EXPECT_ITERABLE_EQ(std::vector<uint16_t>, master_vcf.records[1]->samples[sample2_index]["GT"], ref_gt);
-    EXPECT_ITERABLE_EQ(std::vector<uint16_t>, master_vcf.records[1]->samples[sample1_index]["GT"], ref_gt);
+    EXPECT_TRUE(master_vcf.records[1]->samples[sample4_index].find("GT")
+        == master_vcf.records[1]->samples[sample4_index].end());
+    EXPECT_FALSE(master_vcf.records[1]->samples[sample3_index].find("GT")
+        == master_vcf.records[1]->samples[sample3_index].end());
+    EXPECT_FALSE(master_vcf.records[1]->samples[sample2_index].find("GT")
+        == master_vcf.records[1]->samples[sample2_index].end());
+    EXPECT_FALSE(master_vcf.records[1]->samples[sample1_index].find("GT")
+        == master_vcf.records[1]->samples[sample1_index].end());
+    EXPECT_ITERABLE_EQ(std::vector<uint16_t>,
+        master_vcf.records[1]->samples[sample3_index]["GT"], alt_gt);
+    EXPECT_ITERABLE_EQ(std::vector<uint16_t>,
+        master_vcf.records[1]->samples[sample2_index]["GT"], ref_gt);
+    EXPECT_ITERABLE_EQ(std::vector<uint16_t>,
+        master_vcf.records[1]->samples[sample1_index]["GT"], ref_gt);
 
-    for (const auto format : formats){
-        EXPECT_FALSE(master_vcf.records[1]->samples[sample1_index].find(format) == master_vcf.records[1]->samples[sample1_index].end());
-        EXPECT_FALSE(master_vcf.records[1]->samples[sample2_index].find(format) == master_vcf.records[1]->samples[sample2_index].end());
-        EXPECT_FALSE(master_vcf.records[1]->samples[sample3_index].find(format) == master_vcf.records[1]->samples[sample3_index].end());
-        EXPECT_FALSE(master_vcf.records[1]->samples[sample4_index].find(format) == master_vcf.records[1]->samples[sample4_index].end());
-        EXPECT_ITERABLE_EQ(std::vector<uint16_t>, master_vcf.records[1]->samples[sample1_index][format], no_covg3);
-        EXPECT_ITERABLE_EQ(std::vector<uint16_t>, master_vcf.records[1]->samples[sample2_index][format], no_covg3);
-        EXPECT_ITERABLE_EQ(std::vector<uint16_t>, master_vcf.records[1]->samples[sample3_index][format], no_covg3);
-        EXPECT_ITERABLE_EQ(std::vector<uint16_t>, master_vcf.records[1]->samples[sample4_index][format], no_covg3);
+    for (const auto format : formats) {
+        EXPECT_FALSE(master_vcf.records[1]->samples[sample1_index].find(format)
+            == master_vcf.records[1]->samples[sample1_index].end());
+        EXPECT_FALSE(master_vcf.records[1]->samples[sample2_index].find(format)
+            == master_vcf.records[1]->samples[sample2_index].end());
+        EXPECT_FALSE(master_vcf.records[1]->samples[sample3_index].find(format)
+            == master_vcf.records[1]->samples[sample3_index].end());
+        EXPECT_FALSE(master_vcf.records[1]->samples[sample4_index].find(format)
+            == master_vcf.records[1]->samples[sample4_index].end());
+        EXPECT_ITERABLE_EQ(std::vector<uint16_t>,
+            master_vcf.records[1]->samples[sample1_index][format], no_covg3);
+        EXPECT_ITERABLE_EQ(std::vector<uint16_t>,
+            master_vcf.records[1]->samples[sample2_index][format], no_covg3);
+        EXPECT_ITERABLE_EQ(std::vector<uint16_t>,
+            master_vcf.records[1]->samples[sample3_index][format], no_covg3);
+        EXPECT_ITERABLE_EQ(std::vector<uint16_t>,
+            master_vcf.records[1]->samples[sample4_index][format], no_covg3);
     }
 
     EXPECT_EQ((uint)1, master_vcf.records[2]->pos);
@@ -399,22 +481,33 @@ TEST(PangenomeNodeTest,construct_multisample_vcf_two_prg)
     EXPECT_EQ((uint)1, master_vcf.records[2]->alt.size());
     EXPECT_EQ("G", master_vcf.records[2]->alt[0]);
     EXPECT_EQ((uint)4, master_vcf.records[2]->samples.size());
-    EXPECT_TRUE(master_vcf.records[2]->samples[sample4_index].find("GT") == master_vcf.records[2]->samples[sample4_index].end()) ;
-    EXPECT_FALSE(master_vcf.records[2]->samples[sample3_index].find("GT") == master_vcf.records[2]->samples[sample3_index].end()) ;
-    EXPECT_TRUE(master_vcf.records[2]->samples[sample2_index].find("GT") == master_vcf.records[2]->samples[sample2_index].end()) ;
-    EXPECT_TRUE(master_vcf.records[2]->samples[sample1_index].find("GT") == master_vcf.records[2]->samples[sample1_index].end()) ;
-    EXPECT_ITERABLE_EQ(std::vector<uint16_t>, master_vcf.records[2]->samples[sample3_index]["GT"], alt_gt);
+    EXPECT_TRUE(master_vcf.records[2]->samples[sample4_index].find("GT")
+        == master_vcf.records[2]->samples[sample4_index].end());
+    EXPECT_FALSE(master_vcf.records[2]->samples[sample3_index].find("GT")
+        == master_vcf.records[2]->samples[sample3_index].end());
+    EXPECT_TRUE(master_vcf.records[2]->samples[sample2_index].find("GT")
+        == master_vcf.records[2]->samples[sample2_index].end());
+    EXPECT_TRUE(master_vcf.records[2]->samples[sample1_index].find("GT")
+        == master_vcf.records[2]->samples[sample1_index].end());
+    EXPECT_ITERABLE_EQ(std::vector<uint16_t>,
+        master_vcf.records[2]->samples[sample3_index]["GT"], alt_gt);
 
-    for (const auto format : formats){
-        EXPECT_FALSE(master_vcf.records[2]->samples[sample1_index].find(format) == master_vcf.records[2]->samples[sample1_index].end());
-        EXPECT_TRUE(master_vcf.records[2]->samples[sample2_index].find(format) == master_vcf.records[2]->samples[sample2_index].end());
-        EXPECT_FALSE(master_vcf.records[2]->samples[sample3_index].find(format) == master_vcf.records[2]->samples[sample3_index].end());
-        EXPECT_FALSE(master_vcf.records[2]->samples[sample4_index].find(format) == master_vcf.records[2]->samples[sample4_index].end());
-        EXPECT_ITERABLE_EQ(std::vector<uint16_t>, master_vcf.records[2]->samples[sample1_index][format], no_covg2);
-        EXPECT_ITERABLE_EQ(std::vector<uint16_t>, master_vcf.records[2]->samples[sample3_index][format], no_covg2);
-        EXPECT_ITERABLE_EQ(std::vector<uint16_t>, master_vcf.records[2]->samples[sample4_index][format], no_covg2);
+    for (const auto format : formats) {
+        EXPECT_FALSE(master_vcf.records[2]->samples[sample1_index].find(format)
+            == master_vcf.records[2]->samples[sample1_index].end());
+        EXPECT_TRUE(master_vcf.records[2]->samples[sample2_index].find(format)
+            == master_vcf.records[2]->samples[sample2_index].end());
+        EXPECT_FALSE(master_vcf.records[2]->samples[sample3_index].find(format)
+            == master_vcf.records[2]->samples[sample3_index].end());
+        EXPECT_FALSE(master_vcf.records[2]->samples[sample4_index].find(format)
+            == master_vcf.records[2]->samples[sample4_index].end());
+        EXPECT_ITERABLE_EQ(std::vector<uint16_t>,
+            master_vcf.records[2]->samples[sample1_index][format], no_covg2);
+        EXPECT_ITERABLE_EQ(std::vector<uint16_t>,
+            master_vcf.records[2]->samples[sample3_index][format], no_covg2);
+        EXPECT_ITERABLE_EQ(std::vector<uint16_t>,
+            master_vcf.records[2]->samples[sample4_index][format], no_covg2);
     }
-
 
     EXPECT_EQ((uint)2, master_vcf.records[3]->pos);
     EXPECT_EQ("A", master_vcf.records[3]->ref);
@@ -422,54 +515,68 @@ TEST(PangenomeNodeTest,construct_multisample_vcf_two_prg)
     EXPECT_EQ("G", master_vcf.records[3]->alt[0]);
     EXPECT_EQ("GA", master_vcf.records[3]->alt[1]);
     EXPECT_EQ((uint)4, master_vcf.records[3]->samples.size());
-    EXPECT_FALSE(master_vcf.records[3]->samples[sample4_index].find("GT") == master_vcf.records[3]->samples[sample4_index].end()) ;
-    EXPECT_TRUE(master_vcf.records[3]->samples[sample3_index].find("GT") == master_vcf.records[3]->samples[sample3_index].end()) ;
-    EXPECT_TRUE(master_vcf.records[3]->samples[sample2_index].find("GT") == master_vcf.records[3]->samples[sample2_index].end()) ;
-    EXPECT_FALSE(master_vcf.records[3]->samples[sample1_index].find("GT") == master_vcf.records[3]->samples[sample1_index].end()) ;
-    EXPECT_ITERABLE_EQ(std::vector<uint16_t>, master_vcf.records[3]->samples[sample1_index]["GT"], alt_gt);
-    EXPECT_ITERABLE_EQ(std::vector<uint16_t>, master_vcf.records[3]->samples[sample4_index]["GT"], alt2_gt);
+    EXPECT_FALSE(master_vcf.records[3]->samples[sample4_index].find("GT")
+        == master_vcf.records[3]->samples[sample4_index].end());
+    EXPECT_TRUE(master_vcf.records[3]->samples[sample3_index].find("GT")
+        == master_vcf.records[3]->samples[sample3_index].end());
+    EXPECT_TRUE(master_vcf.records[3]->samples[sample2_index].find("GT")
+        == master_vcf.records[3]->samples[sample2_index].end());
+    EXPECT_FALSE(master_vcf.records[3]->samples[sample1_index].find("GT")
+        == master_vcf.records[3]->samples[sample1_index].end());
+    EXPECT_ITERABLE_EQ(std::vector<uint16_t>,
+        master_vcf.records[3]->samples[sample1_index]["GT"], alt_gt);
+    EXPECT_ITERABLE_EQ(std::vector<uint16_t>,
+        master_vcf.records[3]->samples[sample4_index]["GT"], alt2_gt);
 
-    for (const auto format : formats){
-        EXPECT_FALSE(master_vcf.records[3]->samples[sample1_index].find(format) == master_vcf.records[3]->samples[sample1_index].end());
-        EXPECT_TRUE(master_vcf.records[3]->samples[sample2_index].find(format) == master_vcf.records[3]->samples[sample2_index].end());
-        EXPECT_FALSE(master_vcf.records[3]->samples[sample3_index].find(format) == master_vcf.records[3]->samples[sample3_index].end());
-        EXPECT_FALSE(master_vcf.records[3]->samples[sample4_index].find(format) == master_vcf.records[3]->samples[sample4_index].end());
-        EXPECT_ITERABLE_EQ(std::vector<uint16_t>, master_vcf.records[3]->samples[sample1_index][format], no_covg3);
-        EXPECT_ITERABLE_EQ(std::vector<uint16_t>, master_vcf.records[3]->samples[sample3_index][format], no_covg3);
-        EXPECT_ITERABLE_EQ(std::vector<uint16_t>, master_vcf.records[3]->samples[sample4_index][format], no_covg3);
+    for (const auto format : formats) {
+        EXPECT_FALSE(master_vcf.records[3]->samples[sample1_index].find(format)
+            == master_vcf.records[3]->samples[sample1_index].end());
+        EXPECT_TRUE(master_vcf.records[3]->samples[sample2_index].find(format)
+            == master_vcf.records[3]->samples[sample2_index].end());
+        EXPECT_FALSE(master_vcf.records[3]->samples[sample3_index].find(format)
+            == master_vcf.records[3]->samples[sample3_index].end());
+        EXPECT_FALSE(master_vcf.records[3]->samples[sample4_index].find(format)
+            == master_vcf.records[3]->samples[sample4_index].end());
+        EXPECT_ITERABLE_EQ(std::vector<uint16_t>,
+            master_vcf.records[3]->samples[sample1_index][format], no_covg3);
+        EXPECT_ITERABLE_EQ(std::vector<uint16_t>,
+            master_vcf.records[3]->samples[sample3_index][format], no_covg3);
+        EXPECT_ITERABLE_EQ(std::vector<uint16_t>,
+            master_vcf.records[3]->samples[sample4_index][format], no_covg3);
     }
 }
 
-TEST(PangenomeNodeTest,construct_multisample_vcf_two_prg_with_covgs)
+TEST(PangenomeNodeTest, construct_multisample_vcf_two_prg_with_covgs)
 {
-    uint32_t prg_id1 = 3, w=1, k=3, min_kmer_covg=0;
+    uint32_t prg_id1 = 3, w = 1, k = 3, min_kmer_covg = 0;
     std::string prg_name1 = "nested varsite";
-    LocalPRG local_prg1(prg_id1, prg_name1 , "A 5 G 7 C 8 T 8 CT 7  6 G 5 T");
+    LocalPRG local_prg1(prg_id1, prg_name1, "A 5 G 7 C 8 T 8 CT 7  6 G 5 T");
     uint32_t prg_id2 = 5;
     std::string prg_name2 = "modified";
-    LocalPRG local_prg2(prg_id2, prg_name2 , "A 5 G 7 G 8 A 8 GA 7  6 G 5 T");
+    LocalPRG local_prg2(prg_id2, prg_name2, "A 5 G 7 G 8 A 8 GA 7  6 G 5 T");
 
     auto index = std::make_shared<Index>();
     local_prg1.minimizer_sketch(index, w, k);
     auto prg_ptr1 = std::make_shared<LocalPRG>(local_prg1);
-    auto &kg1 = local_prg1.kmer_prg;
+    auto& kg1 = local_prg1.kmer_prg;
     local_prg2.minimizer_sketch(index, w, k);
     auto prg_ptr2 = std::make_shared<LocalPRG>(local_prg2);
-    auto &kg2 = local_prg2.kmer_prg;
+    auto& kg2 = local_prg2.kmer_prg;
 
-    pangenome::Graph pangraph({"sample1", "sample2", "sample3", "sample4"});
+    pangenome::Graph pangraph({ "sample1", "sample2", "sample3", "sample4" });
 
-    //sample1
+    // sample1
     std::string sample_name = "sample1";
-    std::vector<KmerNodePtr> sample_kmer_path = {kg1.nodes[0], kg1.nodes[2], kg1.nodes[6], kg1.nodes[9]};
+    std::vector<KmerNodePtr> sample_kmer_path
+        = { kg1.nodes[0], kg1.nodes[2], kg1.nodes[6], kg1.nodes[9] };
     pangraph.add_node(prg_ptr1);
     pangraph.add_hits_between_PRG_and_sample(prg_id1, sample_name, sample_kmer_path);
-    sample_kmer_path = {kg2.nodes[0], kg2.nodes[1], kg2.nodes[5], kg2.nodes[9]};
+    sample_kmer_path = { kg2.nodes[0], kg2.nodes[1], kg2.nodes[5], kg2.nodes[9] };
     pangraph.add_node(prg_ptr2);
     pangraph.add_hits_between_PRG_and_sample(prg_id2, sample_name, sample_kmer_path);
 
-    auto &pannode1 = *pangraph.nodes[prg_id1];
-    auto &pannode2 = *pangraph.nodes[prg_id2];
+    auto& pannode1 = *pangraph.nodes[prg_id1];
+    auto& pannode2 = *pangraph.nodes[prg_id2];
 
     pannode1.kmer_prg_with_coverage.set_covg(0, 4, 0, 0);
     pannode1.kmer_prg_with_coverage.set_covg(2, 4, 0, 0);
@@ -480,9 +587,9 @@ TEST(PangenomeNodeTest,construct_multisample_vcf_two_prg_with_covgs)
     pannode2.kmer_prg_with_coverage.set_covg(5, 4, 0, 0);
     pannode2.kmer_prg_with_coverage.set_covg(9, 4, 0, 0);
 
-    //sample2 identical to sample1 in prg1, no prg2
+    // sample2 identical to sample1 in prg1, no prg2
     sample_name = "sample2";
-    sample_kmer_path = {kg1.nodes[0], kg1.nodes[2], kg1.nodes[6], kg1.nodes[9]};
+    sample_kmer_path = { kg1.nodes[0], kg1.nodes[2], kg1.nodes[6], kg1.nodes[9] };
     pangraph.add_node(prg_ptr1);
     pangraph.add_hits_between_PRG_and_sample(prg_id1, sample_name, sample_kmer_path);
     pannode1.kmer_prg_with_coverage.set_covg(0, 10, 0, 1);
@@ -490,12 +597,12 @@ TEST(PangenomeNodeTest,construct_multisample_vcf_two_prg_with_covgs)
     pannode1.kmer_prg_with_coverage.set_covg(6, 10, 0, 1);
     pannode1.kmer_prg_with_coverage.set_covg(9, 10, 0, 1);
 
-    //sample3 with top path
+    // sample3 with top path
     sample_name = "sample3";
-    sample_kmer_path = {kg1.nodes[0], kg1.nodes[1], kg1.nodes[5], kg1.nodes[9]};
+    sample_kmer_path = { kg1.nodes[0], kg1.nodes[1], kg1.nodes[5], kg1.nodes[9] };
     pangraph.add_node(prg_ptr1);
     pangraph.add_hits_between_PRG_and_sample(prg_id1, sample_name, sample_kmer_path);
-    sample_kmer_path = {kg2.nodes[0], kg2.nodes[4], kg2.nodes[9]};
+    sample_kmer_path = { kg2.nodes[0], kg2.nodes[4], kg2.nodes[9] };
     pangraph.add_node(prg_ptr2);
     pangraph.add_hits_between_PRG_and_sample(prg_id2, sample_name, sample_kmer_path);
     pannode1.kmer_prg_with_coverage.set_covg(0, 2, 0, 2);
@@ -506,12 +613,13 @@ TEST(PangenomeNodeTest,construct_multisample_vcf_two_prg_with_covgs)
     pannode2.kmer_prg_with_coverage.set_covg(4, 2, 0, 2);
     pannode2.kmer_prg_with_coverage.set_covg(9, 2, 0, 2);
 
-    //sample4 with bottom path
+    // sample4 with bottom path
     sample_name = "sample4";
-    sample_kmer_path = {kg1.nodes[0], kg1.nodes[4], kg1.nodes[9]};
+    sample_kmer_path = { kg1.nodes[0], kg1.nodes[4], kg1.nodes[9] };
     pangraph.add_node(prg_ptr1);
     pangraph.add_hits_between_PRG_and_sample(prg_id1, sample_name, sample_kmer_path);
-    sample_kmer_path = {kg2.nodes[0], kg2.nodes[3], kg2.nodes[7], kg2.nodes[8], kg2.nodes[9]};
+    sample_kmer_path
+        = { kg2.nodes[0], kg2.nodes[3], kg2.nodes[7], kg2.nodes[8], kg2.nodes[9] };
     pangraph.add_node(prg_ptr2);
     pangraph.add_hits_between_PRG_and_sample(prg_id2, sample_name, sample_kmer_path);
     pannode1.kmer_prg_with_coverage.set_covg(0, 5, 0, 3);
@@ -524,57 +632,82 @@ TEST(PangenomeNodeTest,construct_multisample_vcf_two_prg_with_covgs)
     pannode2.kmer_prg_with_coverage.set_covg(9, 5, 0, 3);
 
     VCF master_vcf;
-    std::vector<LocalNodePtr> vcf_reference_path1 = {local_prg1.prg.nodes[0], local_prg1.prg.nodes[1], local_prg1.prg.nodes[3], local_prg1.prg.nodes[5], local_prg1.prg.nodes[7]};
-    std::vector<LocalNodePtr> vcf_reference_path2 = {local_prg2.prg.nodes[0], local_prg2.prg.nodes[1], local_prg2.prg.nodes[3], local_prg2.prg.nodes[5], local_prg2.prg.nodes[7]};
+    std::vector<LocalNodePtr> vcf_reference_path1
+        = { local_prg1.prg.nodes[0], local_prg1.prg.nodes[1], local_prg1.prg.nodes[3],
+              local_prg1.prg.nodes[5], local_prg1.prg.nodes[7] };
+    std::vector<LocalNodePtr> vcf_reference_path2
+        = { local_prg2.prg.nodes[0], local_prg2.prg.nodes[1], local_prg2.prg.nodes[3],
+              local_prg2.prg.nodes[5], local_prg2.prg.nodes[7] };
 
-    pannode1.construct_multisample_vcf(master_vcf, vcf_reference_path1, prg_ptr1, w, min_kmer_covg);
-    pannode2.construct_multisample_vcf(master_vcf, vcf_reference_path2, prg_ptr2, w, min_kmer_covg);
+    pannode1.construct_multisample_vcf(
+        master_vcf, vcf_reference_path1, prg_ptr1, w, min_kmer_covg);
+    pannode2.construct_multisample_vcf(
+        master_vcf, vcf_reference_path2, prg_ptr2, w, min_kmer_covg);
 
     EXPECT_EQ((uint)4, master_vcf.records.size());
     EXPECT_EQ((uint)4, master_vcf.samples.size());
 
-    //NB samples order changes to get index of each sample so can compare
-    //samples 1 and 2 are ref, sample 3 is top path and sample 4 is bottom path
+    // NB samples order changes to get index of each sample so can compare
+    // samples 1 and 2 are ref, sample 3 is top path and sample 4 is bottom path
     auto sample1_index = master_vcf.get_sample_index("sample1");
     auto sample2_index = master_vcf.get_sample_index("sample2");
     auto sample3_index = master_vcf.get_sample_index("sample3");
     auto sample4_index = master_vcf.get_sample_index("sample4");
-    std::vector<uint16_t> covgs_40 = {4,0};
-    std::vector<uint16_t> covgs_100 = {10,0};
-    std::vector<uint16_t> covgs_02 = {0,2};
-    std::vector<uint16_t> covgs_05 = {0,5};
-    std::vector<uint16_t> covgs_00 = {0,0};
-    std::vector<uint16_t> covgs_400 = {4,0,0};
-    std::vector<uint16_t> covgs_040 = {0,4,0};
-    std::vector<uint16_t> covgs_1000 = {10,0,0};
-    std::vector<uint16_t> covgs_020 = {0,2,0};
-    std::vector<uint16_t> covgs_005 = {0,0,5};
-    std::vector<uint16_t> covgs_000 = {0,0,0};
+    std::vector<uint16_t> covgs_40 = { 4, 0 };
+    std::vector<uint16_t> covgs_100 = { 10, 0 };
+    std::vector<uint16_t> covgs_02 = { 0, 2 };
+    std::vector<uint16_t> covgs_05 = { 0, 5 };
+    std::vector<uint16_t> covgs_00 = { 0, 0 };
+    std::vector<uint16_t> covgs_400 = { 4, 0, 0 };
+    std::vector<uint16_t> covgs_040 = { 0, 4, 0 };
+    std::vector<uint16_t> covgs_1000 = { 10, 0, 0 };
+    std::vector<uint16_t> covgs_020 = { 0, 2, 0 };
+    std::vector<uint16_t> covgs_005 = { 0, 0, 5 };
+    std::vector<uint16_t> covgs_000 = { 0, 0, 0 };
 
-    EXPECT_ITERABLE_EQ(std::vector<uint16_t>, master_vcf.records[0]->samples[sample4_index]["MEAN_FWD_COVG"], covgs_05);
-    EXPECT_ITERABLE_EQ(std::vector<uint16_t>, master_vcf.records[0]->samples[sample2_index]["MEAN_FWD_COVG"], covgs_100);
-    EXPECT_ITERABLE_EQ(std::vector<uint16_t>, master_vcf.records[0]->samples[sample1_index]["MEAN_FWD_COVG"], covgs_40);
-    EXPECT_ITERABLE_EQ(std::vector<uint16_t>, master_vcf.records[0]->samples[sample4_index]["MEAN_REV_COVG"], covgs_00);
-    EXPECT_ITERABLE_EQ(std::vector<uint16_t>, master_vcf.records[0]->samples[sample2_index]["MEAN_REV_COVG"], covgs_00);
-    EXPECT_ITERABLE_EQ(std::vector<uint16_t>, master_vcf.records[0]->samples[sample1_index]["MEAN_REV_COVG"], covgs_00);
+    EXPECT_ITERABLE_EQ(std::vector<uint16_t>,
+        master_vcf.records[0]->samples[sample4_index]["MEAN_FWD_COVG"], covgs_05);
+    EXPECT_ITERABLE_EQ(std::vector<uint16_t>,
+        master_vcf.records[0]->samples[sample2_index]["MEAN_FWD_COVG"], covgs_100);
+    EXPECT_ITERABLE_EQ(std::vector<uint16_t>,
+        master_vcf.records[0]->samples[sample1_index]["MEAN_FWD_COVG"], covgs_40);
+    EXPECT_ITERABLE_EQ(std::vector<uint16_t>,
+        master_vcf.records[0]->samples[sample4_index]["MEAN_REV_COVG"], covgs_00);
+    EXPECT_ITERABLE_EQ(std::vector<uint16_t>,
+        master_vcf.records[0]->samples[sample2_index]["MEAN_REV_COVG"], covgs_00);
+    EXPECT_ITERABLE_EQ(std::vector<uint16_t>,
+        master_vcf.records[0]->samples[sample1_index]["MEAN_REV_COVG"], covgs_00);
 
-    EXPECT_ITERABLE_EQ(std::vector<uint16_t>, master_vcf.records[1]->samples[sample3_index]["MEAN_FWD_COVG"], covgs_020);
-    EXPECT_ITERABLE_EQ(std::vector<uint16_t>, master_vcf.records[1]->samples[sample2_index]["MEAN_FWD_COVG"], covgs_1000);
-    EXPECT_ITERABLE_EQ(std::vector<uint16_t>, master_vcf.records[1]->samples[sample1_index]["MEAN_FWD_COVG"], covgs_400);
-    EXPECT_ITERABLE_EQ(std::vector<uint16_t>, master_vcf.records[1]->samples[sample4_index]["MEAN_REV_COVG"], covgs_000);
-    EXPECT_ITERABLE_EQ(std::vector<uint16_t>, master_vcf.records[1]->samples[sample2_index]["MEAN_REV_COVG"], covgs_000);
-    EXPECT_ITERABLE_EQ(std::vector<uint16_t>, master_vcf.records[1]->samples[sample1_index]["MEAN_REV_COVG"], covgs_000);
+    EXPECT_ITERABLE_EQ(std::vector<uint16_t>,
+        master_vcf.records[1]->samples[sample3_index]["MEAN_FWD_COVG"], covgs_020);
+    EXPECT_ITERABLE_EQ(std::vector<uint16_t>,
+        master_vcf.records[1]->samples[sample2_index]["MEAN_FWD_COVG"], covgs_1000);
+    EXPECT_ITERABLE_EQ(std::vector<uint16_t>,
+        master_vcf.records[1]->samples[sample1_index]["MEAN_FWD_COVG"], covgs_400);
+    EXPECT_ITERABLE_EQ(std::vector<uint16_t>,
+        master_vcf.records[1]->samples[sample4_index]["MEAN_REV_COVG"], covgs_000);
+    EXPECT_ITERABLE_EQ(std::vector<uint16_t>,
+        master_vcf.records[1]->samples[sample2_index]["MEAN_REV_COVG"], covgs_000);
+    EXPECT_ITERABLE_EQ(std::vector<uint16_t>,
+        master_vcf.records[1]->samples[sample1_index]["MEAN_REV_COVG"], covgs_000);
 
-    EXPECT_ITERABLE_EQ(std::vector<uint16_t>, master_vcf.records[2]->samples[sample3_index]["MEAN_FWD_COVG"], covgs_02);
-    EXPECT_ITERABLE_EQ(std::vector<uint16_t>, master_vcf.records[2]->samples[sample3_index]["MEAN_REV_COVG"], covgs_00);
+    EXPECT_ITERABLE_EQ(std::vector<uint16_t>,
+        master_vcf.records[2]->samples[sample3_index]["MEAN_FWD_COVG"], covgs_02);
+    EXPECT_ITERABLE_EQ(std::vector<uint16_t>,
+        master_vcf.records[2]->samples[sample3_index]["MEAN_REV_COVG"], covgs_00);
 
-    EXPECT_ITERABLE_EQ(std::vector<uint16_t>, master_vcf.records[3]->samples[sample1_index]["MEAN_FWD_COVG"], covgs_040);
-    EXPECT_ITERABLE_EQ(std::vector<uint16_t>, master_vcf.records[3]->samples[sample4_index]["MEAN_FWD_COVG"], covgs_005);
-    EXPECT_ITERABLE_EQ(std::vector<uint16_t>, master_vcf.records[3]->samples[sample1_index]["MEAN_REV_COVG"], covgs_000);
-    EXPECT_ITERABLE_EQ(std::vector<uint16_t>, master_vcf.records[3]->samples[sample4_index]["MEAN_REV_COVG"], covgs_000);
+    EXPECT_ITERABLE_EQ(std::vector<uint16_t>,
+        master_vcf.records[3]->samples[sample1_index]["MEAN_FWD_COVG"], covgs_040);
+    EXPECT_ITERABLE_EQ(std::vector<uint16_t>,
+        master_vcf.records[3]->samples[sample4_index]["MEAN_FWD_COVG"], covgs_005);
+    EXPECT_ITERABLE_EQ(std::vector<uint16_t>,
+        master_vcf.records[3]->samples[sample1_index]["MEAN_REV_COVG"], covgs_000);
+    EXPECT_ITERABLE_EQ(std::vector<uint16_t>,
+        master_vcf.records[3]->samples[sample4_index]["MEAN_REV_COVG"], covgs_000);
 }
 
-TEST(PangenomeNodeTest, equals) {
+TEST(PangenomeNodeTest, equals)
+{
     auto l1 { std::make_shared<LocalPRG>(3, "3", "") };
     auto l2 { std::make_shared<LocalPRG>(2, "2", "") };
     pangenome::Node pn1(l1);
@@ -590,7 +723,8 @@ TEST(PangenomeNodeTest, equals) {
     EXPECT_EQ((pn1 == pn3), false);
 }
 
-TEST(PangenomeNodeTest, nequals) {
+TEST(PangenomeNodeTest, nequals)
+{
     auto l1 { std::make_shared<LocalPRG>(3, "3", "") };
     auto l2 { std::make_shared<LocalPRG>(2, "2", "") };
     pangenome::Node pn1(l1);
@@ -605,7 +739,8 @@ TEST(PangenomeNodeTest, nequals) {
     EXPECT_EQ((pn2 != pn3), false);
 }
 
-TEST(PangenomeNodeTest, less) {
+TEST(PangenomeNodeTest, less)
+{
     auto l1 { std::make_shared<LocalPRG>(3, "3", "") };
     auto l2 { std::make_shared<LocalPRG>(2, "2", "") };
     pangenome::Node pn1(l1);
@@ -619,10 +754,10 @@ TEST(PangenomeNodeTest, less) {
     EXPECT_EQ((pn1 < pn2), false);
     EXPECT_EQ((pn2 < pn1), true);
     EXPECT_EQ((pn3 < pn1), true);
-
 }
 
-TEST(ExtractReadsTest, get_read_overlap_coordinates) {
+TEST(ExtractReadsTest, get_read_overlap_coordinates)
+{
     //
     //  Read 0 has prg 3 sequence in interval (2,12] only
     //  Read 1 has prg 3 sequence in interval (6,16] as well as noise
@@ -642,7 +777,6 @@ TEST(ExtractReadsTest, get_read_overlap_coordinates) {
     PanNodePtr pan_node = make_shared<pangenome::Node>(local_prg_ptr);
     PanReadPtr pr = make_shared<pangenome::Read>(read_id);
     set<MinimizerHitPtr, pComp> hits;
-
 
     // READ 0
     // hits overlapping edges of path
@@ -889,7 +1023,6 @@ TEST(ExtractReadsTest, get_read_overlap_coordinates) {
     mh = make_shared<MinimizerHit>(read_id, m34, mr34);
     hits.insert(mh);
 
-
     // noise
     d = { Interval(7, 8), Interval(16, 17), Interval(27, 28) };
     prg_path.initialize(d);
@@ -954,17 +1087,17 @@ TEST(ExtractReadsTest, get_read_overlap_coordinates) {
 
     // RUN GET_READ_OVERLAPS
     LocalPRG l3(3, "nested varsite", "A 5 G 7 C 8 T 7 T 9 CCG 10 CGG 9  6 G 5 TAT");
-    const std::vector<LocalNodePtr> lmp {//l3.prg.nodes[0],
-            l3.prg.nodes[1], l3.prg.nodes[2], l3.prg.nodes[4], l3.prg.nodes[6], l3.prg.nodes[7]//, l3.prg.nodes[9]
+    const std::vector<LocalNodePtr> lmp {
+        // l3.prg.nodes[0],
+        l3.prg.nodes[1], l3.prg.nodes[2], l3.prg.nodes[4], l3.prg.nodes[6],
+        l3.prg.nodes[7] //, l3.prg.nodes[9]
     };
     // A G C T CGG  TAT
-    const std::set<ReadCoordinate> expected_overlaps {{ 0, 3, 9,  1 },
-                                                      { 1, 7, 13, 1 },
-                                                      { 2, 5, 13, 1 },
-                                                      { 3, 6, 10, 1 }};
+    const std::set<ReadCoordinate> expected_overlaps { { 0, 3, 9, 1 }, { 1, 7, 13, 1 },
+        { 2, 5, 13, 1 }, { 3, 6, 10, 1 } };
 
     prg::Path local_path;
-    for (const auto &node : lmp) {
+    for (const auto& node : lmp) {
         local_path.add_end_interval(node->pos);
     }
     const auto overlaps { pan_node->get_read_overlap_coordinates(local_path) };
@@ -972,8 +1105,8 @@ TEST(ExtractReadsTest, get_read_overlap_coordinates) {
     EXPECT_ITERABLE_EQ(std::set<ReadCoordinate>, expected_overlaps, overlaps);
 }
 
-
-TEST(ExtractReadsTest, get_read_overlap_coordinates_no_duplicates) {
+TEST(ExtractReadsTest, get_read_overlap_coordinates_no_duplicates)
+{
     //
     //  Read 0 has prg 3 sequence in interval (2,12] only
     //  Read 1 has prg 3 sequence in interval (6,16] as well as noise
@@ -994,7 +1127,6 @@ TEST(ExtractReadsTest, get_read_overlap_coordinates_no_duplicates) {
     PanReadPtr pr = make_shared<pangenome::Read>(read_id);
 
     set<MinimizerHitPtr, pComp> hits;
-
 
     // READ 0
     // hits overlapping edges of path
@@ -1062,7 +1194,7 @@ TEST(ExtractReadsTest, get_read_overlap_coordinates_no_duplicates) {
     prg_path.initialize(d);
     Minimizer m9(0, 12, 15, orientation); // kmer, start, end, strand
     MiniRecord mr9(prg_id, prg_path, knode_id, orientation);
-    mh = make_shared<MinimizerHit>(read_id, m9 ,mr9);
+    mh = make_shared<MinimizerHit>(read_id, m9, mr9);
     hits.insert(mh);
     d = { Interval(28, 30), Interval(33, 33), Interval(40, 41) };
     prg_path.initialize(d);
@@ -1241,7 +1373,6 @@ TEST(ExtractReadsTest, get_read_overlap_coordinates_no_duplicates) {
     mh = make_shared<MinimizerHit>(read_id, m34, mr34);
     hits.insert(mh);
 
-
     // noise
     d = { Interval(7, 8), Interval(16, 17), Interval(27, 28) };
     prg_path.initialize(d);
@@ -1360,17 +1491,17 @@ TEST(ExtractReadsTest, get_read_overlap_coordinates_no_duplicates) {
 
     // RUN GET_READ_OVERLAPS
     LocalPRG l3(3, "nested varsite", "A 5 G 7 C 8 T 7 T 9 CCG 10 CGG 9  6 G 5 TAT");
-    const std::vector<LocalNodePtr> lmp {//l3.prg.nodes[0],
-            l3.prg.nodes[1], l3.prg.nodes[2], l3.prg.nodes[4], l3.prg.nodes[6], l3.prg.nodes[7]//, l3.prg.nodes[9]
+    const std::vector<LocalNodePtr> lmp {
+        // l3.prg.nodes[0],
+        l3.prg.nodes[1], l3.prg.nodes[2], l3.prg.nodes[4], l3.prg.nodes[6],
+        l3.prg.nodes[7] //, l3.prg.nodes[9]
     };
     // A G C T CGG  TAT
-    const std::set<ReadCoordinate> expected_overlaps {{ 0, 3, 9,  1 },
-                                                      { 1, 7, 13, 1 },
-                                                      { 2, 5, 13, 1 },
-                                                      { 3, 6, 10, 1 }};
+    const std::set<ReadCoordinate> expected_overlaps { { 0, 3, 9, 1 }, { 1, 7, 13, 1 },
+        { 2, 5, 13, 1 }, { 3, 6, 10, 1 } };
 
     prg::Path local_path;
-    for (const auto &node : lmp) {
+    for (const auto& node : lmp) {
         local_path.add_end_interval(node->pos);
     }
     const auto overlaps { pan_node->get_read_overlap_coordinates(local_path) };

--- a/test/panread_test.cpp
+++ b/test/panread_test.cpp
@@ -1,31 +1,31 @@
-#include "gtest/gtest.h"
-#include "test_macro.cpp"
+#include "minihit.h"
 #include "pangenome/ns.cpp"
 #include "pangenome/pannode.h"
 #include "pangenome/panread.h"
 #include "pangenome_graph_class.h"
 #include "test_helpers.h"
-#include "minihit.h"
-#include <stdint.h>
-#include <iostream>
-#include <utility>
+#include "test_macro.cpp"
+#include "gtest/gtest.h"
 #include <functional>
+#include <iostream>
 #include <set>
-
+#include <stdint.h>
+#include <utility>
 
 using namespace pangenome;
 
-TEST(PangenomeReadTest, create) {
+TEST(PangenomeReadTest, create)
+{
 
     Read pr(3);
-    EXPECT_EQ((uint) 3, pr.id);
-    EXPECT_EQ((uint) 0, pr.get_nodes().size());
-    EXPECT_EQ((uint) 0, pr.node_orientations.size());
-    EXPECT_EQ((uint) 0, pr.get_hits_as_unordered_map().size());
+    EXPECT_EQ((uint)3, pr.id);
+    EXPECT_EQ((uint)0, pr.get_nodes().size());
+    EXPECT_EQ((uint)0, pr.node_orientations.size());
+    EXPECT_EQ((uint)0, pr.get_hits_as_unordered_map().size());
 }
 
-
-TEST(ReadAddHits, AddOneEmptyClusterToHits_ReadHitsSizeOne) {
+TEST(ReadAddHits, AddOneEmptyClusterToHits_ReadHitsSizeOne)
+{
     uint32_t read_id = 1;
     Read read(read_id);
     std::set<MinimizerHitPtr, pComp> cluster;
@@ -39,8 +39,8 @@ TEST(ReadAddHits, AddOneEmptyClusterToHits_ReadHitsSizeOne) {
     EXPECT_EQ(result, expect);
 }
 
-
-TEST(ReadAddHits, AddOneEmptyClusterToHits_ReadHitsMapContainsCorrectPrgId) {
+TEST(ReadAddHits, AddOneEmptyClusterToHits_ReadHitsMapContainsCorrectPrgId)
+{
     uint32_t read_id = 1;
     Read read(read_id);
     std::set<MinimizerHitPtr, pComp> cluster;
@@ -54,15 +54,15 @@ TEST(ReadAddHits, AddOneEmptyClusterToHits_ReadHitsMapContainsCorrectPrgId) {
     EXPECT_TRUE(result);
 }
 
-
-TEST(ReadAddHits, AddClusterSecondTime_DeathAndReadHitsNotChanged) {
+TEST(ReadAddHits, AddClusterSecondTime_DeathAndReadHitsNotChanged)
+{
     uint32_t read_id = 1;
     Read read(read_id);
     std::set<MinimizerHitPtr, pComp> cluster;
     uint32_t prg_id = 4;
 
     Interval interval(0, 5);
-    std::deque<Interval> raw_path = {Interval(7, 8), Interval(10, 14)};
+    std::deque<Interval> raw_path = { Interval(7, 8), Interval(10, 14) };
     prg::Path path;
     path.initialize(raw_path);
     Minimizer m1(0, interval.start, interval.get_end(), 0); // kmer, start, end, strand
@@ -74,10 +74,11 @@ TEST(ReadAddHits, AddClusterSecondTime_DeathAndReadHitsNotChanged) {
     PanNodePtr pan_node = make_shared<pangenome::Node>(local_prg_ptr);
     read.add_hits(pan_node, cluster);
     EXPECT_DEATH(read.add_hits(pan_node, cluster), "");
-    EXPECT_EQ((uint) 1, read.get_hits_as_unordered_map()[prg_id].size());
+    EXPECT_EQ((uint)1, read.get_hits_as_unordered_map()[prg_id].size());
 }
 
-TEST(ReadAddHits, AddSecondCluster_ReadHitsMapContainsCorrectPrgIds) {
+TEST(ReadAddHits, AddSecondCluster_ReadHitsMapContainsCorrectPrgIds)
+{
     uint32_t read_id = 1;
     Read read(read_id);
     std::set<MinimizerHitPtr, pComp> cluster;
@@ -88,7 +89,7 @@ TEST(ReadAddHits, AddSecondCluster_ReadHitsMapContainsCorrectPrgIds) {
 
     prg_id = 5;
     Interval interval(0, 5);
-    std::deque<Interval> raw_path = {Interval(7, 8), Interval(10, 14)};
+    std::deque<Interval> raw_path = { Interval(7, 8), Interval(10, 14) };
     prg::Path path;
     path.initialize(raw_path);
     Minimizer m1(0, interval.start, interval.get_end(), 0); // kmer, start, end, strand
@@ -103,7 +104,8 @@ TEST(ReadAddHits, AddSecondCluster_ReadHitsMapContainsCorrectPrgIds) {
     EXPECT_TRUE(result);
 }
 
-TEST(PangenomeReadTest, find_position) {
+TEST(PangenomeReadTest, find_position)
+{
     std::set<MinimizerHitPtr, pComp> dummy_cluster;
     PGraphTester pg;
 
@@ -131,7 +133,6 @@ TEST(PangenomeReadTest, find_position) {
     pg.add_hits_between_PRG_and_read(l5, 0, dummy_cluster);
     pg.add_hits_between_PRG_and_read(l9, 0, dummy_cluster);
 
-
     // read 1: 0->1->2
     pg.add_hits_between_PRG_and_read(l0, 1, dummy_cluster);
     pg.add_hits_between_PRG_and_read(l1, 1, dummy_cluster);
@@ -139,8 +140,8 @@ TEST(PangenomeReadTest, find_position) {
 
     pg.reads[0]->node_orientations[6] = 1;
 
-    std::vector<uint_least32_t> v = {2, 3, 5};
-    std::vector<bool> b = {0, 0, 0};
+    std::vector<uint_least32_t> v = { 2, 3, 5 };
+    std::vector<bool> b = { 0, 0, 0 };
     std::pair<uint, uint> p = pg.reads[0]->find_position(v, b);
     std::pair<uint, uint> truth = std::make_pair(2, 4);
 
@@ -148,74 +149,76 @@ TEST(PangenomeReadTest, find_position) {
     EXPECT_EQ(p.second, truth.second);
 
     // one at the end of the string
-    v = {3, 5, 9};
+    v = { 3, 5, 9 };
     p = pg.reads[0]->find_position(v, b);
     truth = std::make_pair(8, 10);
     EXPECT_EQ(p.first, truth.first);
     EXPECT_EQ(p.second, truth.second);
 
     // one in reverse
-    v = {0, 5, 3};
-    b = {1, 1, 1};
+    v = { 0, 5, 3 };
+    b = { 1, 1, 1 };
     p = pg.reads[0]->find_position(v, b);
     truth = std::make_pair(3, 5);
     EXPECT_EQ(p.first, truth.first);
     EXPECT_EQ(p.second, truth.second);
 
     // one overlapping start
-    v = {9, 0, 1};
-    b = {0, 0, 0};
+    v = { 9, 0, 1 };
+    b = { 0, 0, 0 };
     p = pg.reads[0]->find_position(v, b);
     truth = std::make_pair(0, 1);
     EXPECT_EQ(p.first, truth.first);
     EXPECT_EQ(p.second, truth.second);
     // one in reverse overlapping start
-    v = {1, 0, 9};
-    b = {1, 1, 1};
+    v = { 1, 0, 9 };
+    b = { 1, 1, 1 };
     p = pg.reads[0]->find_position(v, b);
     truth = std::make_pair(0, 1);
     EXPECT_EQ(p.first, truth.first);
     EXPECT_EQ(p.second, truth.second);
 
     // one overlapping the end
-    b = {0, 0, 0};
-    v = {5, 9, 9};
+    b = { 0, 0, 0 };
+    v = { 5, 9, 9 };
     p = pg.reads[0]->find_position(v, b);
     truth = std::make_pair(9, 10);
     EXPECT_EQ(p.first, truth.first);
     EXPECT_EQ(p.second, truth.second);
 
     // one in reverse overlapping end
-    b = {1, 1, 1};
-    v = {0, 9, 5};
+    b = { 1, 1, 1 };
+    v = { 0, 9, 5 };
     p = pg.reads[0]->find_position(v, b);
     truth = std::make_pair(9, 10);
     EXPECT_EQ(p.first, truth.first);
     EXPECT_EQ(p.second, truth.second);
 
     // one not a match
-    b = {0, 0, 0};
-    v = {8, 8, 8};
+    b = { 0, 0, 0 };
+    v = { 8, 8, 8 };
     p = pg.reads[0]->find_position(v, b);
-    truth = std::make_pair(std::numeric_limits<uint>::max(), std::numeric_limits<uint>::max());
+    truth = std::make_pair(
+        std::numeric_limits<uint>::max(), std::numeric_limits<uint>::max());
     EXPECT_EQ(p.first, truth.first);
     EXPECT_EQ(p.second, truth.second);
 
     // one where orientations mean not a match
-    v = {3, 2, 7};
+    v = { 3, 2, 7 };
     p = pg.reads[0]->find_position(v, b);
     EXPECT_EQ(p.first, truth.first);
     EXPECT_EQ(p.second, truth.second);
 
     // and when is whole read
-    v = {0, 1, 2};
+    v = { 0, 1, 2 };
     p = pg.reads[1]->find_position(v, b);
     truth = std::make_pair(0, 2);
     EXPECT_EQ(p.first, truth.first);
     EXPECT_EQ(p.second, truth.second);
 }
 
-TEST(PangenomeReadTest, remove_node) {
+TEST(PangenomeReadTest, remove_node)
+{
 
     std::set<MinimizerHitPtr, pComp> dummy_cluster;
 
@@ -247,54 +250,72 @@ TEST(PangenomeReadTest, remove_node) {
     pg.add_hits_between_PRG_and_read(l4, 2, dummy_cluster);
 
     // check all as expected
-    exp_read_nodes = {pg.nodes[0], pg.nodes[1], pg.nodes[2], pg.nodes[3]};
-    exp_read_orientations = {0, 0, 0, 0};
-    EXPECT_TRUE(equal_containers(pg.reads[0]->get_nodes(), exp_read_nodes, EqualComparatorWeakNodePtr()));
-    EXPECT_ITERABLE_EQ(std::vector<bool>, pg.reads[0]->node_orientations, exp_read_orientations);
-    exp_read_nodes = {pg.nodes[4], pg.nodes[3], pg.nodes[1]};
-    exp_read_orientations = {0, 0, 0};
-    EXPECT_TRUE(equal_containers(pg.reads[1]->get_nodes(), exp_read_nodes, EqualComparatorWeakNodePtr()));
-    EXPECT_ITERABLE_EQ(std::vector<bool>, pg.reads[1]->node_orientations, exp_read_orientations);
-    exp_read_nodes = {pg.nodes[0], pg.nodes[1], pg.nodes[3], pg.nodes[4]};
-    exp_read_orientations = {0, 0, 0, 0};
-    EXPECT_TRUE(equal_containers(pg.reads[2]->get_nodes(), exp_read_nodes, EqualComparatorWeakNodePtr()));
-    EXPECT_ITERABLE_EQ(std::vector<bool>, pg.reads[2]->node_orientations, exp_read_orientations);
+    exp_read_nodes = { pg.nodes[0], pg.nodes[1], pg.nodes[2], pg.nodes[3] };
+    exp_read_orientations = { 0, 0, 0, 0 };
+    EXPECT_TRUE(equal_containers(
+        pg.reads[0]->get_nodes(), exp_read_nodes, EqualComparatorWeakNodePtr()));
+    EXPECT_ITERABLE_EQ(
+        std::vector<bool>, pg.reads[0]->node_orientations, exp_read_orientations);
+    exp_read_nodes = { pg.nodes[4], pg.nodes[3], pg.nodes[1] };
+    exp_read_orientations = { 0, 0, 0 };
+    EXPECT_TRUE(equal_containers(
+        pg.reads[1]->get_nodes(), exp_read_nodes, EqualComparatorWeakNodePtr()));
+    EXPECT_ITERABLE_EQ(
+        std::vector<bool>, pg.reads[1]->node_orientations, exp_read_orientations);
+    exp_read_nodes = { pg.nodes[0], pg.nodes[1], pg.nodes[3], pg.nodes[4] };
+    exp_read_orientations = { 0, 0, 0, 0 };
+    EXPECT_TRUE(equal_containers(
+        pg.reads[2]->get_nodes(), exp_read_nodes, EqualComparatorWeakNodePtr()));
+    EXPECT_ITERABLE_EQ(
+        std::vector<bool>, pg.reads[2]->node_orientations, exp_read_orientations);
 
     // example with a node replacing an old node which only appears in one read
     pg.reads[0]->remove_all_nodes_with_this_id(pg.nodes[2]->node_id);
 
-    exp_read_nodes = {pg.nodes[0], pg.nodes[1], pg.nodes[3]};
-    exp_read_orientations = {0, 0, 0};
-    EXPECT_TRUE(equal_containers(pg.reads[0]->get_nodes(), exp_read_nodes, EqualComparatorWeakNodePtr()));
-    EXPECT_ITERABLE_EQ(std::vector<bool>, pg.reads[0]->node_orientations, exp_read_orientations);
-    exp_read_nodes = {pg.nodes[4], pg.nodes[3], pg.nodes[1]};
-    exp_read_orientations = {0, 0, 0};
-    EXPECT_TRUE(equal_containers(pg.reads[1]->get_nodes(), exp_read_nodes, EqualComparatorWeakNodePtr()));
-    EXPECT_ITERABLE_EQ(std::vector<bool>, pg.reads[1]->node_orientations, exp_read_orientations);
-    exp_read_nodes = {pg.nodes[0], pg.nodes[1], pg.nodes[3], pg.nodes[4]};
-    exp_read_orientations = {0, 0, 0, 0};
-    EXPECT_TRUE(equal_containers(pg.reads[2]->get_nodes(), exp_read_nodes, EqualComparatorWeakNodePtr()));
-    EXPECT_ITERABLE_EQ(std::vector<bool>, pg.reads[2]->node_orientations, exp_read_orientations);
+    exp_read_nodes = { pg.nodes[0], pg.nodes[1], pg.nodes[3] };
+    exp_read_orientations = { 0, 0, 0 };
+    EXPECT_TRUE(equal_containers(
+        pg.reads[0]->get_nodes(), exp_read_nodes, EqualComparatorWeakNodePtr()));
+    EXPECT_ITERABLE_EQ(
+        std::vector<bool>, pg.reads[0]->node_orientations, exp_read_orientations);
+    exp_read_nodes = { pg.nodes[4], pg.nodes[3], pg.nodes[1] };
+    exp_read_orientations = { 0, 0, 0 };
+    EXPECT_TRUE(equal_containers(
+        pg.reads[1]->get_nodes(), exp_read_nodes, EqualComparatorWeakNodePtr()));
+    EXPECT_ITERABLE_EQ(
+        std::vector<bool>, pg.reads[1]->node_orientations, exp_read_orientations);
+    exp_read_nodes = { pg.nodes[0], pg.nodes[1], pg.nodes[3], pg.nodes[4] };
+    exp_read_orientations = { 0, 0, 0, 0 };
+    EXPECT_TRUE(equal_containers(
+        pg.reads[2]->get_nodes(), exp_read_nodes, EqualComparatorWeakNodePtr()));
+    EXPECT_ITERABLE_EQ(
+        std::vector<bool>, pg.reads[2]->node_orientations, exp_read_orientations);
 
     // example where old node appears in more than one read
     pg.reads[0]->remove_all_nodes_with_this_id(pg.nodes[1]->node_id);
 
-    exp_read_nodes = {pg.nodes[0], pg.nodes[3]};
-    exp_read_orientations = {0, 0};
-    EXPECT_TRUE(equal_containers(pg.reads[0]->get_nodes(), exp_read_nodes, EqualComparatorWeakNodePtr()));
-    EXPECT_ITERABLE_EQ(std::vector<bool>, pg.reads[0]->node_orientations, exp_read_orientations);
-    exp_read_nodes = {pg.nodes[4], pg.nodes[3], pg.nodes[1]};
-    exp_read_orientations = {0, 0, 0};
-    EXPECT_TRUE(equal_containers(pg.reads[1]->get_nodes(), exp_read_nodes, EqualComparatorWeakNodePtr()));
-    EXPECT_ITERABLE_EQ(std::vector<bool>, pg.reads[1]->node_orientations, exp_read_orientations);
-    exp_read_nodes = {pg.nodes[0], pg.nodes[1], pg.nodes[3], pg.nodes[4]};
-    exp_read_orientations = {0, 0, 0, 0};
-    EXPECT_TRUE(equal_containers(pg.reads[2]->get_nodes(), exp_read_nodes, EqualComparatorWeakNodePtr()));
-    EXPECT_ITERABLE_EQ(std::vector<bool>, pg.reads[2]->node_orientations, exp_read_orientations);
+    exp_read_nodes = { pg.nodes[0], pg.nodes[3] };
+    exp_read_orientations = { 0, 0 };
+    EXPECT_TRUE(equal_containers(
+        pg.reads[0]->get_nodes(), exp_read_nodes, EqualComparatorWeakNodePtr()));
+    EXPECT_ITERABLE_EQ(
+        std::vector<bool>, pg.reads[0]->node_orientations, exp_read_orientations);
+    exp_read_nodes = { pg.nodes[4], pg.nodes[3], pg.nodes[1] };
+    exp_read_orientations = { 0, 0, 0 };
+    EXPECT_TRUE(equal_containers(
+        pg.reads[1]->get_nodes(), exp_read_nodes, EqualComparatorWeakNodePtr()));
+    EXPECT_ITERABLE_EQ(
+        std::vector<bool>, pg.reads[1]->node_orientations, exp_read_orientations);
+    exp_read_nodes = { pg.nodes[0], pg.nodes[1], pg.nodes[3], pg.nodes[4] };
+    exp_read_orientations = { 0, 0, 0, 0 };
+    EXPECT_TRUE(equal_containers(
+        pg.reads[2]->get_nodes(), exp_read_nodes, EqualComparatorWeakNodePtr()));
+    EXPECT_ITERABLE_EQ(
+        std::vector<bool>, pg.reads[2]->node_orientations, exp_read_orientations);
 
     // example where have actual hit
     Interval i(0, 5);
-    std::deque<Interval> d = {Interval(7, 8), Interval(10, 14)};
+    std::deque<Interval> d = { Interval(7, 8), Interval(10, 14) };
     prg::Path p;
     p.initialize(d);
     Minimizer m1(0, i.start, i.get_end(), 0); // kmer, start, end, strand
@@ -306,38 +327,51 @@ TEST(PangenomeReadTest, remove_node) {
 
     pg.reads[2]->remove_all_nodes_with_this_id(pg.nodes[4]->node_id);
 
-    exp_read_nodes = {pg.nodes[0], pg.nodes[3]};
-    exp_read_orientations = {0, 0};
-    EXPECT_TRUE(equal_containers(pg.reads[0]->get_nodes(), exp_read_nodes, EqualComparatorWeakNodePtr()));
-    EXPECT_ITERABLE_EQ(std::vector<bool>, pg.reads[0]->node_orientations, exp_read_orientations);
-    exp_read_nodes = {pg.nodes[4], pg.nodes[3], pg.nodes[1]};
-    exp_read_orientations = {0, 0, 0};
-    EXPECT_TRUE(equal_containers(pg.reads[1]->get_nodes(), exp_read_nodes, EqualComparatorWeakNodePtr()));
-    EXPECT_ITERABLE_EQ(std::vector<bool>, pg.reads[1]->node_orientations, exp_read_orientations);
-    exp_read_nodes = {pg.nodes[0], pg.nodes[1], pg.nodes[3]};
-    exp_read_orientations = {0, 0, 0};
-    EXPECT_TRUE(equal_containers(pg.reads[2]->get_nodes(), exp_read_nodes, EqualComparatorWeakNodePtr()));
-    EXPECT_ITERABLE_EQ(std::vector<bool>, pg.reads[2]->node_orientations, exp_read_orientations);
+    exp_read_nodes = { pg.nodes[0], pg.nodes[3] };
+    exp_read_orientations = { 0, 0 };
+    EXPECT_TRUE(equal_containers(
+        pg.reads[0]->get_nodes(), exp_read_nodes, EqualComparatorWeakNodePtr()));
+    EXPECT_ITERABLE_EQ(
+        std::vector<bool>, pg.reads[0]->node_orientations, exp_read_orientations);
+    exp_read_nodes = { pg.nodes[4], pg.nodes[3], pg.nodes[1] };
+    exp_read_orientations = { 0, 0, 0 };
+    EXPECT_TRUE(equal_containers(
+        pg.reads[1]->get_nodes(), exp_read_nodes, EqualComparatorWeakNodePtr()));
+    EXPECT_ITERABLE_EQ(
+        std::vector<bool>, pg.reads[1]->node_orientations, exp_read_orientations);
+    exp_read_nodes = { pg.nodes[0], pg.nodes[1], pg.nodes[3] };
+    exp_read_orientations = { 0, 0, 0 };
+    EXPECT_TRUE(equal_containers(
+        pg.reads[2]->get_nodes(), exp_read_nodes, EqualComparatorWeakNodePtr()));
+    EXPECT_ITERABLE_EQ(
+        std::vector<bool>, pg.reads[2]->node_orientations, exp_read_orientations);
 
-    //example where node appears twice in read
+    // example where node appears twice in read
     pg.add_hits_between_PRG_and_read(l1, 2, dummy_cluster);
     pg.reads[2]->remove_all_nodes_with_this_id(pg.nodes[1]->node_id);
 
-    exp_read_nodes = {pg.nodes[0], pg.nodes[3]};
-    exp_read_orientations = {0, 0};
-    EXPECT_TRUE(equal_containers(pg.reads[0]->get_nodes(), exp_read_nodes, EqualComparatorWeakNodePtr()));
-    EXPECT_ITERABLE_EQ(std::vector<bool>, pg.reads[0]->node_orientations, exp_read_orientations);
-    exp_read_nodes = {pg.nodes[4], pg.nodes[3], pg.nodes[1]};
-    exp_read_orientations = {0, 0, 0};
-    EXPECT_TRUE(equal_containers(pg.reads[1]->get_nodes(), exp_read_nodes, EqualComparatorWeakNodePtr()));
-    EXPECT_ITERABLE_EQ(std::vector<bool>, pg.reads[1]->node_orientations, exp_read_orientations);
-    exp_read_nodes = {pg.nodes[0], pg.nodes[3]};
-    exp_read_orientations = {0, 0};
-    EXPECT_TRUE(equal_containers(pg.reads[2]->get_nodes(), exp_read_nodes, EqualComparatorWeakNodePtr()));
-    EXPECT_ITERABLE_EQ(std::vector<bool>, pg.reads[2]->node_orientations, exp_read_orientations);
+    exp_read_nodes = { pg.nodes[0], pg.nodes[3] };
+    exp_read_orientations = { 0, 0 };
+    EXPECT_TRUE(equal_containers(
+        pg.reads[0]->get_nodes(), exp_read_nodes, EqualComparatorWeakNodePtr()));
+    EXPECT_ITERABLE_EQ(
+        std::vector<bool>, pg.reads[0]->node_orientations, exp_read_orientations);
+    exp_read_nodes = { pg.nodes[4], pg.nodes[3], pg.nodes[1] };
+    exp_read_orientations = { 0, 0, 0 };
+    EXPECT_TRUE(equal_containers(
+        pg.reads[1]->get_nodes(), exp_read_nodes, EqualComparatorWeakNodePtr()));
+    EXPECT_ITERABLE_EQ(
+        std::vector<bool>, pg.reads[1]->node_orientations, exp_read_orientations);
+    exp_read_nodes = { pg.nodes[0], pg.nodes[3] };
+    exp_read_orientations = { 0, 0 };
+    EXPECT_TRUE(equal_containers(
+        pg.reads[2]->get_nodes(), exp_read_nodes, EqualComparatorWeakNodePtr()));
+    EXPECT_ITERABLE_EQ(
+        std::vector<bool>, pg.reads[2]->node_orientations, exp_read_orientations);
 }
 
-TEST(PangenomeReadTest, remove_node_it) {
+TEST(PangenomeReadTest, remove_node_it)
+{
     std::set<MinimizerHitPtr, pComp> dummy_cluster;
 
     PGraphTester pg;
@@ -368,55 +402,73 @@ TEST(PangenomeReadTest, remove_node_it) {
     pg.add_hits_between_PRG_and_read(l4, 2, dummy_cluster);
 
     // check all as expected
-    exp_read_nodes = {pg.nodes[0], pg.nodes[1], pg.nodes[2], pg.nodes[3]};
-    exp_read_orientations = {0, 0, 0, 0};
-    EXPECT_TRUE(equal_containers(pg.reads[0]->get_nodes(), exp_read_nodes, EqualComparatorWeakNodePtr()));
-    EXPECT_ITERABLE_EQ(std::vector<bool>, pg.reads[0]->node_orientations, exp_read_orientations);
-    exp_read_nodes = {pg.nodes[4], pg.nodes[3], pg.nodes[1]};
-    exp_read_orientations = {0, 0, 0};
-    EXPECT_TRUE(equal_containers(pg.reads[1]->get_nodes(), exp_read_nodes, EqualComparatorWeakNodePtr()));
-    EXPECT_ITERABLE_EQ(std::vector<bool>, pg.reads[1]->node_orientations, exp_read_orientations);
-    exp_read_nodes = {pg.nodes[0], pg.nodes[1], pg.nodes[3], pg.nodes[4]};
-    exp_read_orientations = {0, 0, 0, 0};
-    EXPECT_TRUE(equal_containers(pg.reads[2]->get_nodes(), exp_read_nodes, EqualComparatorWeakNodePtr()));
-    EXPECT_ITERABLE_EQ(std::vector<bool>, pg.reads[2]->node_orientations, exp_read_orientations);
+    exp_read_nodes = { pg.nodes[0], pg.nodes[1], pg.nodes[2], pg.nodes[3] };
+    exp_read_orientations = { 0, 0, 0, 0 };
+    EXPECT_TRUE(equal_containers(
+        pg.reads[0]->get_nodes(), exp_read_nodes, EqualComparatorWeakNodePtr()));
+    EXPECT_ITERABLE_EQ(
+        std::vector<bool>, pg.reads[0]->node_orientations, exp_read_orientations);
+    exp_read_nodes = { pg.nodes[4], pg.nodes[3], pg.nodes[1] };
+    exp_read_orientations = { 0, 0, 0 };
+    EXPECT_TRUE(equal_containers(
+        pg.reads[1]->get_nodes(), exp_read_nodes, EqualComparatorWeakNodePtr()));
+    EXPECT_ITERABLE_EQ(
+        std::vector<bool>, pg.reads[1]->node_orientations, exp_read_orientations);
+    exp_read_nodes = { pg.nodes[0], pg.nodes[1], pg.nodes[3], pg.nodes[4] };
+    exp_read_orientations = { 0, 0, 0, 0 };
+    EXPECT_TRUE(equal_containers(
+        pg.reads[2]->get_nodes(), exp_read_nodes, EqualComparatorWeakNodePtr()));
+    EXPECT_ITERABLE_EQ(
+        std::vector<bool>, pg.reads[2]->node_orientations, exp_read_orientations);
 
     // example removing a node which only appears in one read
     auto it = pg.reads[0]->find_node_by_id(pg.nodes[2]->node_id);
     pg.reads[0]->remove_node_with_iterator(it);
 
-    exp_read_nodes = {pg.nodes[0], pg.nodes[1], pg.nodes[3]};
-    exp_read_orientations = {0, 0, 0};
-    EXPECT_TRUE(equal_containers(pg.reads[0]->get_nodes(), exp_read_nodes, EqualComparatorWeakNodePtr()));
-    EXPECT_ITERABLE_EQ(std::vector<bool>, pg.reads[0]->node_orientations, exp_read_orientations);
-    exp_read_nodes = {pg.nodes[4], pg.nodes[3], pg.nodes[1]};
-    exp_read_orientations = {0, 0, 0};
-    EXPECT_TRUE(equal_containers(pg.reads[1]->get_nodes(), exp_read_nodes, EqualComparatorWeakNodePtr()));
-    EXPECT_ITERABLE_EQ(std::vector<bool>, pg.reads[1]->node_orientations, exp_read_orientations);
-    exp_read_nodes = {pg.nodes[0], pg.nodes[1], pg.nodes[3], pg.nodes[4]};
-    exp_read_orientations = {0, 0, 0, 0};
-    EXPECT_TRUE(equal_containers(pg.reads[2]->get_nodes(), exp_read_nodes, EqualComparatorWeakNodePtr()));
-    EXPECT_ITERABLE_EQ(std::vector<bool>, pg.reads[2]->node_orientations, exp_read_orientations);
+    exp_read_nodes = { pg.nodes[0], pg.nodes[1], pg.nodes[3] };
+    exp_read_orientations = { 0, 0, 0 };
+    EXPECT_TRUE(equal_containers(
+        pg.reads[0]->get_nodes(), exp_read_nodes, EqualComparatorWeakNodePtr()));
+    EXPECT_ITERABLE_EQ(
+        std::vector<bool>, pg.reads[0]->node_orientations, exp_read_orientations);
+    exp_read_nodes = { pg.nodes[4], pg.nodes[3], pg.nodes[1] };
+    exp_read_orientations = { 0, 0, 0 };
+    EXPECT_TRUE(equal_containers(
+        pg.reads[1]->get_nodes(), exp_read_nodes, EqualComparatorWeakNodePtr()));
+    EXPECT_ITERABLE_EQ(
+        std::vector<bool>, pg.reads[1]->node_orientations, exp_read_orientations);
+    exp_read_nodes = { pg.nodes[0], pg.nodes[1], pg.nodes[3], pg.nodes[4] };
+    exp_read_orientations = { 0, 0, 0, 0 };
+    EXPECT_TRUE(equal_containers(
+        pg.reads[2]->get_nodes(), exp_read_nodes, EqualComparatorWeakNodePtr()));
+    EXPECT_ITERABLE_EQ(
+        std::vector<bool>, pg.reads[2]->node_orientations, exp_read_orientations);
 
     // example where old node appears in more than one read
     pg.reads[0]->remove_all_nodes_with_this_id(pg.nodes[1]->node_id);
 
-    exp_read_nodes = {pg.nodes[0], pg.nodes[3]};
-    exp_read_orientations = {0, 0};
-    EXPECT_TRUE(equal_containers(pg.reads[0]->get_nodes(), exp_read_nodes, EqualComparatorWeakNodePtr()));
-    EXPECT_ITERABLE_EQ(std::vector<bool>, pg.reads[0]->node_orientations, exp_read_orientations);
-    exp_read_nodes = {pg.nodes[4], pg.nodes[3], pg.nodes[1]};
-    exp_read_orientations = {0, 0, 0};
-    EXPECT_TRUE(equal_containers(pg.reads[1]->get_nodes(), exp_read_nodes, EqualComparatorWeakNodePtr()));
-    EXPECT_ITERABLE_EQ(std::vector<bool>, pg.reads[1]->node_orientations, exp_read_orientations);
-    exp_read_nodes = {pg.nodes[0], pg.nodes[1], pg.nodes[3], pg.nodes[4]};
-    exp_read_orientations = {0, 0, 0, 0};
-    EXPECT_TRUE(equal_containers(pg.reads[2]->get_nodes(), exp_read_nodes, EqualComparatorWeakNodePtr()));
-    EXPECT_ITERABLE_EQ(std::vector<bool>, pg.reads[2]->node_orientations, exp_read_orientations);
+    exp_read_nodes = { pg.nodes[0], pg.nodes[3] };
+    exp_read_orientations = { 0, 0 };
+    EXPECT_TRUE(equal_containers(
+        pg.reads[0]->get_nodes(), exp_read_nodes, EqualComparatorWeakNodePtr()));
+    EXPECT_ITERABLE_EQ(
+        std::vector<bool>, pg.reads[0]->node_orientations, exp_read_orientations);
+    exp_read_nodes = { pg.nodes[4], pg.nodes[3], pg.nodes[1] };
+    exp_read_orientations = { 0, 0, 0 };
+    EXPECT_TRUE(equal_containers(
+        pg.reads[1]->get_nodes(), exp_read_nodes, EqualComparatorWeakNodePtr()));
+    EXPECT_ITERABLE_EQ(
+        std::vector<bool>, pg.reads[1]->node_orientations, exp_read_orientations);
+    exp_read_nodes = { pg.nodes[0], pg.nodes[1], pg.nodes[3], pg.nodes[4] };
+    exp_read_orientations = { 0, 0, 0, 0 };
+    EXPECT_TRUE(equal_containers(
+        pg.reads[2]->get_nodes(), exp_read_nodes, EqualComparatorWeakNodePtr()));
+    EXPECT_ITERABLE_EQ(
+        std::vector<bool>, pg.reads[2]->node_orientations, exp_read_orientations);
 
     // example where have actual hit
     Interval i(0, 5);
-    std::deque<Interval> d = {Interval(7, 8), Interval(10, 14)};
+    std::deque<Interval> d = { Interval(7, 8), Interval(10, 14) };
     prg::Path p;
     p.initialize(d);
     Minimizer m1(0, i.start, i.get_end(), 0); // kmer, start, end, strand
@@ -428,38 +480,51 @@ TEST(PangenomeReadTest, remove_node_it) {
 
     pg.reads[2]->remove_all_nodes_with_this_id(pg.nodes[4]->node_id);
 
-    exp_read_nodes = {pg.nodes[0], pg.nodes[3]};
-    exp_read_orientations = {0, 0};
-    EXPECT_TRUE(equal_containers(pg.reads[0]->get_nodes(), exp_read_nodes, EqualComparatorWeakNodePtr()));
-    EXPECT_ITERABLE_EQ(std::vector<bool>, pg.reads[0]->node_orientations, exp_read_orientations);
-    exp_read_nodes = {pg.nodes[4], pg.nodes[3], pg.nodes[1]};
-    exp_read_orientations = {0, 0, 0};
-    EXPECT_TRUE(equal_containers(pg.reads[1]->get_nodes(), exp_read_nodes, EqualComparatorWeakNodePtr()));
-    EXPECT_ITERABLE_EQ(std::vector<bool>, pg.reads[1]->node_orientations, exp_read_orientations);
-    exp_read_nodes = {pg.nodes[0], pg.nodes[1], pg.nodes[3]};
-    exp_read_orientations = {0, 0, 0};
-    EXPECT_TRUE(equal_containers(pg.reads[2]->get_nodes(), exp_read_nodes, EqualComparatorWeakNodePtr()));
-    EXPECT_ITERABLE_EQ(std::vector<bool>, pg.reads[2]->node_orientations, exp_read_orientations);
+    exp_read_nodes = { pg.nodes[0], pg.nodes[3] };
+    exp_read_orientations = { 0, 0 };
+    EXPECT_TRUE(equal_containers(
+        pg.reads[0]->get_nodes(), exp_read_nodes, EqualComparatorWeakNodePtr()));
+    EXPECT_ITERABLE_EQ(
+        std::vector<bool>, pg.reads[0]->node_orientations, exp_read_orientations);
+    exp_read_nodes = { pg.nodes[4], pg.nodes[3], pg.nodes[1] };
+    exp_read_orientations = { 0, 0, 0 };
+    EXPECT_TRUE(equal_containers(
+        pg.reads[1]->get_nodes(), exp_read_nodes, EqualComparatorWeakNodePtr()));
+    EXPECT_ITERABLE_EQ(
+        std::vector<bool>, pg.reads[1]->node_orientations, exp_read_orientations);
+    exp_read_nodes = { pg.nodes[0], pg.nodes[1], pg.nodes[3] };
+    exp_read_orientations = { 0, 0, 0 };
+    EXPECT_TRUE(equal_containers(
+        pg.reads[2]->get_nodes(), exp_read_nodes, EqualComparatorWeakNodePtr()));
+    EXPECT_ITERABLE_EQ(
+        std::vector<bool>, pg.reads[2]->node_orientations, exp_read_orientations);
 
-    //example where node appears twice in read
+    // example where node appears twice in read
     pg.add_hits_between_PRG_and_read(l1, 2, dummy_cluster);
     pg.reads[2]->remove_all_nodes_with_this_id(pg.nodes[1]->node_id);
 
-    exp_read_nodes = {pg.nodes[0], pg.nodes[3]};
-    exp_read_orientations = {0, 0};
-    EXPECT_TRUE(equal_containers(pg.reads[0]->get_nodes(), exp_read_nodes, EqualComparatorWeakNodePtr()));
-    EXPECT_ITERABLE_EQ(std::vector<bool>, pg.reads[0]->node_orientations, exp_read_orientations);
-    exp_read_nodes = {pg.nodes[4], pg.nodes[3], pg.nodes[1]};
-    exp_read_orientations = {0, 0, 0};
-    EXPECT_TRUE(equal_containers(pg.reads[1]->get_nodes(), exp_read_nodes, EqualComparatorWeakNodePtr()));
-    EXPECT_ITERABLE_EQ(std::vector<bool>, pg.reads[1]->node_orientations, exp_read_orientations);
-    exp_read_nodes = {pg.nodes[0], pg.nodes[3]};
-    exp_read_orientations = {0, 0};
-    EXPECT_TRUE(equal_containers(pg.reads[2]->get_nodes(), exp_read_nodes, EqualComparatorWeakNodePtr()));
-    EXPECT_ITERABLE_EQ(std::vector<bool>, pg.reads[2]->node_orientations, exp_read_orientations);
+    exp_read_nodes = { pg.nodes[0], pg.nodes[3] };
+    exp_read_orientations = { 0, 0 };
+    EXPECT_TRUE(equal_containers(
+        pg.reads[0]->get_nodes(), exp_read_nodes, EqualComparatorWeakNodePtr()));
+    EXPECT_ITERABLE_EQ(
+        std::vector<bool>, pg.reads[0]->node_orientations, exp_read_orientations);
+    exp_read_nodes = { pg.nodes[4], pg.nodes[3], pg.nodes[1] };
+    exp_read_orientations = { 0, 0, 0 };
+    EXPECT_TRUE(equal_containers(
+        pg.reads[1]->get_nodes(), exp_read_nodes, EqualComparatorWeakNodePtr()));
+    EXPECT_ITERABLE_EQ(
+        std::vector<bool>, pg.reads[1]->node_orientations, exp_read_orientations);
+    exp_read_nodes = { pg.nodes[0], pg.nodes[3] };
+    exp_read_orientations = { 0, 0 };
+    EXPECT_TRUE(equal_containers(
+        pg.reads[2]->get_nodes(), exp_read_nodes, EqualComparatorWeakNodePtr()));
+    EXPECT_ITERABLE_EQ(
+        std::vector<bool>, pg.reads[2]->node_orientations, exp_read_orientations);
 }
 
-TEST(PangenomeReadTest, replace_node) {
+TEST(PangenomeReadTest, replace_node)
+{
     std::set<MinimizerHitPtr, pComp> dummy_cluster;
 
     pangenome::Graph pg;
@@ -483,26 +548,29 @@ TEST(PangenomeReadTest, replace_node) {
     pg.add_hits_between_PRG_and_read(l1, 1, dummy_cluster);
 
     // check what we expect to start with
-    EXPECT_EQ((uint) 5, pg.nodes.size());
-    EXPECT_EQ(pg.nodes[0]->node_id, (uint) 0);
-    EXPECT_EQ(pg.nodes[0]->covg, (uint) 1);
-    EXPECT_EQ(pg.nodes[1]->node_id, (uint) 1);
-    EXPECT_EQ(pg.nodes[1]->covg, (uint) 3);
-    EXPECT_EQ(pg.nodes[2]->node_id, (uint) 2);
-    EXPECT_EQ(pg.nodes[2]->covg, (uint) 1);
-    EXPECT_EQ(pg.nodes[3]->node_id, (uint) 3);
-    EXPECT_EQ(pg.nodes[3]->covg, (uint) 2);
-    EXPECT_EQ(pg.nodes[4]->node_id, (uint) 4);
-    EXPECT_EQ(pg.nodes[4]->covg, (uint) 1);
+    EXPECT_EQ((uint)5, pg.nodes.size());
+    EXPECT_EQ(pg.nodes[0]->node_id, (uint)0);
+    EXPECT_EQ(pg.nodes[0]->covg, (uint)1);
+    EXPECT_EQ(pg.nodes[1]->node_id, (uint)1);
+    EXPECT_EQ(pg.nodes[1]->covg, (uint)3);
+    EXPECT_EQ(pg.nodes[2]->node_id, (uint)2);
+    EXPECT_EQ(pg.nodes[2]->covg, (uint)1);
+    EXPECT_EQ(pg.nodes[3]->node_id, (uint)3);
+    EXPECT_EQ(pg.nodes[3]->covg, (uint)2);
+    EXPECT_EQ(pg.nodes[4]->node_id, (uint)4);
+    EXPECT_EQ(pg.nodes[4]->covg, (uint)1);
 
-    EXPECT_EQ((uint) 2, pg.reads.size());
-    std::vector<WeakNodePtr> read_exp = {pg.nodes[0], pg.nodes[1], pg.nodes[2], pg.nodes[3], pg.nodes[1]};
-    std::vector<bool> read_o_exp = {0, 0, 0, 0, 0};
-    EXPECT_TRUE(equal_containers(pg.reads[0]->get_nodes(), read_exp, EqualComparatorWeakNodePtr()));
+    EXPECT_EQ((uint)2, pg.reads.size());
+    std::vector<WeakNodePtr> read_exp
+        = { pg.nodes[0], pg.nodes[1], pg.nodes[2], pg.nodes[3], pg.nodes[1] };
+    std::vector<bool> read_o_exp = { 0, 0, 0, 0, 0 };
+    EXPECT_TRUE(equal_containers(
+        pg.reads[0]->get_nodes(), read_exp, EqualComparatorWeakNodePtr()));
     EXPECT_ITERABLE_EQ(std::vector<bool>, read_o_exp, pg.reads[0]->node_orientations);
-    read_exp = {pg.nodes[4], pg.nodes[3], pg.nodes[1]};
-    read_o_exp = {0, 0, 0};
-    EXPECT_TRUE(equal_containers(pg.reads[1]->get_nodes(), read_exp, EqualComparatorWeakNodePtr()));
+    read_exp = { pg.nodes[4], pg.nodes[3], pg.nodes[1] };
+    read_o_exp = { 0, 0, 0 };
+    EXPECT_TRUE(equal_containers(
+        pg.reads[1]->get_nodes(), read_exp, EqualComparatorWeakNodePtr()));
     EXPECT_ITERABLE_EQ(std::vector<bool>, read_o_exp, pg.reads[1]->node_orientations);
 
     // example with a node replacing an old node which only appears in one read
@@ -511,22 +579,24 @@ TEST(PangenomeReadTest, replace_node) {
     auto it = pg.reads[0]->get_nodes().begin() + 2;
     pg.reads[0]->replace_node_with_iterator(it, n);
 
-    EXPECT_EQ((uint) 6, pg.nodes.size());
-    EXPECT_EQ(pg.nodes[0]->prg_id, (uint) 0);
-    EXPECT_EQ(pg.nodes[1]->prg_id, (uint) 1);
-    EXPECT_EQ(pg.nodes[2]->prg_id, (uint) 2);
-    EXPECT_EQ(pg.nodes[3]->prg_id, (uint) 3);
-    EXPECT_EQ(pg.nodes[4]->prg_id, (uint) 4);
-    EXPECT_EQ(pg.nodes[5]->prg_id, (uint) 2);
+    EXPECT_EQ((uint)6, pg.nodes.size());
+    EXPECT_EQ(pg.nodes[0]->prg_id, (uint)0);
+    EXPECT_EQ(pg.nodes[1]->prg_id, (uint)1);
+    EXPECT_EQ(pg.nodes[2]->prg_id, (uint)2);
+    EXPECT_EQ(pg.nodes[3]->prg_id, (uint)3);
+    EXPECT_EQ(pg.nodes[4]->prg_id, (uint)4);
+    EXPECT_EQ(pg.nodes[5]->prg_id, (uint)2);
 
-    EXPECT_EQ((uint) 2, pg.reads.size());
-    read_exp = {pg.nodes[0], pg.nodes[1], pg.nodes[5], pg.nodes[3], pg.nodes[1]};
-    read_o_exp = {0, 0, 0, 0, 0};
-    EXPECT_TRUE(equal_containers(pg.reads[0]->get_nodes(), read_exp, EqualComparatorWeakNodePtr()));
+    EXPECT_EQ((uint)2, pg.reads.size());
+    read_exp = { pg.nodes[0], pg.nodes[1], pg.nodes[5], pg.nodes[3], pg.nodes[1] };
+    read_o_exp = { 0, 0, 0, 0, 0 };
+    EXPECT_TRUE(equal_containers(
+        pg.reads[0]->get_nodes(), read_exp, EqualComparatorWeakNodePtr()));
     EXPECT_ITERABLE_EQ(std::vector<bool>, read_o_exp, pg.reads[0]->node_orientations);
-    read_exp = {pg.nodes[4], pg.nodes[3], pg.nodes[1]};
-    read_o_exp = {0, 0, 0};
-    EXPECT_TRUE(equal_containers(pg.reads[1]->get_nodes(), read_exp, EqualComparatorWeakNodePtr()));
+    read_exp = { pg.nodes[4], pg.nodes[3], pg.nodes[1] };
+    read_o_exp = { 0, 0, 0 };
+    EXPECT_TRUE(equal_containers(
+        pg.reads[1]->get_nodes(), read_exp, EqualComparatorWeakNodePtr()));
     EXPECT_ITERABLE_EQ(std::vector<bool>, read_o_exp, pg.reads[1]->node_orientations);
 
     // example where old node appears in more than one read
@@ -535,28 +605,30 @@ TEST(PangenomeReadTest, replace_node) {
     it = pg.reads[1]->get_nodes().begin() + 1;
     pg.reads[1]->replace_node_with_iterator(it, n);
 
-    EXPECT_EQ((uint) 7, pg.nodes.size());
-    EXPECT_EQ(pg.nodes[0]->prg_id, (uint) 0);
-    EXPECT_EQ(pg.nodes[1]->prg_id, (uint) 1);
-    EXPECT_EQ(pg.nodes[2]->prg_id, (uint) 2);
-    EXPECT_EQ(pg.nodes[3]->prg_id, (uint) 3);
-    EXPECT_EQ(pg.nodes[4]->prg_id, (uint) 4);
-    EXPECT_EQ(pg.nodes[5]->prg_id, (uint) 2);
-    EXPECT_EQ(pg.nodes[6]->prg_id, (uint) 3);
+    EXPECT_EQ((uint)7, pg.nodes.size());
+    EXPECT_EQ(pg.nodes[0]->prg_id, (uint)0);
+    EXPECT_EQ(pg.nodes[1]->prg_id, (uint)1);
+    EXPECT_EQ(pg.nodes[2]->prg_id, (uint)2);
+    EXPECT_EQ(pg.nodes[3]->prg_id, (uint)3);
+    EXPECT_EQ(pg.nodes[4]->prg_id, (uint)4);
+    EXPECT_EQ(pg.nodes[5]->prg_id, (uint)2);
+    EXPECT_EQ(pg.nodes[6]->prg_id, (uint)3);
 
-    EXPECT_EQ((uint) 2, pg.reads.size());
-    read_exp = {pg.nodes[0], pg.nodes[1], pg.nodes[5], pg.nodes[3], pg.nodes[1]};
-    read_o_exp = {0, 0, 0, 0, 0};
-    EXPECT_TRUE(equal_containers(pg.reads[0]->get_nodes(), read_exp, EqualComparatorWeakNodePtr()));
+    EXPECT_EQ((uint)2, pg.reads.size());
+    read_exp = { pg.nodes[0], pg.nodes[1], pg.nodes[5], pg.nodes[3], pg.nodes[1] };
+    read_o_exp = { 0, 0, 0, 0, 0 };
+    EXPECT_TRUE(equal_containers(
+        pg.reads[0]->get_nodes(), read_exp, EqualComparatorWeakNodePtr()));
     EXPECT_ITERABLE_EQ(std::vector<bool>, read_o_exp, pg.reads[0]->node_orientations);
-    read_exp = {pg.nodes[4], pg.nodes[6], pg.nodes[1]};
-    read_o_exp = {0, 0, 0};
-    EXPECT_TRUE(equal_containers(pg.reads[1]->get_nodes(), read_exp, EqualComparatorWeakNodePtr()));
+    read_exp = { pg.nodes[4], pg.nodes[6], pg.nodes[1] };
+    read_o_exp = { 0, 0, 0 };
+    EXPECT_TRUE(equal_containers(
+        pg.reads[1]->get_nodes(), read_exp, EqualComparatorWeakNodePtr()));
     EXPECT_ITERABLE_EQ(std::vector<bool>, read_o_exp, pg.reads[1]->node_orientations);
 
     // example where move actual hits
     Interval i(0, 5);
-    std::deque<Interval> d = {Interval(7, 8), Interval(10, 14)};
+    std::deque<Interval> d = { Interval(7, 8), Interval(10, 14) };
     prg::Path p;
     p.initialize(d);
     Minimizer m1(0, i.start, i.get_end(), 0); // kmer, start, end, strand
@@ -565,65 +637,68 @@ TEST(PangenomeReadTest, replace_node) {
     std::set<MinimizerHitPtr, pComp> c;
     c.insert(mh);
     pg.reads[1]->add_hits(pg.nodes[4], c);
-    EXPECT_EQ(pg.reads[1]->get_hits_as_unordered_map()[4].size(), (uint) 1);
+    EXPECT_EQ(pg.reads[1]->get_hits_as_unordered_map()[4].size(), (uint)1);
     n = std::make_shared<pangenome::Node>(l4, 7);
     pg.nodes[7] = n;
     it = pg.reads[1]->get_nodes().begin();
     pg.reads[1]->replace_node_with_iterator(it, n);
 
-    EXPECT_EQ((uint) 8, pg.nodes.size());
-    EXPECT_EQ(pg.nodes[0]->prg_id, (uint) 0);
-    EXPECT_EQ(pg.nodes[1]->prg_id, (uint) 1);
-    EXPECT_EQ(pg.nodes[2]->prg_id, (uint) 2);
-    EXPECT_EQ(pg.nodes[3]->prg_id, (uint) 3);
-    EXPECT_EQ(pg.nodes[4]->prg_id, (uint) 4);
-    EXPECT_EQ(pg.nodes[5]->prg_id, (uint) 2);
-    EXPECT_EQ(pg.nodes[6]->prg_id, (uint) 3);
-    EXPECT_EQ(pg.nodes[7]->prg_id, (uint) 4);
+    EXPECT_EQ((uint)8, pg.nodes.size());
+    EXPECT_EQ(pg.nodes[0]->prg_id, (uint)0);
+    EXPECT_EQ(pg.nodes[1]->prg_id, (uint)1);
+    EXPECT_EQ(pg.nodes[2]->prg_id, (uint)2);
+    EXPECT_EQ(pg.nodes[3]->prg_id, (uint)3);
+    EXPECT_EQ(pg.nodes[4]->prg_id, (uint)4);
+    EXPECT_EQ(pg.nodes[5]->prg_id, (uint)2);
+    EXPECT_EQ(pg.nodes[6]->prg_id, (uint)3);
+    EXPECT_EQ(pg.nodes[7]->prg_id, (uint)4);
 
-    EXPECT_EQ((uint) 2, pg.reads.size());
-    read_exp = {pg.nodes[0], pg.nodes[1], pg.nodes[5], pg.nodes[3], pg.nodes[1]};
-    read_o_exp = {0, 0, 0, 0, 0};
-    EXPECT_TRUE(equal_containers(pg.reads[0]->get_nodes(), read_exp, EqualComparatorWeakNodePtr()));
+    EXPECT_EQ((uint)2, pg.reads.size());
+    read_exp = { pg.nodes[0], pg.nodes[1], pg.nodes[5], pg.nodes[3], pg.nodes[1] };
+    read_o_exp = { 0, 0, 0, 0, 0 };
+    EXPECT_TRUE(equal_containers(
+        pg.reads[0]->get_nodes(), read_exp, EqualComparatorWeakNodePtr()));
     EXPECT_ITERABLE_EQ(std::vector<bool>, read_o_exp, pg.reads[0]->node_orientations);
-    read_exp = {pg.nodes[7], pg.nodes[6], pg.nodes[1], pg.nodes[4]};
-    read_o_exp = {0, 0, 0, 1};
-    EXPECT_TRUE(equal_containers(pg.reads[1]->get_nodes(), read_exp, EqualComparatorWeakNodePtr()));
+    read_exp = { pg.nodes[7], pg.nodes[6], pg.nodes[1], pg.nodes[4] };
+    read_o_exp = { 0, 0, 0, 1 };
+    EXPECT_TRUE(equal_containers(
+        pg.reads[1]->get_nodes(), read_exp, EqualComparatorWeakNodePtr()));
     EXPECT_ITERABLE_EQ(std::vector<bool>, read_o_exp, pg.reads[1]->node_orientations);
-    EXPECT_EQ(pg.reads[1]->get_hits_as_unordered_map()[7].size(), (uint) 0);
-    EXPECT_EQ(pg.reads[1]->get_hits_as_unordered_map()[4].size(), (uint) 1);
+    EXPECT_EQ(pg.reads[1]->get_hits_as_unordered_map()[7].size(), (uint)0);
+    EXPECT_EQ(pg.reads[1]->get_hits_as_unordered_map()[4].size(), (uint)1);
 
-    //example where node appears twice in read
+    // example where node appears twice in read
     n = std::make_shared<pangenome::Node>(l1, 8);
     pg.nodes[8] = n;
     it = pg.reads[0]->get_nodes().begin() + 4;
     pg.reads[0]->replace_node_with_iterator(it, n);
 
-    EXPECT_EQ((uint) 9, pg.nodes.size());
-    EXPECT_EQ(pg.nodes[0]->prg_id, (uint) 0);
-    EXPECT_EQ(pg.nodes[1]->prg_id, (uint) 1);
-    EXPECT_EQ(pg.nodes[2]->prg_id, (uint) 2);
-    EXPECT_EQ(pg.nodes[3]->prg_id, (uint) 3);
-    EXPECT_EQ(pg.nodes[4]->prg_id, (uint) 4);
-    EXPECT_EQ(pg.nodes[5]->prg_id, (uint) 2);
-    EXPECT_EQ(pg.nodes[6]->prg_id, (uint) 3);
-    EXPECT_EQ(pg.nodes[7]->prg_id, (uint) 4);
-    EXPECT_EQ(pg.nodes[8]->prg_id, (uint) 1);
+    EXPECT_EQ((uint)9, pg.nodes.size());
+    EXPECT_EQ(pg.nodes[0]->prg_id, (uint)0);
+    EXPECT_EQ(pg.nodes[1]->prg_id, (uint)1);
+    EXPECT_EQ(pg.nodes[2]->prg_id, (uint)2);
+    EXPECT_EQ(pg.nodes[3]->prg_id, (uint)3);
+    EXPECT_EQ(pg.nodes[4]->prg_id, (uint)4);
+    EXPECT_EQ(pg.nodes[5]->prg_id, (uint)2);
+    EXPECT_EQ(pg.nodes[6]->prg_id, (uint)3);
+    EXPECT_EQ(pg.nodes[7]->prg_id, (uint)4);
+    EXPECT_EQ(pg.nodes[8]->prg_id, (uint)1);
 
-
-    EXPECT_EQ((uint) 2, pg.reads.size());
-    read_exp = {pg.nodes[0], pg.nodes[1], pg.nodes[5], pg.nodes[3], pg.nodes[8]};
-    read_o_exp = {0, 0, 0, 0, 0};
-    EXPECT_TRUE(equal_containers(pg.reads[0]->get_nodes(), read_exp, EqualComparatorWeakNodePtr()));
+    EXPECT_EQ((uint)2, pg.reads.size());
+    read_exp = { pg.nodes[0], pg.nodes[1], pg.nodes[5], pg.nodes[3], pg.nodes[8] };
+    read_o_exp = { 0, 0, 0, 0, 0 };
+    EXPECT_TRUE(equal_containers(
+        pg.reads[0]->get_nodes(), read_exp, EqualComparatorWeakNodePtr()));
     EXPECT_ITERABLE_EQ(std::vector<bool>, read_o_exp, pg.reads[0]->node_orientations);
-    read_exp = {pg.nodes[7], pg.nodes[6], pg.nodes[1], pg.nodes[4]};
-    read_o_exp = {0, 0, 0, 1};
-    EXPECT_TRUE(equal_containers(pg.reads[1]->get_nodes(), read_exp, EqualComparatorWeakNodePtr()));
+    read_exp = { pg.nodes[7], pg.nodes[6], pg.nodes[1], pg.nodes[4] };
+    read_o_exp = { 0, 0, 0, 1 };
+    EXPECT_TRUE(equal_containers(
+        pg.reads[1]->get_nodes(), read_exp, EqualComparatorWeakNodePtr()));
     EXPECT_ITERABLE_EQ(std::vector<bool>, read_o_exp, pg.reads[1]->node_orientations);
-
 }
 
-TEST(PangenomeReadTest, equals) {
+TEST(PangenomeReadTest, equals)
+{
     Read pr1(1);
     Read pr2(2);
     EXPECT_EQ(pr1, pr1);
@@ -632,7 +707,8 @@ TEST(PangenomeReadTest, equals) {
     EXPECT_EQ((pr2 == pr1), false);
 }
 
-TEST(PangenomeReadTest, nequals) {
+TEST(PangenomeReadTest, nequals)
+{
     Read pr1(1);
     Read pr2(2);
     EXPECT_NE(pr1, pr2);
@@ -641,7 +717,8 @@ TEST(PangenomeReadTest, nequals) {
     EXPECT_EQ((pr2 != pr2), false);
 }
 
-TEST(PangenomeReadTest, less) {
+TEST(PangenomeReadTest, less)
+{
     Read pr1(1);
     Read pr2(2);
     EXPECT_EQ((pr1 < pr1), false);

--- a/test/pansample_test.cpp
+++ b/test/pansample_test.cpp
@@ -1,43 +1,45 @@
-#include "gtest/gtest.h"
 #include "pangenome/ns.cpp"
 #include "pangenome/pannode.h"
 #include "pangenome/pansample.h"
-#include <stdint.h>
+#include "gtest/gtest.h"
 #include <iostream>
-
+#include <stdint.h>
 
 using namespace pangenome;
 
-TEST(PangenomeSampleTest, create) {
+TEST(PangenomeSampleTest, create)
+{
 
     Sample ps("sample", 0);
     EXPECT_EQ("sample", ps.name);
-    EXPECT_EQ((uint) 0, ps.paths.size());
+    EXPECT_EQ((uint)0, ps.paths.size());
 
     // do the same creating a pointer
     SamplePtr ps1(std::make_shared<Sample>("sample", 0));
     EXPECT_EQ("sample", ps1->name);
-    EXPECT_EQ((uint) 0, ps1->paths.size());
+    EXPECT_EQ((uint)0, ps1->paths.size());
 }
 
-TEST(PangenomeSampleTest, add_path) {
+TEST(PangenomeSampleTest, add_path)
+{
     Sample ps("sample", 0);
     std::vector<KmerNodePtr> kmp;
     ps.add_path(2, kmp);
-    EXPECT_EQ((uint) 1, ps.paths.size());
-    EXPECT_EQ((uint) 1, ps.paths[2].size());
+    EXPECT_EQ((uint)1, ps.paths.size());
+    EXPECT_EQ((uint)1, ps.paths[2].size());
 
     ps.add_path(2, kmp);
-    EXPECT_EQ((uint) 1, ps.paths.size());
-    EXPECT_EQ((uint) 2, ps.paths[2].size());
+    EXPECT_EQ((uint)1, ps.paths.size());
+    EXPECT_EQ((uint)2, ps.paths[2].size());
 
     ps.add_path(3, kmp);
-    EXPECT_EQ((uint) 2, ps.paths.size());
-    EXPECT_EQ((uint) 2, ps.paths[2].size());
-    EXPECT_EQ((uint) 1, ps.paths[3].size());
+    EXPECT_EQ((uint)2, ps.paths.size());
+    EXPECT_EQ((uint)2, ps.paths[2].size());
+    EXPECT_EQ((uint)1, ps.paths[3].size());
 }
 
-TEST(PangenomeSampleTest, equals) {
+TEST(PangenomeSampleTest, equals)
+{
     Sample ps1("1", 0);
     Sample ps2("2", 0);
     EXPECT_EQ(ps1, ps1);
@@ -46,7 +48,8 @@ TEST(PangenomeSampleTest, equals) {
     EXPECT_EQ((ps2 == ps1), false);
 }
 
-TEST(PangenomeSampleTest, nequals) {
+TEST(PangenomeSampleTest, nequals)
+{
     Sample ps1("1", 0);
     Sample ps2("2", 0);
     EXPECT_EQ((ps1 != ps1), false);
@@ -55,7 +58,8 @@ TEST(PangenomeSampleTest, nequals) {
     EXPECT_EQ((ps2 != ps1), true);
 }
 
-TEST(PangenomeSampleTest, less) {
+TEST(PangenomeSampleTest, less)
+{
     Sample ps1("1", 0);
     Sample ps2("2", 0);
     EXPECT_EQ((ps1 < ps1), false);

--- a/test/path_test.cpp
+++ b/test/path_test.cpp
@@ -1,18 +1,18 @@
-#include "gtest/gtest.h"
-#include "test_macro.cpp"
 #include "interval.h"
 #include "prg/path.h"
-#include <stdint.h>
+#include "test_macro.cpp"
+#include "gtest/gtest.h"
 #include <iostream>
-
+#include <stdint.h>
 
 typedef prg::Path Path;
 using namespace std;
 using namespace prg;
 
-TEST(PathTest, initialize) {
+TEST(PathTest, initialize)
+{
     Path p;
-    vector<Interval> d = {Interval(0, 1), Interval(3, 3), Interval(5, 10)};
+    vector<Interval> d = { Interval(0, 1), Interval(3, 3), Interval(5, 10) };
     p.initialize(d);
     EXPECT_EQ(p.size(), d.size());
     for (uint i = 0; i != d.size(); ++i) {
@@ -20,26 +20,28 @@ TEST(PathTest, initialize) {
     }
 }
 
-TEST(PathTest, length) {
+TEST(PathTest, length)
+{
     Path p;
-    vector<Interval> d = {Interval(0, 0)};
+    vector<Interval> d = { Interval(0, 0) };
     p.initialize(d);
     uint j = 0;
     EXPECT_EQ(j, p.length());
 
-    d = {Interval(0, 1), Interval(3, 3), Interval(5, 10)};
+    d = { Interval(0, 1), Interval(3, 3), Interval(5, 10) };
     p.initialize(d);
     j = 6;
     EXPECT_EQ(j, p.length());
 
-    d = {Interval(0, 1), Interval(3, 3)};
+    d = { Interval(0, 1), Interval(3, 3) };
     p.initialize(d);
     j = 1;
     EXPECT_EQ(j, p.length());
 }
 
-TEST(PathTest, add_end_interval) {
-    vector<Interval> d = {Interval(4, 5)};
+TEST(PathTest, add_end_interval)
+{
+    vector<Interval> d = { Interval(4, 5) };
     Path p;
     p.initialize(d);
     p.add_end_interval(Interval(6, 9));
@@ -48,55 +50,59 @@ TEST(PathTest, add_end_interval) {
     EXPECT_DEATH(p.add_end_interval(Interval(0, 1)), "");
 }
 
-TEST(PathTest, subpath) {
+TEST(PathTest, subpath)
+{
     vector<Interval> d, d1;
-    d = {Interval(1, 3), Interval(4, 5), Interval(6, 6), Interval(9, 40)};
+    d = { Interval(1, 3), Interval(4, 5), Interval(6, 6), Interval(9, 40) };
     Path p, p1;
     p.initialize(d);
 
     // regular
     p1 = p.subpath(0, 3);
-    d1 = {Interval(1, 3), Interval(4, 5)};
+    d1 = { Interval(1, 3), Interval(4, 5) };
     EXPECT_ITERABLE_EQ(vector<Interval>, d1, p1.getPath());
 
     // handle zero-length interval
     p1 = p.subpath(1, 3);
-    d1 = {Interval(2, 3), Interval(4, 5), Interval(6, 6), Interval(9, 10)};
+    d1 = { Interval(2, 3), Interval(4, 5), Interval(6, 6), Interval(9, 10) };
     EXPECT_ITERABLE_EQ(vector<Interval>, d1, p1.getPath());
 
     // start in another interval
     p1 = p.subpath(2, 3);
-    d1 = {Interval(4, 5), Interval(6, 6), Interval(9, 11)};
+    d1 = { Interval(4, 5), Interval(6, 6), Interval(9, 11) };
     EXPECT_ITERABLE_EQ(vector<Interval>, d1, p1.getPath());
 
     // all in one interval
     p1 = p.subpath(3, 3);
-    d1 = {Interval(6, 6), Interval(9, 12)};
+    d1 = { Interval(6, 6), Interval(9, 12) };
     EXPECT_ITERABLE_EQ(vector<Interval>, d1, p1.getPath());
 
     // all in one interval
     p1 = p.subpath(4, 3);
-    d1 = {Interval(10, 13)};
+    d1 = { Interval(10, 13) };
     EXPECT_ITERABLE_EQ(vector<Interval>, d1, p1.getPath());
 
     // and several null nodes at start of path
-    d = {Interval(0, 0), Interval(1, 1), Interval(3, 3), Interval(4, 5), Interval(6, 6), Interval(9, 40)};
+    d = { Interval(0, 0), Interval(1, 1), Interval(3, 3), Interval(4, 5),
+        Interval(6, 6), Interval(9, 40) };
     p.initialize(d);
-    d1 = {Interval(0, 0), Interval(1, 1), Interval(3, 3), Interval(4, 5), Interval(6, 6), Interval(9, 10)};
+    d1 = { Interval(0, 0), Interval(1, 1), Interval(3, 3), Interval(4, 5),
+        Interval(6, 6), Interval(9, 10) };
     p1 = p.subpath(0, 2);
     EXPECT_ITERABLE_EQ(vector<Interval>, d1, p1.getPath());
 
     // can't get subpath from a coordinate not in path
-    //EXPECT_DEATH(p.subpath(0,3), "");
+    // EXPECT_DEATH(p.subpath(0,3), "");
     // can't get subpath of right length if not enough length left in path from start
-    //EXPECT_DEATH(p.subpath(39,3), "");
+    // EXPECT_DEATH(p.subpath(39,3), "");
 }
 
-TEST(PathTest, is_branching) {
+TEST(PathTest, is_branching)
+{
     vector<Interval> d, d1;
-    d = {Interval(1, 3), Interval(4, 5), Interval(6, 6), Interval(9, 40)};
-    d1 = {Interval(1, 3), Interval(4, 5), Interval(8, 9),
-          Interval(9, 40)}; // same number intervals, different intervals
+    d = { Interval(1, 3), Interval(4, 5), Interval(6, 6), Interval(9, 40) };
+    d1 = { Interval(1, 3), Interval(4, 5), Interval(8, 9),
+        Interval(9, 40) }; // same number intervals, different intervals
     Path p, p1;
     p.initialize(d);
     p1.initialize(d1);
@@ -105,24 +111,26 @@ TEST(PathTest, is_branching) {
     EXPECT_EQ(p.is_branching(p1), true);
     EXPECT_EQ(p1.is_branching(p), true);
 
-    d1 = {Interval(4, 5), Interval(6, 6), Interval(9, 47)};
+    d1 = { Interval(4, 5), Interval(6, 6), Interval(9, 47) };
     p1.initialize(d1);
     EXPECT_EQ(p1.is_branching(p1), false);
     EXPECT_EQ(p1.is_branching(p), false);
     EXPECT_EQ(p.is_branching(p1), false);
 
-    d1 = {Interval(0, 0), Interval(4, 5), Interval(6, 6), Interval(9, 40)};
+    d1 = { Interval(0, 0), Interval(4, 5), Interval(6, 6), Interval(9, 40) };
     p1.initialize(d1);
     EXPECT_EQ(p.is_branching(p1), true);
     EXPECT_EQ(p1.is_branching(p), true);
 
-    d1 = {Interval(1, 3), Interval(4, 5), Interval(6, 6), Interval(41, 50)};
+    d1 = { Interval(1, 3), Interval(4, 5), Interval(6, 6), Interval(41, 50) };
     p1.initialize(d1);
     EXPECT_EQ(p.is_branching(p1), true);
     EXPECT_EQ(p1.is_branching(p), true);
 
-    d = {Interval(16810, 16812), Interval(16897, 16904), Interval(16909, 16909), Interval(16914, 16920)};
-    d1 = {Interval(16819, 16822), Interval(16897, 16904), Interval(16909, 16909), Interval(16914, 16920)};
+    d = { Interval(16810, 16812), Interval(16897, 16904), Interval(16909, 16909),
+        Interval(16914, 16920) };
+    d1 = { Interval(16819, 16822), Interval(16897, 16904), Interval(16909, 16909),
+        Interval(16914, 16920) };
     p.initialize(d);
     p1.initialize(d1);
     EXPECT_EQ(p.is_branching(p), false);
@@ -130,8 +138,8 @@ TEST(PathTest, is_branching) {
     EXPECT_EQ(p.is_branching(p1), true);
     EXPECT_EQ(p1.is_branching(p), true);
 
-    d = {Interval(37, 52)};
-    d1 = {Interval(41, 54), Interval(61, 63)};
+    d = { Interval(37, 52) };
+    d1 = { Interval(41, 54), Interval(61, 63) };
     p.initialize(d);
     p1.initialize(d1);
     EXPECT_EQ(p.is_branching(p), false);
@@ -140,10 +148,11 @@ TEST(PathTest, is_branching) {
     EXPECT_EQ(p1.is_branching(p), false);
 }
 
-TEST(PathTest, is_subpath) {
+TEST(PathTest, is_subpath)
+{
     vector<Interval> d, d1;
-    d = {Interval(1, 3), Interval(4, 5), Interval(6, 6), Interval(9, 40)};
-    d1 = {Interval(1, 3), Interval(4, 5), Interval(6, 6), Interval(9, 10)};
+    d = { Interval(1, 3), Interval(4, 5), Interval(6, 6), Interval(9, 40) };
+    d1 = { Interval(1, 3), Interval(4, 5), Interval(6, 6), Interval(9, 10) };
     Path p, p1;
     p.initialize(d);
     p1.initialize(d1);
@@ -151,32 +160,32 @@ TEST(PathTest, is_subpath) {
     EXPECT_EQ(p1.is_subpath(p), true);
     EXPECT_EQ(p.is_subpath(p1), false);
 
-    d1 = {Interval(2, 3), Interval(4, 5), Interval(6, 6), Interval(9, 40)};
+    d1 = { Interval(2, 3), Interval(4, 5), Interval(6, 6), Interval(9, 40) };
     p1.initialize(d1);
     EXPECT_EQ(p1.is_subpath(p), true);
     EXPECT_EQ(p.is_subpath(p1), false);
 
-    d1 = {Interval(1, 3), Interval(4, 5), Interval(8, 9), Interval(9, 40)};
+    d1 = { Interval(1, 3), Interval(4, 5), Interval(8, 9), Interval(9, 40) };
     p1.initialize(d1);
     EXPECT_EQ(p1.is_subpath(p), false);
     EXPECT_EQ(p.is_subpath(p1), false);
 
-    d1 = {Interval(4, 5), Interval(6, 6), Interval(9, 20)};
+    d1 = { Interval(4, 5), Interval(6, 6), Interval(9, 20) };
     p1.initialize(d1);
     EXPECT_EQ(p1.is_subpath(p), true);
     EXPECT_EQ(p.is_subpath(p1), false);
 
-    d1 = {Interval(1, 3), Interval(4, 5), Interval(6, 6), Interval(9, 41)};
+    d1 = { Interval(1, 3), Interval(4, 5), Interval(6, 6), Interval(9, 41) };
     p1.initialize(d1);
     EXPECT_EQ(p1.is_subpath(p), false);
-
 }
 
-TEST(PathTest, less_than) {
+TEST(PathTest, less_than)
+{
     vector<Interval> d, d1;
-    d = {Interval(1, 3), Interval(4, 5), Interval(6, 6), Interval(9, 40)};
-    d1 = {Interval(1, 3), Interval(4, 5), Interval(8, 9),
-          Interval(9, 40)}; // same number intervals, different intervals
+    d = { Interval(1, 3), Interval(4, 5), Interval(6, 6), Interval(9, 40) };
+    d1 = { Interval(1, 3), Interval(4, 5), Interval(8, 9),
+        Interval(9, 40) }; // same number intervals, different intervals
     Path p, p1;
     p.initialize(d);
     p1.initialize(d1);
@@ -184,37 +193,43 @@ TEST(PathTest, less_than) {
     EXPECT_EQ((p < p1), true);
     EXPECT_EQ((p1 < p), false);
 
-    d1 = {Interval(1, 3), Interval(4, 5), Interval(6, 6), Interval(9, 40)}; // identical
+    d1 = { Interval(1, 3), Interval(4, 5), Interval(6, 6),
+        Interval(9, 40) }; // identical
     p1.initialize(d1);
     EXPECT_EQ((p < p1), false);
     EXPECT_EQ((p1 < p), false);
 
-    d1 = {Interval(1, 3), Interval(4, 5), Interval(9, 40)}; // different number of intervals missing middle one
+    d1 = { Interval(1, 3), Interval(4, 5),
+        Interval(9, 40) }; // different number of intervals missing middle one
     p1.initialize(d1);
     EXPECT_EQ((p < p1), true);
     EXPECT_EQ((p1 < p), false);
 
-    d1 = {Interval(4, 5), Interval(6, 6), Interval(9, 40)}; // different number of intervals missing first
+    d1 = { Interval(4, 5), Interval(6, 6),
+        Interval(9, 40) }; // different number of intervals missing first
     p1.initialize(d1);
     EXPECT_EQ((p < p1), true);
     EXPECT_EQ((p1 < p), false);
 
-    d1 = {Interval(1, 3), Interval(4, 6), Interval(6, 6), Interval(9, 40)}; // different end to one interval
+    d1 = { Interval(1, 3), Interval(4, 6), Interval(6, 6),
+        Interval(9, 40) }; // different end to one interval
     p1.initialize(d1);
     EXPECT_EQ((p < p1), true);
     EXPECT_EQ((p1 < p), false);
 
-    d1 = {Interval(1, 3), Interval(4, 5), Interval(6, 6), Interval(10, 40)}; // different start to one interval
+    d1 = { Interval(1, 3), Interval(4, 5), Interval(6, 6),
+        Interval(10, 40) }; // different start to one interval
     p1.initialize(d1);
     EXPECT_EQ((p < p1), true);
     EXPECT_EQ((p1 < p), false);
 }
 
-TEST(PathTest, equals) {
+TEST(PathTest, equals)
+{
     vector<Interval> d, d1;
-    d = {Interval(1, 3), Interval(4, 5), Interval(6, 6), Interval(9, 40)};
-    d1 = {Interval(1, 3), Interval(4, 5), Interval(8, 9),
-          Interval(9, 40)}; // same number intervals, different intervals
+    d = { Interval(1, 3), Interval(4, 5), Interval(6, 6), Interval(9, 40) };
+    d1 = { Interval(1, 3), Interval(4, 5), Interval(8, 9),
+        Interval(9, 40) }; // same number intervals, different intervals
     Path p, p1;
     p.initialize(d);
     p1.initialize(d1);
@@ -224,37 +239,43 @@ TEST(PathTest, equals) {
     EXPECT_EQ((p == p1), false);
     EXPECT_EQ((p1 == p), false);
 
-    d1 = {Interval(1, 3), Interval(4, 5), Interval(6, 6), Interval(9, 40)}; // identical
+    d1 = { Interval(1, 3), Interval(4, 5), Interval(6, 6),
+        Interval(9, 40) }; // identical
     p1.initialize(d1);
     EXPECT_EQ(p, p1);
     EXPECT_EQ(p1, p);
 
-    d1 = {Interval(1, 3), Interval(4, 5), Interval(9, 40)}; // different number of intervals missing middle one
+    d1 = { Interval(1, 3), Interval(4, 5),
+        Interval(9, 40) }; // different number of intervals missing middle one
     p1.initialize(d1);
     EXPECT_EQ((p == p1), false);
     EXPECT_EQ((p1 == p), false);
 
-    d1 = {Interval(4, 5), Interval(6, 6), Interval(9, 40)}; // different number of intervals missing first
+    d1 = { Interval(4, 5), Interval(6, 6),
+        Interval(9, 40) }; // different number of intervals missing first
     p1.initialize(d1);
     EXPECT_EQ((p == p1), false);
     EXPECT_EQ((p1 == p), false);
 
-    d1 = {Interval(1, 3), Interval(4, 6), Interval(6, 6), Interval(9, 40)}; // different end to one interval
+    d1 = { Interval(1, 3), Interval(4, 6), Interval(6, 6),
+        Interval(9, 40) }; // different end to one interval
     p1.initialize(d1);
     EXPECT_EQ((p == p1), false);
     EXPECT_EQ((p1 == p), false);
 
-    d1 = {Interval(1, 3), Interval(4, 5), Interval(6, 6), Interval(10, 40)}; // different start to one interval
+    d1 = { Interval(1, 3), Interval(4, 5), Interval(6, 6),
+        Interval(10, 40) }; // different start to one interval
     p1.initialize(d1);
     EXPECT_EQ((p == p1), false);
     EXPECT_EQ((p1 == p), false);
 }
 
-//TEST(PathTest, equal_except_null_nodes) {
+// TEST(PathTest, equal_except_null_nodes) {
 //    vector<Interval> d, d1, d2;
 //    d = {Interval(1, 3), Interval(4, 5), Interval(6, 6), Interval(9, 40)};
-//    d1 = {Interval(1, 3), Interval(4, 5), Interval(6, 6), Interval(9, 40), Interval(40, 40), Interval(59, 59)};
-//    d2 = {Interval(0, 0), Interval(1, 1), Interval(1, 3), Interval(4, 5), Interval(6, 6), Interval(9, 40)};
+//    d1 = {Interval(1, 3), Interval(4, 5), Interval(6, 6), Interval(9, 40),
+//    Interval(40, 40), Interval(59, 59)}; d2 = {Interval(0, 0), Interval(1, 1),
+//    Interval(1, 3), Interval(4, 5), Interval(6, 6), Interval(9, 40)};
 //
 //    Path p, p1, p2;
 //    p.initialize(d);
@@ -269,9 +290,10 @@ TEST(PathTest, equals) {
 //    EXPECT_EQ(equal_except_null_nodes(p2, p2), true);
 //}
 
-TEST(PathTest, write) {
+TEST(PathTest, write)
+{
     vector<Interval> d;
-    d = {Interval(1, 3), Interval(4, 5), Interval(6, 6), Interval(9, 40)};
+    d = { Interval(1, 3), Interval(4, 5), Interval(6, 6), Interval(9, 40) };
     Path p;
     p.initialize(d);
 
@@ -280,9 +302,10 @@ TEST(PathTest, write) {
     EXPECT_EQ(out.str(), "4{[1, 3)[4, 5)[6, 6)[9, 40)}");
 }
 
-TEST(PathTest, read) {
+TEST(PathTest, read)
+{
     vector<Interval> d;
-    d = {Interval(1, 3), Interval(4, 5), Interval(6, 6), Interval(9, 40)};
+    d = { Interval(1, 3), Interval(4, 5), Interval(6, 6), Interval(9, 40) };
     Path p, q;
     p.initialize(d);
 
@@ -293,11 +316,13 @@ TEST(PathTest, read) {
     EXPECT_EQ(p, q);
 }
 
-TEST(PathTest, get_union) {
+TEST(PathTest, get_union)
+{
     vector<Interval> d1, d2, d;
-    d1 = {Interval(1, 3), Interval(4, 5), Interval(6, 6), Interval(9, 40)};
-    d2 = {Interval(10, 40), Interval(50, 55)};
-    d = {Interval(1, 3), Interval(4, 5), Interval(6, 6), Interval(9, 40), Interval(50, 55)};
+    d1 = { Interval(1, 3), Interval(4, 5), Interval(6, 6), Interval(9, 40) };
+    d2 = { Interval(10, 40), Interval(50, 55) };
+    d = { Interval(1, 3), Interval(4, 5), Interval(6, 6), Interval(9, 40),
+        Interval(50, 55) };
     Path p1, p2, q;
     p1.initialize(d1);
     p2.initialize(d2);
@@ -305,25 +330,25 @@ TEST(PathTest, get_union) {
 
     EXPECT_EQ(q, get_union(p1, p2));
 
-    d2 = {Interval(10, 40)};
-    d = {Interval(1, 3), Interval(4, 5), Interval(6, 6), Interval(9, 40)};
+    d2 = { Interval(10, 40) };
+    d = { Interval(1, 3), Interval(4, 5), Interval(6, 6), Interval(9, 40) };
     p2.initialize(d2);
     q.initialize(d);
     EXPECT_EQ(q, get_union(p1, p2));
 
     // branching
-    d2 = {Interval(1, 3), Interval(4, 5), Interval(6, 6), Interval(50, 60)};
+    d2 = { Interval(1, 3), Interval(4, 5), Interval(6, 6), Interval(50, 60) };
     p2.initialize(d2);
     q.clear();
     EXPECT_EQ(q, get_union(p1, p2));
 
     // non-overlapping
-    d2 = {Interval(50, 60)};
+    d2 = { Interval(50, 60) };
     p2.initialize(d2);
     EXPECT_EQ(q, get_union(p1, p2));
 
     // wrong way round
-    d2 = {Interval(0, 0)};
+    d2 = { Interval(0, 0) };
     p2.initialize(d2);
     EXPECT_DEATH(get_union(p1, p2), "");
 }

--- a/test/seq_test.cpp
+++ b/test/seq_test.cpp
@@ -1,44 +1,51 @@
-#include "gtest/gtest.h"
-#include "seq.h"
-#include "minimizer.h"
 #include "interval.h"
-#include <stdint.h>
+#include "minimizer.h"
+#include "seq.h"
+#include "gtest/gtest.h"
 #include <iostream>
-
+#include <stdint.h>
 
 using namespace std;
 
-TEST(SeqTest, create) {
+TEST(SeqTest, create)
+{
     Seq s1(0, "0", "AGCTAATGCGTT", 11, 3);
-    EXPECT_EQ((uint) 0, s1.id);
+    EXPECT_EQ((uint)0, s1.id);
     EXPECT_EQ("0", s1.name);
     EXPECT_EQ("AGCTAATGCGTT", s1.seq);
 }
 
-TEST(SeqTest, initialize) {
+TEST(SeqTest, initialize)
+{
     Seq s1(0, "0", "AGCTAATGCGTT", 11, 3);
     s1.initialize(1, "new", "AGCTAATGCATA", 9, 3);
-    EXPECT_EQ((uint) 1, s1.id);
+    EXPECT_EQ((uint)1, s1.id);
     EXPECT_EQ("new", s1.name);
     EXPECT_EQ("AGCTAATGCATA", s1.seq);
 }
 
-TEST(SeqTest, sketchShortReads) {
+TEST(SeqTest, sketchShortReads)
+{
     Seq s1(0, "0", "AGCTAATGCGTT", 11, 3);
     Seq s2(0, "0", "AGCTAATGCGTT", 10, 3);
     Seq s3(0, "0", "AGCTAATGCGTT", 9, 3);
     Seq s4(0, "0", "AGCTAATGCATA", 9, 3);
     uint32_t j = 0;
-    EXPECT_EQ(s1.sketch.size(), j) << "Have " << s1.sketch.size() << " minimizer when string is too short";
+    EXPECT_EQ(s1.sketch.size(), j)
+        << "Have " << s1.sketch.size() << " minimizer when string is too short";
     ++j;
-    EXPECT_EQ(s2.sketch.size(), j) << "Have " << s2.sketch.size() << " minimizers when should have 1";
+    EXPECT_EQ(s2.sketch.size(), j)
+        << "Have " << s2.sketch.size() << " minimizers when should have 1";
     ++j;
-    EXPECT_EQ(s3.sketch.size(), j) << "Have " << s3.sketch.size() << " minimizers when should have 2";
+    EXPECT_EQ(s3.sketch.size(), j)
+        << "Have " << s3.sketch.size() << " minimizers when should have 2";
     j = 1;
-    EXPECT_EQ(s4.sketch.size(), j) << "Have " << s4.sketch.size() << " minimizers when should have 1";
+    EXPECT_EQ(s4.sketch.size(), j)
+        << "Have " << s4.sketch.size() << " minimizers when should have 1";
 }
 
-TEST(SeqTest, sketchIncludesEveryLetter) {
+TEST(SeqTest, sketchIncludesEveryLetter)
+{
     Seq s1(0, "0", "AGCTAATGTGTT", 3, 3);
     Seq s2(0, "0", "AGCTAATGTGTT", 2, 3);
     Seq s3(0, "0", "AGCTAATGTGTT", 1, 3);
@@ -46,40 +53,44 @@ TEST(SeqTest, sketchIncludesEveryLetter) {
 
     set<int> pos_inc;
     for (auto it = s4.sketch.begin(); it != s4.sketch.end(); ++it) {
-        for (uint32_t j = (*it).pos_of_kmer_in_read.start; j < (*it).pos_of_kmer_in_read.get_end(); ++j) {
+        for (uint32_t j = (*it).pos_of_kmer_in_read.start;
+             j < (*it).pos_of_kmer_in_read.get_end(); ++j) {
             pos_inc.insert(j);
         }
-
     }
-    for (uint32_t i = 3 - 1; i != 12 - 3 + 1; ++i) // first or last w-1 may not be included
+    for (uint32_t i = 3 - 1; i != 12 - 3 + 1;
+         ++i) // first or last w-1 may not be included
     {
         EXPECT_EQ((pos_inc.find(i) != pos_inc.end()), true);
     }
 
     uint32_t j = 10;
-    EXPECT_EQ(s3.sketch.size(), j) << "sketch with w=1 has incorrect size " << s3.sketch.size();
+    EXPECT_EQ(s3.sketch.size(), j)
+        << "sketch with w=1 has incorrect size " << s3.sketch.size();
 
     pos_inc.clear();
     for (auto it = s2.sketch.begin(); it != s2.sketch.end(); ++it) {
-        for (uint32_t j = (*it).pos_of_kmer_in_read.start; j < (*it).pos_of_kmer_in_read.get_end(); ++j) {
+        for (uint32_t j = (*it).pos_of_kmer_in_read.start;
+             j < (*it).pos_of_kmer_in_read.get_end(); ++j) {
             pos_inc.insert(j);
         }
     }
-    for (uint32_t i = 2 - 1; i != 12 - 2 + 1; ++i) // first or last w-1 may not be included
+    for (uint32_t i = 2 - 1; i != 12 - 2 + 1;
+         ++i) // first or last w-1 may not be included
     {
         EXPECT_EQ((pos_inc.find(i) != pos_inc.end()), true);
     }
 
     pos_inc.clear();
     for (auto it = s1.sketch.begin(); it != s1.sketch.end(); ++it) {
-        for (uint32_t j = (*it).pos_of_kmer_in_read.start; j < (*it).pos_of_kmer_in_read.get_end(); ++j) {
+        for (uint32_t j = (*it).pos_of_kmer_in_read.start;
+             j < (*it).pos_of_kmer_in_read.get_end(); ++j) {
             pos_inc.insert(j);
         }
     }
-    for (uint32_t i = 3 - 1; i != 12 - 3 + 1; ++i) // first or last w-1 may not be included
+    for (uint32_t i = 3 - 1; i != 12 - 3 + 1;
+         ++i) // first or last w-1 may not be included
     {
         EXPECT_EQ((pos_inc.find(i) != pos_inc.end()), true);
     }
-
 }
-

--- a/test/test_helpers.h
+++ b/test/test_helpers.h
@@ -8,17 +8,20 @@
 #include <algorithm>
 
 template <typename T,
-          template <typename ELEM_TYPE, typename = std::allocator<ELEM_TYPE> > class CONT_TYPE>
-bool equal_containers(const CONT_TYPE<T> &lhs, const CONT_TYPE<T> &rhs) {
-    return lhs.size()==rhs.size() && std::equal(lhs.begin(), lhs.end(), rhs.begin());
+    template <typename ELEM_TYPE, typename = std::allocator<ELEM_TYPE>> class CONT_TYPE>
+bool equal_containers(const CONT_TYPE<T>& lhs, const CONT_TYPE<T>& rhs)
+{
+    return lhs.size() == rhs.size() && std::equal(lhs.begin(), lhs.end(), rhs.begin());
 }
 
 template <typename T,
-          template <typename ELEM_TYPE, typename = std::allocator<ELEM_TYPE> > class CONT_TYPE,
-          class BinaryPredicate>
-bool equal_containers(const CONT_TYPE<T> &lhs, const CONT_TYPE<T> &rhs, const BinaryPredicate &pred) {
-    return lhs.size()==rhs.size() && std::equal(lhs.begin(), lhs.end(), rhs.begin(), pred);
+    template <typename ELEM_TYPE, typename = std::allocator<ELEM_TYPE>> class CONT_TYPE,
+    class BinaryPredicate>
+bool equal_containers(
+    const CONT_TYPE<T>& lhs, const CONT_TYPE<T>& rhs, const BinaryPredicate& pred)
+{
+    return lhs.size() == rhs.size()
+        && std::equal(lhs.begin(), lhs.end(), rhs.begin(), pred);
 }
 
-
-#endif //PANDORA_TEST_HELPERS_H
+#endif // PANDORA_TEST_HELPERS_H

--- a/test/test_macro.cpp
+++ b/test/test_macro.cpp
@@ -1,35 +1,38 @@
 #include "gtest/gtest.h"
 
 //! Using the google test framework, check all elements of two containers
-#define EXPECT_ITERABLE_BASE(PREDICATE, REFTYPE, TARTYPE, ref, target) \
-    { \
-    const REFTYPE& ref_(ref); \
-    const TARTYPE& target_(target); \
-    REFTYPE::const_iterator refIter = ref_.begin(); \
-    TARTYPE::const_iterator tarIter = target_.begin(); \
-    unsigned int i = 0; \
-    while(refIter != ref_.end()) { \
-        if ( tarIter == target_.end() ) { \
-            ADD_FAILURE() << #target " has a smaller length than " #ref ; \
-            break; \
-        } \
-        PREDICATE(* refIter, * tarIter) \
-            << "Containers " #ref  " (refIter) and " #target " (tarIter)" \
-               " differ at index " << i; \
-        ++refIter; ++tarIter; ++i; \
-    } \
-    EXPECT_TRUE( tarIter == target_.end() ) \
-        << #ref " has a smaller length than " #target ; \
+#define EXPECT_ITERABLE_BASE(PREDICATE, REFTYPE, TARTYPE, ref, target)                 \
+    {                                                                                  \
+        const REFTYPE& ref_(ref);                                                      \
+        const TARTYPE& target_(target);                                                \
+        REFTYPE::const_iterator refIter = ref_.begin();                                \
+        TARTYPE::const_iterator tarIter = target_.begin();                             \
+        unsigned int i = 0;                                                            \
+        while (refIter != ref_.end()) {                                                \
+            if (tarIter == target_.end()) {                                            \
+                ADD_FAILURE() << #target " has a smaller length than " #ref;           \
+                break;                                                                 \
+            }                                                                          \
+            PREDICATE(*refIter, *tarIter)                                              \
+                << "Containers " #ref " (refIter) and " #target " (tarIter)"           \
+                   " differ at index "                                                 \
+                << i;                                                                  \
+            ++refIter;                                                                 \
+            ++tarIter;                                                                 \
+            ++i;                                                                       \
+        }                                                                              \
+        EXPECT_TRUE(tarIter == target_.end())                                          \
+            << #ref " has a smaller length than " #target;                             \
     }
 
 //! Check that all elements of two same-type containers are equal
-#define EXPECT_ITERABLE_EQ(TYPE, ref, target) \
-    EXPECT_ITERABLE_BASE( EXPECT_EQ, TYPE, TYPE, ref, target )
+#define EXPECT_ITERABLE_EQ(TYPE, ref, target)                                          \
+    EXPECT_ITERABLE_BASE(EXPECT_EQ, TYPE, TYPE, ref, target)
 
 //! Check that all elements of two different-type containers are equal
-#define EXPECT_ITERABLE_EQ2(REFTYPE, TARTYPE, ref, target) \
-    EXPECT_ITERABLE_BASE( EXPECT_EQ, REFTYPE, TARTYPE, ref, target )
+#define EXPECT_ITERABLE_EQ2(REFTYPE, TARTYPE, ref, target)                             \
+    EXPECT_ITERABLE_BASE(EXPECT_EQ, REFTYPE, TARTYPE, ref, target)
 
 //! Check that all elements of two same-type containers of doubles are equal
-#define EXPECT_ITERABLE_DOUBLE_EQ(TYPE, ref, target) \
-    EXPECT_ITERABLE_BASE( EXPECT_DOUBLE_EQ, TYPE, TYPE, ref, target )
+#define EXPECT_ITERABLE_DOUBLE_EQ(TYPE, ref, target)                                   \
+    EXPECT_ITERABLE_BASE(EXPECT_DOUBLE_EQ, TYPE, TYPE, ref, target)

--- a/test/utils_test.cpp
+++ b/test/utils_test.cpp
@@ -1,31 +1,32 @@
-#include "gtest/gtest.h"
-#include "test_macro.cpp"
-#include "utils.h"
-#include "localPRG.h"
-#include "pangenome/pangraph.h"
+#include "index.h"
 #include "interval.h"
-#include "prg/path.h"
+#include "inthash.h"
+#include "localPRG.h"
 #include "minihit.h"
 #include "minihits.h"
-#include "index.h"
-#include "inthash.h"
+#include "pangenome/pangraph.h"
+#include "prg/path.h"
 #include "seq.h"
-#include <stdint.h>
-#include <iostream>
+#include "test_macro.cpp"
+#include "utils.h"
+#include "gtest/gtest.h"
 #include <algorithm>
+#include <iostream>
+#include <stdint.h>
 #include <vector>
-
 
 using namespace std;
 
-TEST(UtilsTest, split) {
-    vector<string> v = {"abc", "def", "ghi"};
+TEST(UtilsTest, split)
+{
+    vector<string> v = { "abc", "def", "ghi" };
     EXPECT_EQ(v, split("abc, def, ghi", ", "));
     EXPECT_EQ(v, split("abc, def, ghi, ", ", "));
     EXPECT_EQ(v, split(", abc, def, ghi", ", "));
 }
 
-TEST(UtilsTest, revComplement) {
+TEST(UtilsTest, revComplement)
+{
     string s = "ACCTGATTGCGTA";
     EXPECT_EQ(s, rev_complement(rev_complement(s)));
 
@@ -42,11 +43,12 @@ TEST(UtilsTest, revComplement) {
 
 // don't bother with nchoosek test as will remove function
 
-TEST(UtilsTest, readPrgFile) {
+TEST(UtilsTest, readPrgFile)
+{
     std::vector<std::shared_ptr<LocalPRG>> prgs;
 
     // simple case first, single prg with empty string sequence
-    // doesn't get added to prgs 
+    // doesn't get added to prgs
     read_prg_file(prgs, "../../test/test_cases/prg0.fa");
     uint32_t j = 0;
     EXPECT_EQ(prgs.size(), j);
@@ -92,7 +94,8 @@ TEST(UtilsTest, readPrgFile) {
     EXPECT_EQ(prgs.size(), j);
 }
 
-TEST(UtilsTest, readPrgFile_with_offset) {
+TEST(UtilsTest, readPrgFile_with_offset)
+{
     std::vector<std::shared_ptr<LocalPRG>> prgs;
 
     // simple case first, single prg with empty string sequence
@@ -137,7 +140,8 @@ TEST(UtilsTest, readPrgFile_with_offset) {
     EXPECT_EQ(prgs[2]->id, (uint)8);
 }
 
-TEST(UtilsTest, addReadHits) {
+TEST(UtilsTest, addReadHits)
+{
     // initialize minihits container
     auto minimizer_hits = std::make_shared<MinimizerHits>(MinimizerHits());
     MinimizerHits expected1;
@@ -148,7 +152,7 @@ TEST(UtilsTest, addReadHits) {
     // initialize index as we would expect with example prgs 1 and 3 from above
     KmerHash hash;
     auto index = std::make_shared<Index>();
-    deque<Interval> d = {Interval(0, 3)};
+    deque<Interval> d = { Interval(0, 3) };
     prg::Path p;
     p.initialize(d);
     pair<uint64_t, uint64_t> kh = hash.kmerhash("AGC", 3);
@@ -162,7 +166,7 @@ TEST(UtilsTest, addReadHits) {
     MinimizerHitPtr m2(make_shared<MinimizerHit>(0, min2, mr2));
     expected1.hits.insert(m1);
     expected2.hits.insert(m2);
-    d = {Interval(1, 4)};
+    d = { Interval(1, 4) };
     p.initialize(d);
     kh = hash.kmerhash("GCT", 3);
     index->add_record(min(kh.first, kh.second), 1, p, 0, (kh.first < kh.second));
@@ -177,7 +181,7 @@ TEST(UtilsTest, addReadHits) {
 
     expected2.hits.insert(m3);
     expected1.hits.insert(m4);
-    d = {Interval(0, 1), Interval(4, 5), Interval(8, 9)};
+    d = { Interval(0, 1), Interval(4, 5), Interval(8, 9) };
     p.initialize(d);
     kh = hash.kmerhash("AGC", 3);
     index->add_record(min(kh.first, kh.second), 3, p, 0, (kh.first < kh.second));
@@ -190,7 +194,7 @@ TEST(UtilsTest, addReadHits) {
     MinimizerHitPtr m6(make_shared<MinimizerHit>(0, min6, mr6));
     expected1.hits.insert(m5);
     expected2.hits.insert(m6);
-    d = {Interval(0, 1), Interval(4, 5), Interval(12, 13)};
+    d = { Interval(0, 1), Interval(4, 5), Interval(12, 13) };
     p.initialize(d);
     kh = hash.kmerhash("AGT", 3);
     index->add_record(min(kh.first, kh.second), 3, p, 0, (kh.first < kh.second));
@@ -199,7 +203,7 @@ TEST(UtilsTest, addReadHits) {
     MiniRecord mr9(3, p, 0, 1);
     MinimizerHitPtr m9(make_shared<MinimizerHit>(0, min9, mr9));
     expected3.hits.insert(m9);
-    d = {Interval(0, 1), Interval(19, 20), Interval(23, 24)};
+    d = { Interval(0, 1), Interval(19, 20), Interval(23, 24) };
     p.initialize(d);
     index->add_record(min(kh.first, kh.second), 3, p, 0, (kh.first < kh.second));
 
@@ -207,7 +211,7 @@ TEST(UtilsTest, addReadHits) {
     MiniRecord mr10(3, p, 0, 1);
     MinimizerHitPtr m10(make_shared<MinimizerHit>(0, min10, mr10));
     expected3.hits.insert(m10);
-    d = {Interval(4, 5), Interval(8, 9), Interval(16, 16), Interval(23, 24)};
+    d = { Interval(4, 5), Interval(8, 9), Interval(16, 16), Interval(23, 24) };
     p.initialize(d);
     kh = hash.kmerhash("GCT", 3);
     index->add_record(min(kh.first, kh.second), 3, p, 0, (kh.first < kh.second));
@@ -221,7 +225,7 @@ TEST(UtilsTest, addReadHits) {
     MinimizerHitPtr m8(make_shared<MinimizerHit>(0, min8, mr8));
     expected2.hits.insert(m7);
     expected1.hits.insert(m8);
-    d = {Interval(4, 5), Interval(12, 13), Interval(16, 16), Interval(23, 24)};
+    d = { Interval(4, 5), Interval(12, 13), Interval(16, 16), Interval(23, 24) };
     p.initialize(d);
     kh = hash.kmerhash("GTT", 3);
     index->add_record(min(kh.first, kh.second), 3, p, 0, (kh.first < kh.second));
@@ -235,12 +239,14 @@ TEST(UtilsTest, addReadHits) {
     add_read_hits(s, minimizer_hits, *index);
     EXPECT_EQ(expected1.hits.size(), minimizer_hits->hits.size());
     set<MinimizerHitPtr, pComp>::const_iterator it2 = expected1.hits.begin();
-    for (set<MinimizerHitPtr, pComp>::const_iterator it = minimizer_hits->hits.begin(); it != minimizer_hits->hits.end(); ++it) {
+    for (set<MinimizerHitPtr, pComp>::const_iterator it = minimizer_hits->hits.begin();
+         it != minimizer_hits->hits.end(); ++it) {
         EXPECT_EQ(**it2, **it);
         it2++;
     }
 
-    // if take w=2 as sketch of read AGTT should miss AGT, which occurs twice in PRG and contain GTT
+    // if take w=2 as sketch of read AGTT should miss AGT, which occurs twice in PRG and
+    // contain GTT
 
     minimizer_hits = std::make_shared<MinimizerHits>(MinimizerHits());
     uint32_t j = 0;
@@ -249,7 +255,8 @@ TEST(UtilsTest, addReadHits) {
     add_read_hits(s, minimizer_hits, *index);
     EXPECT_EQ(expected4.hits.size(), minimizer_hits->hits.size());
     it2 = expected4.hits.begin();
-    for (set<MinimizerHitPtr, pComp>::const_iterator it = minimizer_hits->hits.begin(); it != minimizer_hits->hits.end(); ++it) {
+    for (set<MinimizerHitPtr, pComp>::const_iterator it = minimizer_hits->hits.begin();
+         it != minimizer_hits->hits.end(); ++it) {
         EXPECT_EQ(**it2, **it);
         it2++;
     }
@@ -263,12 +270,14 @@ TEST(UtilsTest, addReadHits) {
     add_read_hits(s, minimizer_hits, *index);
     EXPECT_EQ(expected3.hits.size(), minimizer_hits->hits.size());
     it2 = expected3.hits.begin();
-    for (set<MinimizerHitPtr, pComp>::const_iterator it = minimizer_hits->hits.begin(); it != minimizer_hits->hits.end(); ++it) {
+    for (set<MinimizerHitPtr, pComp>::const_iterator it = minimizer_hits->hits.begin();
+         it != minimizer_hits->hits.end(); ++it) {
         EXPECT_EQ(**it2, **it);
         it2++;
     }
 
-    // now back to w = 1, add expected2 to expected1 as will get hits against both AGC and GCT
+    // now back to w = 1, add expected2 to expected1 as will get hits against both AGC
+    // and GCT
     minimizer_hits = std::make_shared<MinimizerHits>(MinimizerHits());
     j = 0;
     EXPECT_EQ(j, minimizer_hits->hits.size());
@@ -277,12 +286,14 @@ TEST(UtilsTest, addReadHits) {
     expected1.hits.insert(expected2.hits.begin(), expected2.hits.end());
     EXPECT_EQ(expected1.hits.size(), minimizer_hits->hits.size());
     it2 = expected1.hits.begin();
-    for (auto it = minimizer_hits->hits.begin(); it != minimizer_hits->hits.end(); ++it) {
+    for (auto it = minimizer_hits->hits.begin(); it != minimizer_hits->hits.end();
+         ++it) {
         EXPECT_EQ(**it2, **it);
         it2++;
     }
 
-    // same for w = 2, add expected2 to expected1 as will get hits against both because AGC and GCT are joint minimums
+    // same for w = 2, add expected2 to expected1 as will get hits against both because
+    // AGC and GCT are joint minimums
     minimizer_hits = std::make_shared<MinimizerHits>(MinimizerHits());
     j = 0;
     EXPECT_EQ(j, minimizer_hits->hits.size());
@@ -290,7 +301,8 @@ TEST(UtilsTest, addReadHits) {
     add_read_hits(s, minimizer_hits, *index);
     EXPECT_EQ(expected1.hits.size(), minimizer_hits->hits.size());
     it2 = expected1.hits.begin();
-    for (auto it = minimizer_hits->hits.begin(); it != minimizer_hits->hits.end(); ++it) {
+    for (auto it = minimizer_hits->hits.begin(); it != minimizer_hits->hits.end();
+         ++it) {
         EXPECT_EQ(**it2, **it);
         it2++;
     }
@@ -302,8 +314,9 @@ TEST(UtilsTest, addReadHits) {
     index->clear();
 }
 
-TEST(UtilsTest, filter_clusters2) {
-    deque<Interval> d = {Interval(0, 10)};
+TEST(UtilsTest, filter_clusters2)
+{
+    deque<Interval> d = { Interval(0, 10) };
     prg::Path p;
     p.initialize(d);
 
@@ -312,7 +325,7 @@ TEST(UtilsTest, filter_clusters2) {
 
     MinimizerHitPtr mh;
     for (uint i = 0; i != 6; ++i) {
-        Minimizer min1(0, i, i+10, 0); // kmer, start, end, strand
+        Minimizer min1(0, i, i + 10, 0); // kmer, start, end, strand
         MiniRecord mr1(0, p, 0, 0);
         mh = make_shared<MinimizerHit>(1, min1, mr1);
         s.insert(mh);
@@ -321,7 +334,7 @@ TEST(UtilsTest, filter_clusters2) {
     ss_exp.insert(s);
     s.clear();
     for (uint i = 5; i != 15; ++i) {
-        Minimizer min2(0, i, i+10, 0); // kmer, start, end, strand
+        Minimizer min2(0, i, i + 10, 0); // kmer, start, end, strand
         MiniRecord mr2(1, p, 0, 0);
         mh = make_shared<MinimizerHit>(1, min2, mr2);
         s.insert(mh);
@@ -330,7 +343,7 @@ TEST(UtilsTest, filter_clusters2) {
     ss_exp.insert(s);
     s.clear();
     for (uint i = 3; i != 7; ++i) {
-        Minimizer min3(0, i, i+10, 0); // kmer, start, end, strand
+        Minimizer min3(0, i, i + 10, 0); // kmer, start, end, strand
         MiniRecord mr3(2, p, 0, 0);
         mh = make_shared<MinimizerHit>(1, min3, mr3);
         s.insert(mh);
@@ -340,10 +353,10 @@ TEST(UtilsTest, filter_clusters2) {
     filter_clusters2(ss, 20);
 
     EXPECT_EQ(ss_exp.size(), ss.size());
-
 }
 
-TEST(UtilsTest, simpleInferLocalPRGOrderForRead) {
+TEST(UtilsTest, simpleInferLocalPRGOrderForRead)
+{
     // initialize minihits container
     auto minimizer_hits = std::make_shared<MinimizerHits>(MinimizerHits());
     KmerHash hash;
@@ -355,19 +368,20 @@ TEST(UtilsTest, simpleInferLocalPRGOrderForRead) {
     prgs.push_back(lp3);
     prgs.push_back(lp1);
 
-    // initialize index as we would expect with example prgs (variant of) 1 and 3 from above
+    // initialize index as we would expect with example prgs (variant of) 1 and 3 from
+    // above
     auto index = std::make_shared<Index>();
 
     vector<KmerNodePtr> v;
     KmerNodePtr kn;
 
-    deque<Interval> d = {Interval(0, 0)};
+    deque<Interval> d = { Interval(0, 0) };
     prg::Path p;
     p.initialize(d);
     kn = lp1->kmer_prg.add_node(p);
     v.push_back(kn);
 
-    d = {Interval(0, 3)};
+    d = { Interval(0, 3) };
     p.initialize(d);
     pair<uint64_t, uint64_t> kh = hash.kmerhash("TAC", 3);
     index->add_record(min(kh.first, kh.second), 1, p, 0, (kh.first < kh.second));
@@ -375,7 +389,7 @@ TEST(UtilsTest, simpleInferLocalPRGOrderForRead) {
     v.push_back(kn);
     lp1->kmer_prg.add_edge(v[0], v[1]);
 
-    d = {Interval(1, 4)};
+    d = { Interval(1, 4) };
     p.initialize(d);
     kh = hash.kmerhash("ACG", 3);
     index->add_record(min(kh.first, kh.second), 1, p, 0, (kh.first < kh.second));
@@ -383,18 +397,18 @@ TEST(UtilsTest, simpleInferLocalPRGOrderForRead) {
     v.push_back(kn);
     lp1->kmer_prg.add_edge(v[1], v[2]);
 
-    d = {Interval(4, 4)};
+    d = { Interval(4, 4) };
     p.initialize(d);
     kn = lp1->kmer_prg.add_node(p);
     v.push_back(kn);
     lp1->kmer_prg.add_edge(v[2], v[3]);
 
-    d = {Interval(0, 0)};
+    d = { Interval(0, 0) };
     p.initialize(d);
     kn = lp3->kmer_prg.add_node(p);
     v.push_back(kn);
 
-    d = {Interval(0, 1), Interval(4, 5), Interval(8, 9)};
+    d = { Interval(0, 1), Interval(4, 5), Interval(8, 9) };
     p.initialize(d);
     kh = hash.kmerhash("AGC", 3);
     index->add_record(min(kh.first, kh.second), 0, p, 0, (kh.first < kh.second));
@@ -402,7 +416,7 @@ TEST(UtilsTest, simpleInferLocalPRGOrderForRead) {
     v.push_back(kn);
     lp3->kmer_prg.add_edge(v[4], v[5]);
 
-    d = {Interval(0, 1), Interval(4, 5), Interval(12, 13)};
+    d = { Interval(0, 1), Interval(4, 5), Interval(12, 13) };
     p.initialize(d);
     kh = hash.kmerhash("AGT", 3);
     index->add_record(min(kh.first, kh.second), 0, p, 0, (kh.first < kh.second));
@@ -410,7 +424,7 @@ TEST(UtilsTest, simpleInferLocalPRGOrderForRead) {
     v.push_back(kn);
     lp3->kmer_prg.add_edge(v[4], v[6]);
 
-    d = {Interval(0, 1), Interval(19, 20), Interval(23, 24)};
+    d = { Interval(0, 1), Interval(19, 20), Interval(23, 24) };
     p.initialize(d);
     kh = hash.kmerhash("ATT", 3);
     index->add_record(min(kh.first, kh.second), 0, p, 0, (kh.first < kh.second));
@@ -418,7 +432,7 @@ TEST(UtilsTest, simpleInferLocalPRGOrderForRead) {
     v.push_back(kn);
     lp3->kmer_prg.add_edge(v[4], v[7]);
 
-    d = {Interval(4, 5), Interval(8, 9), Interval(16, 16), Interval(23, 24)};
+    d = { Interval(4, 5), Interval(8, 9), Interval(16, 16), Interval(23, 24) };
     p.initialize(d);
     kh = hash.kmerhash("GCT", 3);
     index->add_record(min(kh.first, kh.second), 0, p, 0, (kh.first < kh.second));
@@ -426,7 +440,7 @@ TEST(UtilsTest, simpleInferLocalPRGOrderForRead) {
     v.push_back(kn);
     lp3->kmer_prg.add_edge(v[5], v[8]);
 
-    d = {Interval(4, 5), Interval(12, 13), Interval(16, 16), Interval(23, 24)};
+    d = { Interval(4, 5), Interval(12, 13), Interval(16, 16), Interval(23, 24) };
     p.initialize(d);
     kh = hash.kmerhash("GTT", 3);
     index->add_record(min(kh.first, kh.second), 0, p, 0, (kh.first < kh.second));
@@ -434,7 +448,7 @@ TEST(UtilsTest, simpleInferLocalPRGOrderForRead) {
     v.push_back(kn);
     lp3->kmer_prg.add_edge(v[6], v[9]);
 
-    d = {Interval(12, 13), Interval(16, 16), Interval(23, 25)};
+    d = { Interval(12, 13), Interval(16, 16), Interval(23, 25) };
     p.initialize(d);
     kh = hash.kmerhash("TTA", 3);
     index->add_record(min(kh.first, kh.second), 0, p, 0, (kh.first < kh.second));
@@ -442,7 +456,7 @@ TEST(UtilsTest, simpleInferLocalPRGOrderForRead) {
     v.push_back(kn);
     lp3->kmer_prg.add_edge(v[9], v[10]);
 
-    d = {Interval(23, 26)};
+    d = { Interval(23, 26) };
     p.initialize(d);
     kh = hash.kmerhash("TAA", 3);
     index->add_record(min(kh.first, kh.second), 0, p, 0, (kh.first < kh.second));
@@ -452,7 +466,7 @@ TEST(UtilsTest, simpleInferLocalPRGOrderForRead) {
     lp3->kmer_prg.add_edge(v[8], v[11]);
     lp3->kmer_prg.add_edge(v[10], v[11]);
 
-    d = {Interval(24, 27)};
+    d = { Interval(24, 27) };
     p.initialize(d);
     kh = hash.kmerhash("AAG", 3);
     index->add_record(min(kh.first, kh.second), 0, p, 0, (kh.first < kh.second));
@@ -460,7 +474,7 @@ TEST(UtilsTest, simpleInferLocalPRGOrderForRead) {
     v.push_back(kn);
     lp3->kmer_prg.add_edge(v[11], v[12]);
 
-    d = {Interval(27, 27)};
+    d = { Interval(27, 27) };
     p.initialize(d);
     kn = lp3->kmer_prg.add_node(p);
     v.push_back(kn);
@@ -469,7 +483,7 @@ TEST(UtilsTest, simpleInferLocalPRGOrderForRead) {
     // add read hits to mhs
     Seq s(0, "read1", "AGTTAAGTACG", 1, 3);
     add_read_hits(s, minimizer_hits, *index);
-    //add_read_hits(0, "read1", "AGTTAAGTACG", mhs, index, 1, 3);
+    // add_read_hits(0, "read1", "AGTTAAGTACG", mhs, index, 1, 3);
 
     // initialize pangraph;
     auto pangraph = std::make_shared<pangenome::Graph>(pangenome::Graph());
@@ -479,13 +493,14 @@ TEST(UtilsTest, simpleInferLocalPRGOrderForRead) {
     pangenome::Graph pg_exp;
     pg_exp.add_node(lp1);
     pg_exp.add_node(lp3);
-    //pg_exp.add_edge(0,1,3,0);
+    // pg_exp.add_edge(0,1,3,0);
 
     EXPECT_EQ(pg_exp, *pangraph);
     index->clear();
 }
 
-TEST(UtilsTest, biggerInferLocalPRGOrderForRead) {
+TEST(UtilsTest, biggerInferLocalPRGOrderForRead)
+{
     // initialize minihits container
     auto minimizer_hits = std::make_shared<MinimizerHits>(MinimizerHits());
     KmerHash hash;
@@ -508,13 +523,13 @@ TEST(UtilsTest, biggerInferLocalPRGOrderForRead) {
     vector<KmerNodePtr> v;
     KmerNodePtr kn;
 
-    deque<Interval> d = {Interval(0, 0)};
+    deque<Interval> d = { Interval(0, 0) };
     prg::Path p;
     p.initialize(d);
     kn = lp1->kmer_prg.add_node(p);
     v.push_back(kn);
 
-    d = {Interval(0, 3)};
+    d = { Interval(0, 3) };
     p.initialize(d);
     pair<uint64_t, uint64_t> kh = hash.kmerhash("TAC", 3);
     index->add_record(min(kh.first, kh.second), 1, p, 0, (kh.first < kh.second));
@@ -522,7 +537,7 @@ TEST(UtilsTest, biggerInferLocalPRGOrderForRead) {
     v.push_back(kn);
     lp1->kmer_prg.add_edge(v[0], v[1]);
 
-    d = {Interval(1, 4)};
+    d = { Interval(1, 4) };
     p.initialize(d);
     kh = hash.kmerhash("ACG", 3);
     index->add_record(min(kh.first, kh.second), 1, p, 0, (kh.first < kh.second));
@@ -530,7 +545,7 @@ TEST(UtilsTest, biggerInferLocalPRGOrderForRead) {
     v.push_back(kn);
     lp1->kmer_prg.add_edge(v[1], v[2]);
 
-    d = {Interval(2, 5)};
+    d = { Interval(2, 5) };
     p.initialize(d);
     kh = hash.kmerhash("CGG", 3);
     index->add_record(min(kh.first, kh.second), 1, p, 0, (kh.first < kh.second));
@@ -538,7 +553,7 @@ TEST(UtilsTest, biggerInferLocalPRGOrderForRead) {
     v.push_back(kn);
     lp1->kmer_prg.add_edge(v[2], v[3]);
 
-    d = {Interval(3, 6)};
+    d = { Interval(3, 6) };
     p.initialize(d);
     kh = hash.kmerhash("GGT", 3);
     index->add_record(min(kh.first, kh.second), 1, p, 0, (kh.first < kh.second));
@@ -546,7 +561,7 @@ TEST(UtilsTest, biggerInferLocalPRGOrderForRead) {
     v.push_back(kn);
     lp1->kmer_prg.add_edge(v[3], v[4]);
 
-    d = {Interval(4, 7)};
+    d = { Interval(4, 7) };
     p.initialize(d);
     kh = hash.kmerhash("GTA", 3);
     index->add_record(min(kh.first, kh.second), 1, p, 0, (kh.first < kh.second));
@@ -554,18 +569,18 @@ TEST(UtilsTest, biggerInferLocalPRGOrderForRead) {
     v.push_back(kn);
     lp1->kmer_prg.add_edge(v[4], v[5]);
 
-    d = {Interval(7, 7)};
+    d = { Interval(7, 7) };
     p.initialize(d);
     kn = lp1->kmer_prg.add_node(p);
     v.push_back(kn);
     lp1->kmer_prg.add_edge(v[5], v[6]);
 
-    d = {Interval(0, 0)};
+    d = { Interval(0, 0) };
     p.initialize(d);
     kn = lp3->kmer_prg.add_node(p);
     v.push_back(kn);
 
-    d = {Interval(0, 1), Interval(4, 5), Interval(8, 9)};
+    d = { Interval(0, 1), Interval(4, 5), Interval(8, 9) };
     p.initialize(d);
     kh = hash.kmerhash("ACC", 3); // inconsistent
     index->add_record(min(kh.first, kh.second), 3, p, 0, (kh.first < kh.second));
@@ -573,7 +588,7 @@ TEST(UtilsTest, biggerInferLocalPRGOrderForRead) {
     v.push_back(kn);
     lp3->kmer_prg.add_edge(v[7], v[8]);
 
-    d = {Interval(0, 1), Interval(4, 5), Interval(12, 13)};
+    d = { Interval(0, 1), Interval(4, 5), Interval(12, 13) };
     p.initialize(d);
     kh = hash.kmerhash("AGT", 3);
     index->add_record(min(kh.first, kh.second), 3, p, 0, (kh.first < kh.second));
@@ -581,7 +596,7 @@ TEST(UtilsTest, biggerInferLocalPRGOrderForRead) {
     v.push_back(kn);
     lp3->kmer_prg.add_edge(v[7], v[9]);
 
-    d = {Interval(0, 1), Interval(19, 20), Interval(23, 24)};
+    d = { Interval(0, 1), Interval(19, 20), Interval(23, 24) };
     p.initialize(d);
     kh = hash.kmerhash("ATT", 3);
     index->add_record(min(kh.first, kh.second), 3, p, 0, (kh.first < kh.second));
@@ -589,7 +604,7 @@ TEST(UtilsTest, biggerInferLocalPRGOrderForRead) {
     v.push_back(kn);
     lp3->kmer_prg.add_edge(v[7], v[10]);
 
-    d = {Interval(4, 5), Interval(8, 9), Interval(16, 16), Interval(23, 24)};
+    d = { Interval(4, 5), Interval(8, 9), Interval(16, 16), Interval(23, 24) };
     p.initialize(d);
     kh = hash.kmerhash("GCT", 3);
     index->add_record(min(kh.first, kh.second), 3, p, 0, (kh.first < kh.second));
@@ -597,7 +612,7 @@ TEST(UtilsTest, biggerInferLocalPRGOrderForRead) {
     v.push_back(kn);
     lp3->kmer_prg.add_edge(v[8], v[11]);
 
-    d = {Interval(4, 5), Interval(12, 13), Interval(16, 16), Interval(23, 24)};
+    d = { Interval(4, 5), Interval(12, 13), Interval(16, 16), Interval(23, 24) };
     p.initialize(d);
     kh = hash.kmerhash("GTT", 3);
     index->add_record(min(kh.first, kh.second), 3, p, 0, (kh.first < kh.second));
@@ -605,7 +620,7 @@ TEST(UtilsTest, biggerInferLocalPRGOrderForRead) {
     v.push_back(kn);
     lp3->kmer_prg.add_edge(v[9], v[12]);
 
-    d = {Interval(12, 13), Interval(16, 16), Interval(23, 25)};
+    d = { Interval(12, 13), Interval(16, 16), Interval(23, 25) };
     p.initialize(d);
     kh = hash.kmerhash("TTA", 3);
     index->add_record(min(kh.first, kh.second), 3, p, 0, (kh.first < kh.second));
@@ -613,9 +628,9 @@ TEST(UtilsTest, biggerInferLocalPRGOrderForRead) {
     v.push_back(kn);
     lp3->kmer_prg.add_edge(v[12], v[13]);
 
-    d = {Interval(23, 26)};
+    d = { Interval(23, 26) };
     p.initialize(d);
-    kh = hash.kmerhash("TAT", 3);//inconsistent but I don't care
+    kh = hash.kmerhash("TAT", 3); // inconsistent but I don't care
     index->add_record(min(kh.first, kh.second), 3, p, 0, (kh.first < kh.second));
     kn = lp3->kmer_prg.add_node(p);
     v.push_back(kn);
@@ -623,7 +638,7 @@ TEST(UtilsTest, biggerInferLocalPRGOrderForRead) {
     lp3->kmer_prg.add_edge(v[11], v[14]);
     lp3->kmer_prg.add_edge(v[13], v[14]);
 
-    d = {Interval(24, 27)};
+    d = { Interval(24, 27) };
     p.initialize(d);
     kh = hash.kmerhash("ATG", 3);
     index->add_record(min(kh.first, kh.second), 3, p, 0, (kh.first < kh.second));
@@ -631,18 +646,18 @@ TEST(UtilsTest, biggerInferLocalPRGOrderForRead) {
     v.push_back(kn);
     lp3->kmer_prg.add_edge(v[14], v[15]);
 
-    d = {Interval(27, 27)};
+    d = { Interval(27, 27) };
     p.initialize(d);
     kn = lp3->kmer_prg.add_node(p);
     v.push_back(kn);
     lp3->kmer_prg.add_edge(v[15], v[16]);
 
-    d = {Interval(8, 8)};
+    d = { Interval(8, 8) };
     p.initialize(d);
     kn = lp0->kmer_prg.add_node(p);
     v.push_back(kn);
 
-    d = {Interval(8, 11)};
+    d = { Interval(8, 11) };
     p.initialize(d);
     kh = hash.kmerhash("CTA", 3);
     index->add_record(min(kh.first, kh.second), 0, p, 0, (kh.first < kh.second));
@@ -650,7 +665,7 @@ TEST(UtilsTest, biggerInferLocalPRGOrderForRead) {
     v.push_back(kn);
     lp0->kmer_prg.add_edge(v[17], v[18]);
 
-    d = {Interval(9, 12)};
+    d = { Interval(9, 12) };
     p.initialize(d);
     kh = hash.kmerhash("TAG", 3);
     index->add_record(min(kh.first, kh.second), 0, p, 0, (kh.first < kh.second));
@@ -658,18 +673,18 @@ TEST(UtilsTest, biggerInferLocalPRGOrderForRead) {
     v.push_back(kn);
     lp0->kmer_prg.add_edge(v[18], v[19]);
 
-    d = {Interval(12, 12)};
+    d = { Interval(12, 12) };
     p.initialize(d);
     kn = lp0->kmer_prg.add_node(p);
     v.push_back(kn);
     lp0->kmer_prg.add_edge(v[19], v[20]);
 
-    d = {Interval(0, 0)};
+    d = { Interval(0, 0) };
     p.initialize(d);
     kn = lp2->kmer_prg.add_node(p);
     v.push_back(kn);
 
-    d = {Interval(0, 3)};
+    d = { Interval(0, 3) };
     p.initialize(d);
     kh = hash.kmerhash("CTA", 3);
     index->add_record(min(kh.first, kh.second), 2, p, 0, (kh.first < kh.second));
@@ -677,7 +692,7 @@ TEST(UtilsTest, biggerInferLocalPRGOrderForRead) {
     v.push_back(kn);
     lp2->kmer_prg.add_edge(v[21], v[22]);
 
-    d = {Interval(1, 4)};
+    d = { Interval(1, 4) };
     p.initialize(d);
     kh = hash.kmerhash("TAC", 3);
     index->add_record(min(kh.first, kh.second), 2, p, 0, (kh.first < kh.second));
@@ -685,7 +700,7 @@ TEST(UtilsTest, biggerInferLocalPRGOrderForRead) {
     v.push_back(kn);
     lp2->kmer_prg.add_edge(v[22], v[23]);
 
-    d = {Interval(2, 5)};
+    d = { Interval(2, 5) };
     p.initialize(d);
     kh = hash.kmerhash("ACT", 3);
     index->add_record(min(kh.first, kh.second), 2, p, 0, (kh.first < kh.second));
@@ -693,7 +708,7 @@ TEST(UtilsTest, biggerInferLocalPRGOrderForRead) {
     v.push_back(kn);
     lp2->kmer_prg.add_edge(v[23], v[24]);
 
-    d = {Interval(5, 5)};
+    d = { Interval(5, 5) };
     p.initialize(d);
     kn = lp2->kmer_prg.add_node(p);
     v.push_back(kn);
@@ -702,22 +717,23 @@ TEST(UtilsTest, biggerInferLocalPRGOrderForRead) {
     // add read hits to mhs
     Seq s(0, "read2", "AGTTATGCTAGCTACTTACGGTA", 1, 3);
     add_read_hits(s, minimizer_hits, *index);
-    //add_read_hits(0, "read2", "AGTTATGCTAGCTACTTACGGTA", mhs, index, 1, 3);
+    // add_read_hits(0, "read2", "AGTTATGCTAGCTACTTACGGTA", mhs, index, 1, 3);
 
     // initialize pangraph;
     auto pangraph = std::make_shared<pangenome::Graph>(pangenome::Graph());
     infer_localPRG_order_for_reads(prgs, minimizer_hits, pangraph, 1, 100, 0.1, 1);
 
     // create a pangraph object representing the truth we expect (prg 3 4 2 1)
-    // note that prgs 1, 3, 4 share no 3mer, but 2 shares a 3mer with each of 2 other prgs
+    // note that prgs 1, 3, 4 share no 3mer, but 2 shares a 3mer with each of 2 other
+    // prgs
     pangenome::Graph pg_exp;
     pg_exp.add_node(lp1);
     pg_exp.add_node(lp2);
     pg_exp.add_node(lp3);
     pg_exp.add_node(lp0);
-    //pg_exp.add_edge(3,0,3,0);
-    //pg_exp.add_edge(0,2,3,0);
-    //pg_exp.add_edge(2,1,3,0);
+    // pg_exp.add_edge(3,0,3,0);
+    // pg_exp.add_edge(0,2,3,0);
+    // pg_exp.add_edge(2,1,3,0);
 
     EXPECT_EQ(pg_exp, *pangraph);
     index->clear();
@@ -731,12 +747,13 @@ TEST(UtilsTest, biggerInferLocalPRGOrderForRead) {
     pg = new pangenome::Graph();
     Index *index;
     std::vector<std::shared_ptr<LocalPRG>> prgs;
-    pangraph_from_read_file("../../test/test_cases/reads.fq.gz", mhs, pg, index, prgs, 1, 3, 1, 0.1);
-    delete mhs;
-    delete pg;
+    pangraph_from_read_file("../../test/test_cases/reads.fq.gz", mhs, pg, index, prgs,
+1, 3, 1, 0.1); delete mhs; delete pg;
 }*/
 
-void setup_index(std::vector<std::shared_ptr<LocalPRG>> &prgs, std::shared_ptr<Index> &index){
+void setup_index(
+    std::vector<std::shared_ptr<LocalPRG>>& prgs, std::shared_ptr<Index>& index)
+{
     auto lp1 = std::make_shared<LocalPRG>(LocalPRG(1, "1", ""));
     auto lp3 = std::make_shared<LocalPRG>(LocalPRG(3, "3", ""));
     auto lp0 = std::make_shared<LocalPRG>(LocalPRG(0, "0", ""));
@@ -750,13 +767,13 @@ void setup_index(std::vector<std::shared_ptr<LocalPRG>> &prgs, std::shared_ptr<I
     vector<KmerNodePtr> v;
     KmerNodePtr kn;
 
-    deque<Interval> d = {Interval(0, 0)};
+    deque<Interval> d = { Interval(0, 0) };
     prg::Path p;
     p.initialize(d);
     kn = lp1->kmer_prg.add_node(p);
     v.push_back(kn);
 
-    d = {Interval(0, 3)};
+    d = { Interval(0, 3) };
     p.initialize(d);
     pair<uint64_t, uint64_t> kh = hash.kmerhash("TAC", 3);
     index->add_record(min(kh.first, kh.second), 1, p, 0, (kh.first < kh.second));
@@ -764,7 +781,7 @@ void setup_index(std::vector<std::shared_ptr<LocalPRG>> &prgs, std::shared_ptr<I
     v.push_back(kn);
     lp1->kmer_prg.add_edge(v[0], v[1]);
 
-    d = {Interval(1, 4)};
+    d = { Interval(1, 4) };
     p.initialize(d);
     kh = hash.kmerhash("ACG", 3);
     index->add_record(min(kh.first, kh.second), 1, p, 0, (kh.first < kh.second));
@@ -772,7 +789,7 @@ void setup_index(std::vector<std::shared_ptr<LocalPRG>> &prgs, std::shared_ptr<I
     v.push_back(kn);
     lp1->kmer_prg.add_edge(v[1], v[2]);
 
-    d = {Interval(2, 5)};
+    d = { Interval(2, 5) };
     p.initialize(d);
     kh = hash.kmerhash("CGG", 3);
     index->add_record(min(kh.first, kh.second), 1, p, 0, (kh.first < kh.second));
@@ -780,7 +797,7 @@ void setup_index(std::vector<std::shared_ptr<LocalPRG>> &prgs, std::shared_ptr<I
     v.push_back(kn);
     lp1->kmer_prg.add_edge(v[2], v[3]);
 
-    d = {Interval(3, 6)};
+    d = { Interval(3, 6) };
     p.initialize(d);
     kh = hash.kmerhash("GGT", 3);
     index->add_record(min(kh.first, kh.second), 1, p, 0, (kh.first < kh.second));
@@ -788,7 +805,7 @@ void setup_index(std::vector<std::shared_ptr<LocalPRG>> &prgs, std::shared_ptr<I
     v.push_back(kn);
     lp1->kmer_prg.add_edge(v[3], v[4]);
 
-    d = {Interval(4, 7)};
+    d = { Interval(4, 7) };
     p.initialize(d);
     kh = hash.kmerhash("GTA", 3);
     index->add_record(min(kh.first, kh.second), 1, p, 0, (kh.first < kh.second));
@@ -796,18 +813,18 @@ void setup_index(std::vector<std::shared_ptr<LocalPRG>> &prgs, std::shared_ptr<I
     v.push_back(kn);
     lp1->kmer_prg.add_edge(v[4], v[5]);
 
-    d = {Interval(7, 7)};
+    d = { Interval(7, 7) };
     p.initialize(d);
     kn = lp1->kmer_prg.add_node(p);
     v.push_back(kn);
     lp1->kmer_prg.add_edge(v[5], v[6]);
 
-    d = {Interval(0, 0)};
+    d = { Interval(0, 0) };
     p.initialize(d);
     kn = lp3->kmer_prg.add_node(p);
     v.push_back(kn);
 
-    d = {Interval(0, 1), Interval(4, 5), Interval(8, 9)};
+    d = { Interval(0, 1), Interval(4, 5), Interval(8, 9) };
     p.initialize(d);
     kh = hash.kmerhash("ACC", 3); // inconsistent
     index->add_record(min(kh.first, kh.second), 3, p, 0, (kh.first < kh.second));
@@ -815,7 +832,7 @@ void setup_index(std::vector<std::shared_ptr<LocalPRG>> &prgs, std::shared_ptr<I
     v.push_back(kn);
     lp3->kmer_prg.add_edge(v[7], v[8]);
 
-    d = {Interval(0, 1), Interval(4, 5), Interval(12, 13)};
+    d = { Interval(0, 1), Interval(4, 5), Interval(12, 13) };
     p.initialize(d);
     kh = hash.kmerhash("AGT", 3);
     index->add_record(min(kh.first, kh.second), 3, p, 0, (kh.first < kh.second));
@@ -823,7 +840,7 @@ void setup_index(std::vector<std::shared_ptr<LocalPRG>> &prgs, std::shared_ptr<I
     v.push_back(kn);
     lp3->kmer_prg.add_edge(v[7], v[9]);
 
-    d = {Interval(0, 1), Interval(19, 20), Interval(23, 24)};
+    d = { Interval(0, 1), Interval(19, 20), Interval(23, 24) };
     p.initialize(d);
     kh = hash.kmerhash("ATT", 3);
     index->add_record(min(kh.first, kh.second), 3, p, 0, (kh.first < kh.second));
@@ -831,7 +848,7 @@ void setup_index(std::vector<std::shared_ptr<LocalPRG>> &prgs, std::shared_ptr<I
     v.push_back(kn);
     lp3->kmer_prg.add_edge(v[7], v[10]);
 
-    d = {Interval(4, 5), Interval(8, 9), Interval(16, 16), Interval(23, 24)};
+    d = { Interval(4, 5), Interval(8, 9), Interval(16, 16), Interval(23, 24) };
     p.initialize(d);
     kh = hash.kmerhash("GCT", 3);
     index->add_record(min(kh.first, kh.second), 3, p, 0, (kh.first < kh.second));
@@ -839,7 +856,7 @@ void setup_index(std::vector<std::shared_ptr<LocalPRG>> &prgs, std::shared_ptr<I
     v.push_back(kn);
     lp3->kmer_prg.add_edge(v[8], v[11]);
 
-    d = {Interval(4, 5), Interval(12, 13), Interval(16, 16), Interval(23, 24)};
+    d = { Interval(4, 5), Interval(12, 13), Interval(16, 16), Interval(23, 24) };
     p.initialize(d);
     kh = hash.kmerhash("GTT", 3);
     index->add_record(min(kh.first, kh.second), 3, p, 0, (kh.first < kh.second));
@@ -847,7 +864,7 @@ void setup_index(std::vector<std::shared_ptr<LocalPRG>> &prgs, std::shared_ptr<I
     v.push_back(kn);
     lp3->kmer_prg.add_edge(v[9], v[12]);
 
-    d = {Interval(12, 13), Interval(16, 16), Interval(23, 25)};
+    d = { Interval(12, 13), Interval(16, 16), Interval(23, 25) };
     p.initialize(d);
     kh = hash.kmerhash("TTA", 3);
     index->add_record(min(kh.first, kh.second), 3, p, 0, (kh.first < kh.second));
@@ -855,9 +872,9 @@ void setup_index(std::vector<std::shared_ptr<LocalPRG>> &prgs, std::shared_ptr<I
     v.push_back(kn);
     lp3->kmer_prg.add_edge(v[12], v[13]);
 
-    d = {Interval(23, 26)};
+    d = { Interval(23, 26) };
     p.initialize(d);
-    kh = hash.kmerhash("TAT", 3);//inconsistent but I don't care
+    kh = hash.kmerhash("TAT", 3); // inconsistent but I don't care
     index->add_record(min(kh.first, kh.second), 3, p, 0, (kh.first < kh.second));
     kn = lp3->kmer_prg.add_node(p);
     v.push_back(kn);
@@ -865,7 +882,7 @@ void setup_index(std::vector<std::shared_ptr<LocalPRG>> &prgs, std::shared_ptr<I
     lp3->kmer_prg.add_edge(v[11], v[14]);
     lp3->kmer_prg.add_edge(v[13], v[14]);
 
-    d = {Interval(24, 27)};
+    d = { Interval(24, 27) };
     p.initialize(d);
     kh = hash.kmerhash("ATG", 3);
     index->add_record(min(kh.first, kh.second), 3, p, 0, (kh.first < kh.second));
@@ -873,18 +890,18 @@ void setup_index(std::vector<std::shared_ptr<LocalPRG>> &prgs, std::shared_ptr<I
     v.push_back(kn);
     lp3->kmer_prg.add_edge(v[14], v[15]);
 
-    d = {Interval(27, 27)};
+    d = { Interval(27, 27) };
     p.initialize(d);
     kn = lp3->kmer_prg.add_node(p);
     v.push_back(kn);
     lp3->kmer_prg.add_edge(v[15], v[16]);
 
-    d = {Interval(8, 8)};
+    d = { Interval(8, 8) };
     p.initialize(d);
     kn = lp0->kmer_prg.add_node(p);
     v.push_back(kn);
 
-    d = {Interval(8, 11)};
+    d = { Interval(8, 11) };
     p.initialize(d);
     kh = hash.kmerhash("CTA", 3);
     index->add_record(min(kh.first, kh.second), 0, p, 0, (kh.first < kh.second));
@@ -892,7 +909,7 @@ void setup_index(std::vector<std::shared_ptr<LocalPRG>> &prgs, std::shared_ptr<I
     v.push_back(kn);
     lp0->kmer_prg.add_edge(v[17], v[18]);
 
-    d = {Interval(9, 12)};
+    d = { Interval(9, 12) };
     p.initialize(d);
     kh = hash.kmerhash("TAG", 3);
     index->add_record(min(kh.first, kh.second), 0, p, 0, (kh.first < kh.second));
@@ -900,18 +917,18 @@ void setup_index(std::vector<std::shared_ptr<LocalPRG>> &prgs, std::shared_ptr<I
     v.push_back(kn);
     lp0->kmer_prg.add_edge(v[18], v[19]);
 
-    d = {Interval(12, 12)};
+    d = { Interval(12, 12) };
     p.initialize(d);
     kn = lp0->kmer_prg.add_node(p);
     v.push_back(kn);
     lp0->kmer_prg.add_edge(v[19], v[20]);
 
-    d = {Interval(0, 0)};
+    d = { Interval(0, 0) };
     p.initialize(d);
     kn = lp2->kmer_prg.add_node(p);
     v.push_back(kn);
 
-    d = {Interval(0, 3)};
+    d = { Interval(0, 3) };
     p.initialize(d);
     kh = hash.kmerhash("CTA", 3);
     index->add_record(min(kh.first, kh.second), 2, p, 0, (kh.first < kh.second));
@@ -919,7 +936,7 @@ void setup_index(std::vector<std::shared_ptr<LocalPRG>> &prgs, std::shared_ptr<I
     v.push_back(kn);
     lp2->kmer_prg.add_edge(v[21], v[22]);
 
-    d = {Interval(1, 4)};
+    d = { Interval(1, 4) };
     p.initialize(d);
     kh = hash.kmerhash("TAC", 3);
     index->add_record(min(kh.first, kh.second), 2, p, 0, (kh.first < kh.second));
@@ -927,7 +944,7 @@ void setup_index(std::vector<std::shared_ptr<LocalPRG>> &prgs, std::shared_ptr<I
     v.push_back(kn);
     lp2->kmer_prg.add_edge(v[22], v[23]);
 
-    d = {Interval(2, 5)};
+    d = { Interval(2, 5) };
     p.initialize(d);
     kh = hash.kmerhash("ACT", 3);
     index->add_record(min(kh.first, kh.second), 2, p, 0, (kh.first < kh.second));
@@ -935,25 +952,27 @@ void setup_index(std::vector<std::shared_ptr<LocalPRG>> &prgs, std::shared_ptr<I
     v.push_back(kn);
     lp2->kmer_prg.add_edge(v[23], v[24]);
 
-    d = {Interval(5, 5)};
+    d = { Interval(5, 5) };
     p.initialize(d);
     kn = lp2->kmer_prg.add_node(p);
     v.push_back(kn);
     lp2->kmer_prg.add_edge(v[24], v[25]);
-
 }
 
-TEST(UtilsTest, pangraphFromReadFile_Fa) {
+TEST(UtilsTest, pangraphFromReadFile_Fa)
+{
     std::vector<std::shared_ptr<LocalPRG>> prgs;
 
     auto index = std::make_shared<Index>();
     setup_index(prgs, index);
 
     auto pangraph = std::make_shared<pangenome::Graph>(pangenome::Graph());
-    pangraph_from_read_file("../../test/test_cases/read2.fa", pangraph, index, prgs, 1, 3, 1, 0.1, 1);
+    pangraph_from_read_file(
+        "../../test/test_cases/read2.fa", pangraph, index, prgs, 1, 3, 1, 0.1, 1);
 
     // create a pangraph object representing the truth we expect (prg 3 4 2 1)
-    // note that prgs 1, 3, 4 share no 3mer, but 2 shares a 3mer with each of 2 other prgs
+    // note that prgs 1, 3, 4 share no 3mer, but 2 shares a 3mer with each of 2 other
+    // prgs
     pangenome::Graph pg_exp;
     pg_exp.add_node(prgs[1]);
     pg_exp.add_node(prgs[2]);
@@ -965,17 +984,20 @@ TEST(UtilsTest, pangraphFromReadFile_Fa) {
     index->clear();
 }
 
-TEST(UtilsTest, pangraphFromReadFile_Fq) {
+TEST(UtilsTest, pangraphFromReadFile_Fq)
+{
     std::vector<std::shared_ptr<LocalPRG>> prgs;
 
     auto index = std::make_shared<Index>();
     setup_index(prgs, index);
 
     auto pangraph = std::make_shared<pangenome::Graph>(pangenome::Graph());
-    pangraph_from_read_file("../../test/test_cases/read2.fq", pangraph, index, prgs, 1, 3, 1, 0.1, 1);
+    pangraph_from_read_file(
+        "../../test/test_cases/read2.fq", pangraph, index, prgs, 1, 3, 1, 0.1, 1);
 
     // create a pangraph object representing the truth we expect (prg 3 4 2 1)
-    // note that prgs 1, 3, 4 share no 3mer, but 2 shares a 3mer with each of 2 other prgs
+    // note that prgs 1, 3, 4 share no 3mer, but 2 shares a 3mer with each of 2 other
+    // prgs
     pangenome::Graph pg_exp;
     pg_exp.add_node(prgs[1]);
     pg_exp.add_node(prgs[2]);

--- a/test/vcf_test.cpp
+++ b/test/vcf_test.cpp
@@ -1,84 +1,92 @@
-#include "gtest/gtest.h"
+#include "interval.h"
+#include "localnode.h"
 #include "test_macro.cpp"
 #include "vcf.h"
 #include "vcfrecord.h"
-#include "interval.h"
-#include "localnode.h"
-#include <stdint.h>
+#include "gtest/gtest.h"
 #include <iostream>
-
+#include <stdint.h>
 
 using namespace std;
 
-TEST(VCFTest, add_record_with_values) {
+TEST(VCFTest, add_record_with_values)
+{
 
     VCF vcf;
-    EXPECT_EQ((uint) 0, vcf.records.size());
+    EXPECT_EQ((uint)0, vcf.records.size());
     vcf.add_record("chrom1", 5, "A", "G");
-    EXPECT_EQ((uint) 1, vcf.records.size());
+    EXPECT_EQ((uint)1, vcf.records.size());
 }
 
-TEST(VCFTest, add_record_twice_with_values) {
-
-    VCF vcf;
-    vcf.add_record("chrom1", 5, "A", "G");
-    vcf.add_record("chrom1", 5, "A", "G");
-    EXPECT_EQ((uint) 1, vcf.records.size());
-}
-
-TEST(VCFTest, add_two_records_with_values) {
+TEST(VCFTest, add_record_twice_with_values)
+{
 
     VCF vcf;
     vcf.add_record("chrom1", 5, "A", "G");
-    vcf.add_record("chrom1", 46, "T", "TA");
-    EXPECT_EQ((uint) 2, vcf.records.size());
+    vcf.add_record("chrom1", 5, "A", "G");
+    EXPECT_EQ((uint)1, vcf.records.size());
 }
 
-TEST(VCFTest, add_two_records_and_a_repeat_with_values) {
+TEST(VCFTest, add_two_records_with_values)
+{
 
     VCF vcf;
     vcf.add_record("chrom1", 5, "A", "G");
     vcf.add_record("chrom1", 46, "T", "TA");
-    vcf.add_record("chrom1", 5, "A", "G");
-    EXPECT_EQ((uint) 2, vcf.records.size());
+    EXPECT_EQ((uint)2, vcf.records.size());
 }
 
-TEST(VCFTest, add_record_by_record) {
+TEST(VCFTest, add_two_records_and_a_repeat_with_values)
+{
+
+    VCF vcf;
+    vcf.add_record("chrom1", 5, "A", "G");
+    vcf.add_record("chrom1", 46, "T", "TA");
+    vcf.add_record("chrom1", 5, "A", "G");
+    EXPECT_EQ((uint)2, vcf.records.size());
+}
+
+TEST(VCFTest, add_record_by_record)
+{
     VCF vcf;
     VCFRecord vr = VCFRecord("chrom1", 79, "C", "G");
     std::vector<std::string> empty = {};
     vcf.add_record(vr, empty);
-    EXPECT_EQ((uint) 1, vcf.records.size());
+    EXPECT_EQ((uint)1, vcf.records.size());
 }
 
-TEST(VCFTest, add_record_by_record_and_values) {
+TEST(VCFTest, add_record_by_record_and_values)
+{
     VCF vcf;
     VCFRecord vr = VCFRecord("chrom1", 79, "C", "G");
     std::vector<std::string> empty = {};
     vcf.add_record(vr, empty);
     vcf.add_record("chrom1", 79, "C", "G");
-    EXPECT_EQ((uint) 1, vcf.records.size());
+    EXPECT_EQ((uint)1, vcf.records.size());
 }
 
-TEST(VCFTest, add_record_by_values_and_record) {
+TEST(VCFTest, add_record_by_values_and_record)
+{
     VCF vcf;
     vcf.add_record("chrom1", 79, "C", "G");
     VCFRecord vr = VCFRecord("chrom1", 79, "C", "G");
     std::vector<std::string> empty = {};
     vcf.add_record(vr, empty);
-    EXPECT_EQ((uint) 1, vcf.records.size());
+    EXPECT_EQ((uint)1, vcf.records.size());
 }
 
-TEST(VCFTest, add_record_by_record_returned_by_reference) {
+TEST(VCFTest, add_record_by_record_returned_by_reference)
+{
     VCF vcf;
     VCFRecord vr = VCFRecord("chrom1", 79, "C", "G");
     std::vector<std::string> empty = {};
-    VCFRecord &ref_vr = vcf.add_record(vr, empty);
+    VCFRecord& ref_vr = vcf.add_record(vr, empty);
     EXPECT_EQ(ref_vr.chrom, "chrom1");
-    EXPECT_EQ(ref_vr.pos, (uint) 79);
+    EXPECT_EQ(ref_vr.pos, (uint)79);
 }
 
-TEST(VCFTest, add_samples_empty) {
+TEST(VCFTest, add_samples_empty)
+{
     VCF vcf;
     std::vector<std::string> samples;
     vcf.add_samples(samples);
@@ -86,29 +94,32 @@ TEST(VCFTest, add_samples_empty) {
     EXPECT_EQ(vcf.records.size(), (uint)0);
 }
 
-TEST(VCFTest, add_samples_simple) {
+TEST(VCFTest, add_samples_simple)
+{
     VCF vcf;
-    std::vector<std::string> samples = {"hello", "there", "people"};
+    std::vector<std::string> samples = { "hello", "there", "people" };
     vcf.add_samples(samples);
     EXPECT_ITERABLE_EQ(std::vector<std::string>, samples, vcf.samples);
     EXPECT_EQ(vcf.records.size(), (uint)0);
 }
 
-TEST(VCFTest, add_samples_with_record) {
+TEST(VCFTest, add_samples_with_record)
+{
     VCF vcf;
     vcf.add_sample_gt("sample", "chrom1", 5, "A", "G");
 
-    std::vector<std::string> samples = {"hello", "there", "people"};
+    std::vector<std::string> samples = { "hello", "there", "people" };
     vcf.add_samples(samples);
 
-    std::vector<std::string> exp_samples = {"sample", "hello", "there", "people"};
+    std::vector<std::string> exp_samples = { "sample", "hello", "there", "people" };
 
     EXPECT_ITERABLE_EQ(std::vector<std::string>, exp_samples, vcf.samples);
     EXPECT_EQ(vcf.records.size(), (uint)1);
     EXPECT_EQ(vcf.records[0]->samples.size(), exp_samples.size());
 }
 
-TEST(VCFTest, add_sample_gt) {
+TEST(VCFTest, add_sample_gt)
+{
     VCF vcf;
     vcf.add_record("chrom1", 5, "A", "G");
     vcf.add_record("chrom1", 46, "T", "TA");
@@ -119,74 +130,82 @@ TEST(VCFTest, add_sample_gt) {
     uint j = 1;
     EXPECT_EQ(j, vcf.samples.size());
     EXPECT_EQ(j, vcf.records[1]->samples.size());
-    EXPECT_EQ((uint16_t) 1, vcf.records[1]->samples[0]["GT"][0]);
+    EXPECT_EQ((uint16_t)1, vcf.records[1]->samples[0]["GT"][0]);
     EXPECT_EQ(j, vcf.records[0]->samples.size());
-    EXPECT_TRUE(vcf.records[0]->samples[0].find("GT") == vcf.records[0]->samples[0].end());
+    EXPECT_TRUE(
+        vcf.records[0]->samples[0].find("GT") == vcf.records[0]->samples[0].end());
     EXPECT_EQ(j, vcf.records[2]->samples.size());
-    EXPECT_TRUE(vcf.records[2]->samples[0].find("GT") == vcf.records[2]->samples[0].end());
+    EXPECT_TRUE(
+        vcf.records[2]->samples[0].find("GT") == vcf.records[2]->samples[0].end());
     EXPECT_EQ(j, vcf.records[3]->samples.size());
-    EXPECT_TRUE(vcf.records[3]->samples[0].find("GT") == vcf.records[3]->samples[0].end());
+    EXPECT_TRUE(
+        vcf.records[3]->samples[0].find("GT") == vcf.records[3]->samples[0].end());
 
     vcf.add_sample_gt("sample", "chrom1", 79, "C", "C");
     EXPECT_EQ(j, vcf.samples.size());
     EXPECT_EQ(j, vcf.records[1]->samples.size());
-    EXPECT_EQ((uint16_t) 1, vcf.records[1]->samples[0]["GT"][0]);
+    EXPECT_EQ((uint16_t)1, vcf.records[1]->samples[0]["GT"][0]);
     EXPECT_EQ(j, vcf.records[0]->samples.size());
-    EXPECT_TRUE(vcf.records[0]->samples[0].find("GT") == vcf.records[0]->samples[0].end());
+    EXPECT_TRUE(
+        vcf.records[0]->samples[0].find("GT") == vcf.records[0]->samples[0].end());
     EXPECT_EQ(j, vcf.records[2]->samples.size());
-    EXPECT_EQ((uint16_t) 0, vcf.records[2]->samples[0]["GT"][0]);
+    EXPECT_EQ((uint16_t)0, vcf.records[2]->samples[0]["GT"][0]);
     EXPECT_EQ(j, vcf.records[3]->samples.size());
-    EXPECT_EQ((uint16_t) 0, vcf.records[3]->samples[0]["GT"][0]);
+    EXPECT_EQ((uint16_t)0, vcf.records[3]->samples[0]["GT"][0]);
 }
 
-TEST(VCFTest, add_record_by_record_with_existing_sample) {
+TEST(VCFTest, add_record_by_record_with_existing_sample)
+{
     VCF vcf;
     vcf.add_sample_gt("sample", "chrom1", 46, "T", "TA");
     VCFRecord vr = VCFRecord("chrom1", 79, "C", "G");
     std::vector<std::string> empty = {};
-    VCFRecord &ref_vr = vcf.add_record(vr, empty);
+    VCFRecord& ref_vr = vcf.add_record(vr, empty);
     EXPECT_EQ(ref_vr.chrom, "chrom1");
-    EXPECT_EQ(ref_vr.pos, (uint) 79);
-    EXPECT_EQ(ref_vr.samples.size(), (uint) 1);
+    EXPECT_EQ(ref_vr.pos, (uint)79);
+    EXPECT_EQ(ref_vr.samples.size(), (uint)1);
 }
 
-TEST(VCFTest, add_record_by_record_with_same_existing_sample) {
+TEST(VCFTest, add_record_by_record_with_same_existing_sample)
+{
     VCF vcf;
     vcf.add_sample_gt("sample", "chrom1", 46, "T", "TA");
     VCFRecord vr = VCFRecord("chrom1", 79, "C", "G");
     std::unordered_map<std::string, std::vector<uint16_t>> empty_map;
     vr.samples.emplace_back(empty_map);
-    vr.samples[0]["GT"] = {1};
-    std::vector<std::string> samples = {"sample"};
-    VCFRecord &ref_vr = vcf.add_record(vr, samples);
+    vr.samples[0]["GT"] = { 1 };
+    std::vector<std::string> samples = { "sample" };
+    VCFRecord& ref_vr = vcf.add_record(vr, samples);
     EXPECT_EQ(ref_vr.chrom, "chrom1");
-    EXPECT_EQ(ref_vr.pos, (uint) 79);
-    EXPECT_EQ(ref_vr.samples.size(), (uint) 1);
+    EXPECT_EQ(ref_vr.pos, (uint)79);
+    EXPECT_EQ(ref_vr.samples.size(), (uint)1);
     EXPECT_ITERABLE_EQ(vector<std::string>, samples, vcf.samples);
     EXPECT_FALSE(ref_vr.samples[0].find("GT") == ref_vr.samples[0].end());
     EXPECT_EQ(ref_vr.samples[0]["GT"][0], (uint16_t)1);
 }
 
-TEST(VCFTest, add_record_by_record_with_different_existing_sample) {
+TEST(VCFTest, add_record_by_record_with_different_existing_sample)
+{
     VCF vcf;
     vcf.add_sample_gt("sample", "chrom1", 46, "T", "TA");
     VCFRecord vr = VCFRecord("chrom1", 79, "C", "G");
     std::unordered_map<std::string, std::vector<uint16_t>> empty_map;
     vr.samples.emplace_back(empty_map);
-    vr.samples[0]["GT"] = {1};
-    std::vector<std::string> samples = {"sample1"};
-    VCFRecord &ref_vr = vcf.add_record(vr, samples);
+    vr.samples[0]["GT"] = { 1 };
+    std::vector<std::string> samples = { "sample1" };
+    VCFRecord& ref_vr = vcf.add_record(vr, samples);
     EXPECT_EQ(ref_vr.chrom, "chrom1");
-    EXPECT_EQ(ref_vr.pos, (uint) 79);
-    EXPECT_EQ(ref_vr.samples.size(), (uint) 2);
-    std::vector<std::string> exp_samples = {"sample", "sample1"};
+    EXPECT_EQ(ref_vr.pos, (uint)79);
+    EXPECT_EQ(ref_vr.samples.size(), (uint)2);
+    std::vector<std::string> exp_samples = { "sample", "sample1" };
     EXPECT_ITERABLE_EQ(vector<std::string>, exp_samples, vcf.samples);
     EXPECT_TRUE(ref_vr.samples[0].find("GT") == ref_vr.samples[0].end());
     EXPECT_FALSE(ref_vr.samples[1].find("GT") == ref_vr.samples[0].end());
     EXPECT_EQ(ref_vr.samples[1]["GT"][0], (uint16_t)1);
 }
 
-TEST(VCFTest, add_sample_ref_alleles) {
+TEST(VCFTest, add_sample_ref_alleles)
+{
     VCF vcf;
     vcf.add_record("chrom1", 5, "A", "G");
     vcf.add_record("chrom1", 46, "T", "TA");
@@ -195,35 +214,44 @@ TEST(VCFTest, add_sample_ref_alleles) {
     vcf.add_record("chrom2", 30, "C", "A");
 
     vcf.add_sample_ref_alleles("sample", "chrom1", 15, 78);
-    EXPECT_EQ((uint) 1, vcf.samples.size());
-    EXPECT_EQ((uint) 5, vcf.records.size());
-    EXPECT_EQ((uint) 1, vcf.records[0]->samples.size());
-    EXPECT_TRUE(vcf.records[0]->samples[0].find("GT") == vcf.records[0]->samples[0].end());
-    EXPECT_EQ((uint) 1, vcf.records[1]->samples.size());
-    EXPECT_EQ((uint16_t) 0, vcf.records[1]->samples[0]["GT"][0]);
-    EXPECT_EQ((uint) 1, vcf.records[2]->samples.size());
-    EXPECT_TRUE(vcf.records[2]->samples[0].find("GT") == vcf.records[2]->samples[0].end());
-    EXPECT_EQ((uint) 1, vcf.records[3]->samples.size());
-    EXPECT_TRUE(vcf.records[3]->samples[0].find("GT") == vcf.records[3]->samples[0].end());
-    EXPECT_EQ((uint) 1, vcf.records[4]->samples.size());
-    EXPECT_TRUE(vcf.records[4]->samples[0].find("GT") == vcf.records[4]->samples[0].end());
+    EXPECT_EQ((uint)1, vcf.samples.size());
+    EXPECT_EQ((uint)5, vcf.records.size());
+    EXPECT_EQ((uint)1, vcf.records[0]->samples.size());
+    EXPECT_TRUE(
+        vcf.records[0]->samples[0].find("GT") == vcf.records[0]->samples[0].end());
+    EXPECT_EQ((uint)1, vcf.records[1]->samples.size());
+    EXPECT_EQ((uint16_t)0, vcf.records[1]->samples[0]["GT"][0]);
+    EXPECT_EQ((uint)1, vcf.records[2]->samples.size());
+    EXPECT_TRUE(
+        vcf.records[2]->samples[0].find("GT") == vcf.records[2]->samples[0].end());
+    EXPECT_EQ((uint)1, vcf.records[3]->samples.size());
+    EXPECT_TRUE(
+        vcf.records[3]->samples[0].find("GT") == vcf.records[3]->samples[0].end());
+    EXPECT_EQ((uint)1, vcf.records[4]->samples.size());
+    EXPECT_TRUE(
+        vcf.records[4]->samples[0].find("GT") == vcf.records[4]->samples[0].end());
 
     vcf.add_sample_ref_alleles("sample2", "chrom1", 5, 46);
-    EXPECT_EQ((uint) 2, vcf.samples.size());
-    EXPECT_EQ((uint) 5, vcf.records.size());
-    EXPECT_EQ((uint) 2, vcf.records[0]->samples.size());
-    EXPECT_EQ((uint16_t) 0, vcf.records[0]->samples[1]["GT"][0]);
-    EXPECT_EQ((uint) 2, vcf.records[1]->samples.size());
-    EXPECT_TRUE(vcf.records[1]->samples[1].find("GT") == vcf.records[1]->samples[1].end());
-    EXPECT_EQ((uint) 2, vcf.records[2]->samples.size());
-    EXPECT_TRUE(vcf.records[2]->samples[1].find("GT") == vcf.records[2]->samples[1].end());
-    EXPECT_EQ((uint) 2, vcf.records[3]->samples.size());
-    EXPECT_TRUE(vcf.records[3]->samples[1].find("GT") == vcf.records[3]->samples[1].end());
-    EXPECT_EQ((uint) 2, vcf.records[4]->samples.size());
-    EXPECT_TRUE(vcf.records[4]->samples[1].find("GT") == vcf.records[4]->samples[1].end());
+    EXPECT_EQ((uint)2, vcf.samples.size());
+    EXPECT_EQ((uint)5, vcf.records.size());
+    EXPECT_EQ((uint)2, vcf.records[0]->samples.size());
+    EXPECT_EQ((uint16_t)0, vcf.records[0]->samples[1]["GT"][0]);
+    EXPECT_EQ((uint)2, vcf.records[1]->samples.size());
+    EXPECT_TRUE(
+        vcf.records[1]->samples[1].find("GT") == vcf.records[1]->samples[1].end());
+    EXPECT_EQ((uint)2, vcf.records[2]->samples.size());
+    EXPECT_TRUE(
+        vcf.records[2]->samples[1].find("GT") == vcf.records[2]->samples[1].end());
+    EXPECT_EQ((uint)2, vcf.records[3]->samples.size());
+    EXPECT_TRUE(
+        vcf.records[3]->samples[1].find("GT") == vcf.records[3]->samples[1].end());
+    EXPECT_EQ((uint)2, vcf.records[4]->samples.size());
+    EXPECT_TRUE(
+        vcf.records[4]->samples[1].find("GT") == vcf.records[4]->samples[1].end());
 }
 
-TEST(VCFTest, reorder_add_record_and_sample) {
+TEST(VCFTest, reorder_add_record_and_sample)
+{
     VCF vcf;
     vcf.add_record("chrom1", 5, "A", "G");
     vcf.add_record("chrom1", 46, "T", "TA");
@@ -234,23 +262,25 @@ TEST(VCFTest, reorder_add_record_and_sample) {
 
     vcf.sort_records();
 
-    EXPECT_EQ((uint) 2, vcf.samples.size());
-    EXPECT_EQ((uint) 4, vcf.records.size());
-    EXPECT_EQ((uint) 2, vcf.records[0]->samples.size());
-    EXPECT_EQ((uint) 2, vcf.records[1]->samples.size());
-    EXPECT_EQ((uint) 2, vcf.records[2]->samples.size());
-    EXPECT_EQ((uint) 2, vcf.records[3]->samples.size());
-    EXPECT_TRUE(vcf.records[0]->samples[0].find("GT") == vcf.records[0]->samples[0].end());
-    EXPECT_EQ((uint16_t) 1, vcf.records[1]->samples[0]["GT"][0]);
-    EXPECT_EQ((uint16_t) 1, vcf.records[2]->samples[0]["GT"][0]);
-    EXPECT_TRUE(vcf.records[3]->samples[0].find("GT") == vcf.records[3]->samples[0].end());
-    EXPECT_TRUE(vcf.records[0]->samples[1].find("GT") == vcf.records[0]->samples[1].end());
-    EXPECT_TRUE(vcf.records[1]->samples[1].find("GT") == vcf.records[1]->samples[1].end());
-    EXPECT_EQ((uint16_t) 0, vcf.records[2]->samples[1]["GT"][0]);
-    EXPECT_EQ((uint16_t) 0, vcf.records[3]->samples[1]["GT"][0]);
-
+    EXPECT_EQ((uint)2, vcf.samples.size());
+    EXPECT_EQ((uint)4, vcf.records.size());
+    EXPECT_EQ((uint)2, vcf.records[0]->samples.size());
+    EXPECT_EQ((uint)2, vcf.records[1]->samples.size());
+    EXPECT_EQ((uint)2, vcf.records[2]->samples.size());
+    EXPECT_EQ((uint)2, vcf.records[3]->samples.size());
+    EXPECT_TRUE(
+        vcf.records[0]->samples[0].find("GT") == vcf.records[0]->samples[0].end());
+    EXPECT_EQ((uint16_t)1, vcf.records[1]->samples[0]["GT"][0]);
+    EXPECT_EQ((uint16_t)1, vcf.records[2]->samples[0]["GT"][0]);
+    EXPECT_TRUE(
+        vcf.records[3]->samples[0].find("GT") == vcf.records[3]->samples[0].end());
+    EXPECT_TRUE(
+        vcf.records[0]->samples[1].find("GT") == vcf.records[0]->samples[1].end());
+    EXPECT_TRUE(
+        vcf.records[1]->samples[1].find("GT") == vcf.records[1]->samples[1].end());
+    EXPECT_EQ((uint16_t)0, vcf.records[2]->samples[1]["GT"][0]);
+    EXPECT_EQ((uint16_t)0, vcf.records[3]->samples[1]["GT"][0]);
 }
-
 
 /*
  * NOTE: since the clear function does not exist anymore, I removed this test
@@ -270,7 +300,8 @@ TEST(VCFTest, clear) {
 }
 */
 
-TEST(VCFTest, append_vcf_simple_case) {
+TEST(VCFTest, append_vcf_simple_case)
+{
     VCF vcf;
     vcf.add_record("chrom1", 5, "A", "G");
     vcf.add_record("chrom1", 46, "T", "TA");
@@ -284,20 +315,21 @@ TEST(VCFTest, append_vcf_simple_case) {
     new_vcf.add_record("chrom2", 79, "C", "A");
 
     vcf.append_vcf(new_vcf);
-    EXPECT_EQ((uint) 8, vcf.records.size());
+    EXPECT_EQ((uint)8, vcf.records.size());
     for (uint i = 0; i < 4; ++i) {
         EXPECT_EQ(vcf.records[i]->chrom, "chrom1");
     }
     for (uint i = 4; i < 8; ++i) {
         EXPECT_EQ(vcf.records[i]->chrom, "chrom2");
     }
-    EXPECT_EQ((uint) 5, vcf.records[4]->pos);
+    EXPECT_EQ((uint)5, vcf.records[4]->pos);
     EXPECT_EQ("TA", vcf.records[5]->alt[0]);
-    EXPECT_EQ((uint) 79, vcf.records[6]->pos);
+    EXPECT_EQ((uint)79, vcf.records[6]->pos);
     EXPECT_EQ("A", vcf.records[7]->alt[0]);
 }
 
-TEST(VCFTest, append_vcf_some_duplicate_records) {
+TEST(VCFTest, append_vcf_some_duplicate_records)
+{
     VCF vcf;
     vcf.add_record("chrom1", 5, "A", "G");
     vcf.add_record("chrom1", 46, "T", "TA");
@@ -311,18 +343,19 @@ TEST(VCFTest, append_vcf_some_duplicate_records) {
     new_vcf.add_record("chrom1", 79, "C", "A");
 
     vcf.append_vcf(new_vcf);
-    EXPECT_EQ((uint) 6, vcf.records.size());
+    EXPECT_EQ((uint)6, vcf.records.size());
     for (uint i = 0; i < 4; ++i) {
         EXPECT_EQ(vcf.records[i]->chrom, "chrom1");
     }
     for (uint i = 4; i < 6; ++i) {
         EXPECT_EQ(vcf.records[i]->chrom, "chrom2");
     }
-    EXPECT_EQ((uint) 5, vcf.records[4]->pos);
-    EXPECT_EQ((uint) 79, vcf.records[5]->pos);
+    EXPECT_EQ((uint)5, vcf.records[4]->pos);
+    EXPECT_EQ((uint)79, vcf.records[5]->pos);
 }
 
-TEST(VCFTest, append_vcf_one_sample) {
+TEST(VCFTest, append_vcf_one_sample)
+{
     VCF vcf;
     vcf.add_record("chrom1", 5, "A", "G");
     vcf.add_record("chrom1", 46, "T", "TA");
@@ -337,26 +370,33 @@ TEST(VCFTest, append_vcf_one_sample) {
     new_vcf.add_record("chrom1", 79, "C", "A");
 
     vcf.append_vcf(new_vcf);
-    EXPECT_EQ((uint) 1, vcf.samples.size());
+    EXPECT_EQ((uint)1, vcf.samples.size());
     EXPECT_EQ("sample", vcf.samples[0]);
-    EXPECT_EQ((uint) 1, vcf.records[0]->samples.size());
-    EXPECT_EQ((uint) 1, vcf.records[5]->samples.size());
-    bool found_gt = vcf.records[2]->samples[0].find("GT") != vcf.records[2]->samples[0].end();
+    EXPECT_EQ((uint)1, vcf.records[0]->samples.size());
+    EXPECT_EQ((uint)1, vcf.records[5]->samples.size());
+    bool found_gt
+        = vcf.records[2]->samples[0].find("GT") != vcf.records[2]->samples[0].end();
     EXPECT_TRUE(found_gt);
-    EXPECT_EQ((uint) 1, vcf.records[2]->samples[0]["GT"][0]);
-    found_gt = vcf.records[0]->samples[0].find("GT") != vcf.records[0]->samples[0].end();
+    EXPECT_EQ((uint)1, vcf.records[2]->samples[0]["GT"][0]);
+    found_gt
+        = vcf.records[0]->samples[0].find("GT") != vcf.records[0]->samples[0].end();
     EXPECT_FALSE(found_gt);
-    found_gt = vcf.records[1]->samples[0].find("GT") != vcf.records[1]->samples[0].end();
+    found_gt
+        = vcf.records[1]->samples[0].find("GT") != vcf.records[1]->samples[0].end();
     EXPECT_FALSE(found_gt);
-    found_gt = vcf.records[4]->samples[0].find("GT") != vcf.records[4]->samples[0].end();
+    found_gt
+        = vcf.records[4]->samples[0].find("GT") != vcf.records[4]->samples[0].end();
     EXPECT_FALSE(found_gt);
-    found_gt = vcf.records[3]->samples[0].find("GT") != vcf.records[3]->samples[0].end();
+    found_gt
+        = vcf.records[3]->samples[0].find("GT") != vcf.records[3]->samples[0].end();
     EXPECT_FALSE(found_gt);
-    found_gt = vcf.records[5]->samples[0].find("GT") != vcf.records[5]->samples[0].end();
+    found_gt
+        = vcf.records[5]->samples[0].find("GT") != vcf.records[5]->samples[0].end();
     EXPECT_FALSE(found_gt);
 }
 
-TEST(VCFTest, append_vcf_one_sample_in_new_vcf) {
+TEST(VCFTest, append_vcf_one_sample_in_new_vcf)
+{
     VCF vcf;
     vcf.add_record("chrom1", 5, "A", "G");
     vcf.add_record("chrom1", 46, "T", "TA");
@@ -371,26 +411,33 @@ TEST(VCFTest, append_vcf_one_sample_in_new_vcf) {
     new_vcf.add_sample_gt("sample", "chrom2", 5, "A", "G");
 
     vcf.append_vcf(new_vcf);
-    EXPECT_EQ((uint) 1, vcf.samples.size());
+    EXPECT_EQ((uint)1, vcf.samples.size());
     EXPECT_EQ("sample", vcf.samples[0]);
-    EXPECT_EQ((uint) 1, vcf.records[0]->samples.size());
-    EXPECT_EQ((uint) 1, vcf.records[5]->samples.size());
-    bool found_gt = vcf.records[4]->samples[0].find("GT") != vcf.records[4]->samples[0].end();
+    EXPECT_EQ((uint)1, vcf.records[0]->samples.size());
+    EXPECT_EQ((uint)1, vcf.records[5]->samples.size());
+    bool found_gt
+        = vcf.records[4]->samples[0].find("GT") != vcf.records[4]->samples[0].end();
     EXPECT_TRUE(found_gt);
-    EXPECT_EQ((uint) 1, vcf.records[4]->samples[0]["GT"][0]);
-    found_gt = vcf.records[0]->samples[0].find("GT") != vcf.records[0]->samples[0].end();
+    EXPECT_EQ((uint)1, vcf.records[4]->samples[0]["GT"][0]);
+    found_gt
+        = vcf.records[0]->samples[0].find("GT") != vcf.records[0]->samples[0].end();
     EXPECT_FALSE(found_gt);
-    found_gt = vcf.records[1]->samples[0].find("GT") != vcf.records[1]->samples[0].end();
+    found_gt
+        = vcf.records[1]->samples[0].find("GT") != vcf.records[1]->samples[0].end();
     EXPECT_FALSE(found_gt);
-    found_gt = vcf.records[2]->samples[0].find("GT") != vcf.records[2]->samples[0].end();
+    found_gt
+        = vcf.records[2]->samples[0].find("GT") != vcf.records[2]->samples[0].end();
     EXPECT_FALSE(found_gt);
-    found_gt = vcf.records[3]->samples[0].find("GT") != vcf.records[3]->samples[0].end();
+    found_gt
+        = vcf.records[3]->samples[0].find("GT") != vcf.records[3]->samples[0].end();
     EXPECT_FALSE(found_gt);
-    found_gt = vcf.records[5]->samples[0].find("GT") != vcf.records[5]->samples[0].end();
+    found_gt
+        = vcf.records[5]->samples[0].find("GT") != vcf.records[5]->samples[0].end();
     EXPECT_FALSE(found_gt);
 }
 
-TEST(VCFTest, append_vcf_shared_sample) {
+TEST(VCFTest, append_vcf_shared_sample)
+{
     VCF vcf;
     vcf.add_record("chrom1", 5, "A", "G");
     vcf.add_record("chrom1", 46, "T", "TA");
@@ -406,26 +453,33 @@ TEST(VCFTest, append_vcf_shared_sample) {
     new_vcf.add_sample_gt("sample", "chrom1", 46, "T", "TA");
 
     vcf.append_vcf(new_vcf);
-    EXPECT_EQ((uint) 1, vcf.samples.size());
+    EXPECT_EQ((uint)1, vcf.samples.size());
     EXPECT_EQ("sample", vcf.samples[0]);
-    EXPECT_EQ((uint) 1, vcf.records[0]->samples.size());
-    EXPECT_EQ((uint) 1, vcf.records[5]->samples.size());
-    bool found_gt = vcf.records[1]->samples[0].find("GT") != vcf.records[1]->samples[0].end();
+    EXPECT_EQ((uint)1, vcf.records[0]->samples.size());
+    EXPECT_EQ((uint)1, vcf.records[5]->samples.size());
+    bool found_gt
+        = vcf.records[1]->samples[0].find("GT") != vcf.records[1]->samples[0].end();
     EXPECT_TRUE(found_gt);
-    EXPECT_EQ((uint) 1, vcf.records[1]->samples[0]["GT"][0]);
-    found_gt = vcf.records[0]->samples[0].find("GT") != vcf.records[0]->samples[0].end();
+    EXPECT_EQ((uint)1, vcf.records[1]->samples[0]["GT"][0]);
+    found_gt
+        = vcf.records[0]->samples[0].find("GT") != vcf.records[0]->samples[0].end();
     EXPECT_FALSE(found_gt);
-    found_gt = vcf.records[4]->samples[0].find("GT") != vcf.records[4]->samples[0].end();
+    found_gt
+        = vcf.records[4]->samples[0].find("GT") != vcf.records[4]->samples[0].end();
     EXPECT_FALSE(found_gt);
-    found_gt = vcf.records[2]->samples[0].find("GT") != vcf.records[2]->samples[0].end();
+    found_gt
+        = vcf.records[2]->samples[0].find("GT") != vcf.records[2]->samples[0].end();
     EXPECT_FALSE(found_gt);
-    found_gt = vcf.records[3]->samples[0].find("GT") != vcf.records[3]->samples[0].end();
+    found_gt
+        = vcf.records[3]->samples[0].find("GT") != vcf.records[3]->samples[0].end();
     EXPECT_FALSE(found_gt);
-    found_gt = vcf.records[5]->samples[0].find("GT") != vcf.records[5]->samples[0].end();
+    found_gt
+        = vcf.records[5]->samples[0].find("GT") != vcf.records[5]->samples[0].end();
     EXPECT_FALSE(found_gt);
 }
 
-TEST(VCFTest, append_vcf_shared_samples_different_order) {
+TEST(VCFTest, append_vcf_shared_samples_different_order)
+{
     VCF vcf;
     vcf.add_record("chrom1", 5, "A", "G");
     vcf.add_record("chrom1", 46, "T", "TA");
@@ -444,42 +498,55 @@ TEST(VCFTest, append_vcf_shared_samples_different_order) {
 
     vcf.append_vcf(new_vcf);
 
-    EXPECT_EQ((uint) 2, vcf.samples.size());
-    vector<string> v = {"sample", "sample1"};
+    EXPECT_EQ((uint)2, vcf.samples.size());
+    vector<string> v = { "sample", "sample1" };
     EXPECT_ITERABLE_EQ(vector<string>, v, vcf.samples);
-    EXPECT_EQ((uint) 2, vcf.records[0]->samples.size());
-    EXPECT_EQ((uint) 2, vcf.records[1]->samples.size());
-    EXPECT_EQ((uint) 2, vcf.records[2]->samples.size());
-    EXPECT_EQ((uint) 2, vcf.records[3]->samples.size());
-    EXPECT_EQ((uint) 2, vcf.records[4]->samples.size());
-    EXPECT_EQ((uint) 2, vcf.records[5]->samples.size());
+    EXPECT_EQ((uint)2, vcf.records[0]->samples.size());
+    EXPECT_EQ((uint)2, vcf.records[1]->samples.size());
+    EXPECT_EQ((uint)2, vcf.records[2]->samples.size());
+    EXPECT_EQ((uint)2, vcf.records[3]->samples.size());
+    EXPECT_EQ((uint)2, vcf.records[4]->samples.size());
+    EXPECT_EQ((uint)2, vcf.records[5]->samples.size());
 
-    vector<uint16_t> alt_gt = {1};
-    vector<uint16_t> ref_gt = {0};
+    vector<uint16_t> alt_gt = { 1 };
+    vector<uint16_t> ref_gt = { 0 };
 
-    EXPECT_FALSE(vcf.records[0]->samples[0].find("GT") != vcf.records[0]->samples[0].end());
-    EXPECT_FALSE(vcf.records[0]->samples[1].find("GT") != vcf.records[0]->samples[1].end());
+    EXPECT_FALSE(
+        vcf.records[0]->samples[0].find("GT") != vcf.records[0]->samples[0].end());
+    EXPECT_FALSE(
+        vcf.records[0]->samples[1].find("GT") != vcf.records[0]->samples[1].end());
 
-    EXPECT_TRUE(vcf.records[1]->samples[0].find("GT") != vcf.records[1]->samples[0].end());
-    EXPECT_TRUE(vcf.records[1]->samples[1].find("GT") != vcf.records[1]->samples[1].end());
+    EXPECT_TRUE(
+        vcf.records[1]->samples[0].find("GT") != vcf.records[1]->samples[0].end());
+    EXPECT_TRUE(
+        vcf.records[1]->samples[1].find("GT") != vcf.records[1]->samples[1].end());
     EXPECT_ITERABLE_EQ(vector<uint16_t>, vcf.records[1]->samples[0]["GT"], alt_gt);
     EXPECT_ITERABLE_EQ(vector<uint16_t>, vcf.records[1]->samples[1]["GT"], ref_gt);
 
-    EXPECT_FALSE(vcf.records[2]->samples[0].find("GT") != vcf.records[2]->samples[0].end());
-    EXPECT_FALSE(vcf.records[2]->samples[1].find("GT") != vcf.records[2]->samples[1].end());
+    EXPECT_FALSE(
+        vcf.records[2]->samples[0].find("GT") != vcf.records[2]->samples[0].end());
+    EXPECT_FALSE(
+        vcf.records[2]->samples[1].find("GT") != vcf.records[2]->samples[1].end());
 
-    EXPECT_FALSE(vcf.records[3]->samples[0].find("GT") != vcf.records[3]->samples[0].end());
-    EXPECT_TRUE(vcf.records[3]->samples[1].find("GT") != vcf.records[3]->samples[1].end());
+    EXPECT_FALSE(
+        vcf.records[3]->samples[0].find("GT") != vcf.records[3]->samples[0].end());
+    EXPECT_TRUE(
+        vcf.records[3]->samples[1].find("GT") != vcf.records[3]->samples[1].end());
     EXPECT_ITERABLE_EQ(vector<uint16_t>, vcf.records[3]->samples[1]["GT"], alt_gt);
 
-    EXPECT_FALSE(vcf.records[4]->samples[0].find("GT") != vcf.records[4]->samples[0].end());
-    EXPECT_FALSE(vcf.records[4]->samples[1].find("GT") != vcf.records[4]->samples[1].end());
+    EXPECT_FALSE(
+        vcf.records[4]->samples[0].find("GT") != vcf.records[4]->samples[0].end());
+    EXPECT_FALSE(
+        vcf.records[4]->samples[1].find("GT") != vcf.records[4]->samples[1].end());
 
-    EXPECT_FALSE(vcf.records[5]->samples[0].find("GT") != vcf.records[5]->samples[0].end());
-    EXPECT_FALSE(vcf.records[5]->samples[1].find("GT") != vcf.records[5]->samples[1].end());
+    EXPECT_FALSE(
+        vcf.records[5]->samples[0].find("GT") != vcf.records[5]->samples[0].end());
+    EXPECT_FALSE(
+        vcf.records[5]->samples[1].find("GT") != vcf.records[5]->samples[1].end());
 }
 
-TEST(VCFTest, sort_records) {
+TEST(VCFTest, sort_records)
+{
     VCF vcf;
     vcf.add_record("chrom1", 5, "A", "G");
     vcf.add_record("chrom1", 79, "C", "G");
@@ -492,24 +559,25 @@ TEST(VCFTest, sort_records) {
     vcf.add_record("chrom2", 79, "C", "G");
     vcf.sort_records();
 
-    EXPECT_EQ((uint) 6, vcf.records.size());
+    EXPECT_EQ((uint)6, vcf.records.size());
     for (uint i = 0; i < 4; ++i) {
         EXPECT_EQ("chrom1", vcf.records[i]->chrom);
     }
     for (uint i = 4; i < 6; ++i) {
         EXPECT_EQ("chrom2", vcf.records[i]->chrom);
     }
-    EXPECT_EQ((uint) 5, vcf.records[0]->pos);
-    EXPECT_EQ((uint) 5, vcf.records[4]->pos);
-    EXPECT_EQ((uint) 46, vcf.records[1]->pos);
-    EXPECT_EQ((uint) 79, vcf.records[2]->pos);
-    EXPECT_EQ((uint) 79, vcf.records[3]->pos);
-    EXPECT_EQ((uint) 79, vcf.records[5]->pos);
+    EXPECT_EQ((uint)5, vcf.records[0]->pos);
+    EXPECT_EQ((uint)5, vcf.records[4]->pos);
+    EXPECT_EQ((uint)46, vcf.records[1]->pos);
+    EXPECT_EQ((uint)79, vcf.records[2]->pos);
+    EXPECT_EQ((uint)79, vcf.records[3]->pos);
+    EXPECT_EQ((uint)79, vcf.records[5]->pos);
     EXPECT_EQ("G", vcf.records[3]->alt[0]);
     EXPECT_EQ("G", vcf.records[5]->alt[0]);
 }
 
-TEST(VCFTest, pos_in_range) {
+TEST(VCFTest, pos_in_range)
+{
     VCF vcf;
     vcf.add_record("chrom1", 5, "A", "G");
     vcf.add_record("chrom1", 79, "C", "G");
@@ -517,7 +585,7 @@ TEST(VCFTest, pos_in_range) {
     vcf.add_record("chrom1", 46, "T", "TA");
     vcf.add_record("chrom2", 20, "A", "G");
     vcf.add_record("chrom2", 79, "C", "G");
-    //vcf.sort();
+    // vcf.sort();
 
     EXPECT_TRUE(vcf.pos_in_range(4, 6, "chrom1"));
     EXPECT_FALSE(vcf.pos_in_range(5, 6, "chrom1"));
@@ -533,10 +601,10 @@ TEST(VCFTest, pos_in_range) {
     EXPECT_FALSE(vcf.pos_in_range(79, 80, "chrom1"));
     EXPECT_FALSE(vcf.pos_in_range(78, 79, "chrom1"));
     EXPECT_TRUE(vcf.pos_in_range(78, 80, "chrom2"));
-
 }
 
-TEST(VCFTest, genotype) {
+TEST(VCFTest, genotype)
+{
     // not a snp site
     // missing count data
     // not confident
@@ -562,92 +630,96 @@ TEST(VCFTest, genotype) {
     vcf.add_sample_gt("asample", "chrom2", 80, "A", "A");
 
     vcf.sort_records();
-    std::vector<float> f = {0.0, 0.0};
+    std::vector<float> f = { 0.0, 0.0 };
 
     // record 0, not a snp site
-    vcf.records[0]->samples[0]["MEAN_FWD_COVG"] = {0, 10};
-    vcf.records[0]->samples[0]["MEAN_REV_COVG"] = {1, 20};
-    vcf.records[0]->samples[1]["MEAN_FWD_COVG"] = {1, 15};
-    vcf.records[0]->samples[1]["MEAN_REV_COVG"] = {2, 24};
-    vcf.records[0]->set_format(0,"GAPS", f);
-    vcf.records[0]->set_format(1,"GAPS", f);
-
+    vcf.records[0]->samples[0]["MEAN_FWD_COVG"] = { 0, 10 };
+    vcf.records[0]->samples[0]["MEAN_REV_COVG"] = { 1, 20 };
+    vcf.records[0]->samples[1]["MEAN_FWD_COVG"] = { 1, 15 };
+    vcf.records[0]->samples[1]["MEAN_REV_COVG"] = { 2, 24 };
+    vcf.records[0]->set_format(0, "GAPS", f);
+    vcf.records[0]->set_format(1, "GAPS", f);
 
     // record 1, different genotypes but both correct
-    vcf.records[1]->samples[0]["MEAN_FWD_COVG"] = {0, 10};
-    vcf.records[1]->samples[0]["MEAN_REV_COVG"] = {1, 20};
-    vcf.records[1]->samples[1]["MEAN_FWD_COVG"] = {10, 1};
-    vcf.records[1]->samples[1]["MEAN_REV_COVG"] = {21, 2};
-    vcf.records[1]->set_format(0,"GAPS", f);
-    vcf.records[1]->set_format(1,"GAPS", f);
+    vcf.records[1]->samples[0]["MEAN_FWD_COVG"] = { 0, 10 };
+    vcf.records[1]->samples[0]["MEAN_REV_COVG"] = { 1, 20 };
+    vcf.records[1]->samples[1]["MEAN_FWD_COVG"] = { 10, 1 };
+    vcf.records[1]->samples[1]["MEAN_REV_COVG"] = { 21, 2 };
+    vcf.records[1]->set_format(0, "GAPS", f);
+    vcf.records[1]->set_format(1, "GAPS", f);
 
     // record 2, same genotypes first correct
-    vcf.records[2]->samples[0]["MEAN_FWD_COVG"] = {0, 10};
-    vcf.records[2]->samples[0]["MEAN_REV_COVG"] = {1, 20};
-    vcf.records[2]->samples[1]["MEAN_FWD_COVG"] = {10, 1};
-    vcf.records[2]->samples[1]["MEAN_REV_COVG"] = {21, 2};
-    vcf.records[2]->set_format(0,"GAPS", f);
-    vcf.records[2]->set_format(1,"GAPS", f);
+    vcf.records[2]->samples[0]["MEAN_FWD_COVG"] = { 0, 10 };
+    vcf.records[2]->samples[0]["MEAN_REV_COVG"] = { 1, 20 };
+    vcf.records[2]->samples[1]["MEAN_FWD_COVG"] = { 10, 1 };
+    vcf.records[2]->samples[1]["MEAN_REV_COVG"] = { 21, 2 };
+    vcf.records[2]->set_format(0, "GAPS", f);
+    vcf.records[2]->set_format(1, "GAPS", f);
 
     // record 3, same genotypes both wrong
-    vcf.records[3]->samples[0]["MEAN_FWD_COVG"] = {20, 1};
-    vcf.records[3]->samples[0]["MEAN_REV_COVG"] = {21, 2};
-    vcf.records[3]->samples[1]["MEAN_FWD_COVG"] = {10, 1};
-    vcf.records[3]->samples[1]["MEAN_REV_COVG"] = {21, 2};
-    vcf.records[3]->set_format(0,"GAPS", f);
-    vcf.records[3]->set_format(1,"GAPS", f);
+    vcf.records[3]->samples[0]["MEAN_FWD_COVG"] = { 20, 1 };
+    vcf.records[3]->samples[0]["MEAN_REV_COVG"] = { 21, 2 };
+    vcf.records[3]->samples[1]["MEAN_FWD_COVG"] = { 10, 1 };
+    vcf.records[3]->samples[1]["MEAN_REV_COVG"] = { 21, 2 };
+    vcf.records[3]->set_format(0, "GAPS", f);
+    vcf.records[3]->set_format(1, "GAPS", f);
 
     // record 4, missing count data for first sample
-    vcf.records[4]->samples[0]["MEAN_FWD_COVG"] = {0, 10};
-    vcf.records[4]->samples[0]["MEAN_REV_COVG"] = {20};
-    vcf.records[4]->samples[1]["MEAN_FWD_COVG"] = {10, 1};
-    vcf.records[4]->samples[1]["MEAN_REV_COVG"] = {21, 2};
-    vcf.records[4]->set_format(0,"GAPS", f);
-    vcf.records[4]->set_format(1,"GAPS", f);
+    vcf.records[4]->samples[0]["MEAN_FWD_COVG"] = { 0, 10 };
+    vcf.records[4]->samples[0]["MEAN_REV_COVG"] = { 20 };
+    vcf.records[4]->samples[1]["MEAN_FWD_COVG"] = { 10, 1 };
+    vcf.records[4]->samples[1]["MEAN_REV_COVG"] = { 21, 2 };
+    vcf.records[4]->set_format(0, "GAPS", f);
+    vcf.records[4]->set_format(1, "GAPS", f);
 
     // record 5, not confident for second sample
-    vcf.records[5]->samples[0]["MEAN_FWD_COVG"] = {0, 10};
-    vcf.records[5]->samples[0]["MEAN_REV_COVG"] = {1, 20};
-    vcf.records[5]->samples[1]["MEAN_FWD_COVG"] = {2, 1};
-    vcf.records[5]->samples[1]["MEAN_REV_COVG"] = {4, 2};
-    vcf.records[5]->set_format(0,"GAPS", f);
-    vcf.records[5]->set_format(1,"GAPS", f);
+    vcf.records[5]->samples[0]["MEAN_FWD_COVG"] = { 0, 10 };
+    vcf.records[5]->samples[0]["MEAN_REV_COVG"] = { 1, 20 };
+    vcf.records[5]->samples[1]["MEAN_FWD_COVG"] = { 2, 1 };
+    vcf.records[5]->samples[1]["MEAN_REV_COVG"] = { 4, 2 };
+    vcf.records[5]->set_format(0, "GAPS", f);
+    vcf.records[5]->set_format(1, "GAPS", f);
 
-    vcf.genotype({30, 30}, 0.01, 30, 0, 1, 0, 0, true);
+    vcf.genotype({ 30, 30 }, 0.01, 30, 0, 1, 0, 0, true);
 
     // not genotyped first record
-    EXPECT_EQ((uint16_t) 1, vcf.records[0]->samples[0]["GT"][0]);
-    EXPECT_EQ((uint16_t) 1, vcf.records[0]->samples[1]["GT"][0]);
-    bool found_confidence = vcf.records[0]->regt_samples[0].find("GT_CONF")!=vcf.records[0]->regt_samples[0].end();
+    EXPECT_EQ((uint16_t)1, vcf.records[0]->samples[0]["GT"][0]);
+    EXPECT_EQ((uint16_t)1, vcf.records[0]->samples[1]["GT"][0]);
+    bool found_confidence = vcf.records[0]->regt_samples[0].find("GT_CONF")
+        != vcf.records[0]->regt_samples[0].end();
     EXPECT_FALSE(found_confidence);
-    found_confidence = vcf.records[0]->regt_samples[1].find("GT_CONF")!=vcf.records[0]->regt_samples[1].end();
+    found_confidence = vcf.records[0]->regt_samples[1].find("GT_CONF")
+        != vcf.records[0]->regt_samples[1].end();
     EXPECT_FALSE(found_confidence);
 
     // both correct
-    EXPECT_EQ((uint) 2, vcf.records[1]->samples.size());
-    bool found_gt = vcf.records[1]->samples[0].find("GT") != vcf.records[1]->samples[0].end();
+    EXPECT_EQ((uint)2, vcf.records[1]->samples.size());
+    bool found_gt
+        = vcf.records[1]->samples[0].find("GT") != vcf.records[1]->samples[0].end();
     EXPECT_TRUE(found_gt);
-    found_gt = vcf.records[1]->samples[1].find("GT") != vcf.records[1]->samples[1].end();
+    found_gt
+        = vcf.records[1]->samples[1].find("GT") != vcf.records[1]->samples[1].end();
     EXPECT_TRUE(found_gt);
-    EXPECT_EQ((uint) 1, vcf.records[1]->samples[0]["GT"].size());
-    EXPECT_EQ((uint) 1, vcf.records[1]->samples[1]["GT"].size());
-    EXPECT_EQ((uint16_t) 1, vcf.records[1]->samples[0]["GT"][0]);
-    EXPECT_EQ((uint16_t) 0, vcf.records[1]->samples[1]["GT"][0]);
+    EXPECT_EQ((uint)1, vcf.records[1]->samples[0]["GT"].size());
+    EXPECT_EQ((uint)1, vcf.records[1]->samples[1]["GT"].size());
+    EXPECT_EQ((uint16_t)1, vcf.records[1]->samples[0]["GT"][0]);
+    EXPECT_EQ((uint16_t)0, vcf.records[1]->samples[1]["GT"][0]);
     // first correct
-    EXPECT_EQ((uint16_t) 1, vcf.records[2]->samples[0]["GT"][0]);
-    EXPECT_EQ((uint16_t) 0, vcf.records[2]->samples[1]["GT"][0]);
+    EXPECT_EQ((uint16_t)1, vcf.records[2]->samples[0]["GT"][0]);
+    EXPECT_EQ((uint16_t)0, vcf.records[2]->samples[1]["GT"][0]);
     // both wrong
-    EXPECT_EQ((uint16_t) 0, vcf.records[3]->samples[0]["GT"][0]);
-    EXPECT_EQ((uint16_t) 0, vcf.records[3]->samples[1]["GT"][0]);
+    EXPECT_EQ((uint16_t)0, vcf.records[3]->samples[0]["GT"][0]);
+    EXPECT_EQ((uint16_t)0, vcf.records[3]->samples[1]["GT"][0]);
     // first missing data
-    EXPECT_EQ((uint) 0, vcf.records[4]->samples[0]["GT"].size());
-    EXPECT_EQ((uint16_t) 0, vcf.records[4]->samples[1]["GT"][0]);
+    EXPECT_EQ((uint)0, vcf.records[4]->samples[0]["GT"].size());
+    EXPECT_EQ((uint16_t)0, vcf.records[4]->samples[1]["GT"][0]);
     // second not confident
-    EXPECT_EQ((uint16_t) 1, vcf.records[5]->samples[0]["GT"][0]);
-    EXPECT_EQ((uint) 0, vcf.records[5]->samples[1]["GT"].size());
+    EXPECT_EQ((uint16_t)1, vcf.records[5]->samples[0]["GT"][0]);
+    EXPECT_EQ((uint)0, vcf.records[5]->samples[1]["GT"].size());
 }
 
-TEST(VCFTest, genotype_with_all_sites) {
+TEST(VCFTest, genotype_with_all_sites)
+{
     // not a snp site
     // missing count data
     // not confident
@@ -673,7 +745,7 @@ TEST(VCFTest, genotype_with_all_sites) {
     vcf.add_sample_gt("asample", "chrom2", 80, "AC", "AC");
 
     vcf.sort_records();
-    std::vector<float> f = {0.0, 0.0};
+    std::vector<float> f = { 0.0, 0.0 };
 
     // record 0, not a snp site
     vcf.records[0]->samples[0]["MEAN_FWD_COVG"].push_back(0);
@@ -684,8 +756,8 @@ TEST(VCFTest, genotype_with_all_sites) {
     vcf.records[0]->samples[1]["MEAN_REV_COVG"].push_back(2);
     vcf.records[0]->samples[1]["MEAN_FWD_COVG"].push_back(15);
     vcf.records[0]->samples[1]["MEAN_REV_COVG"].push_back(24);
-    vcf.records[0]->set_format(0,"GAPS", f);
-    vcf.records[0]->set_format(1,"GAPS", f);
+    vcf.records[0]->set_format(0, "GAPS", f);
+    vcf.records[0]->set_format(1, "GAPS", f);
 
     // record 1, different genotypes but both correct
     vcf.records[1]->samples[0]["MEAN_FWD_COVG"].push_back(0);
@@ -696,8 +768,8 @@ TEST(VCFTest, genotype_with_all_sites) {
     vcf.records[1]->samples[1]["MEAN_REV_COVG"].push_back(21);
     vcf.records[1]->samples[1]["MEAN_FWD_COVG"].push_back(1);
     vcf.records[1]->samples[1]["MEAN_REV_COVG"].push_back(2);
-    vcf.records[1]->set_format(0,"GAPS", f);
-    vcf.records[1]->set_format(1,"GAPS", f);
+    vcf.records[1]->set_format(0, "GAPS", f);
+    vcf.records[1]->set_format(1, "GAPS", f);
 
     // record 2, same genotypes first correct
     vcf.records[2]->samples[0]["MEAN_FWD_COVG"].push_back(0);
@@ -708,8 +780,8 @@ TEST(VCFTest, genotype_with_all_sites) {
     vcf.records[2]->samples[1]["MEAN_REV_COVG"].push_back(21);
     vcf.records[2]->samples[1]["MEAN_FWD_COVG"].push_back(1);
     vcf.records[2]->samples[1]["MEAN_REV_COVG"].push_back(2);
-    vcf.records[2]->set_format(0,"GAPS", f);
-    vcf.records[2]->set_format(1,"GAPS", f);
+    vcf.records[2]->set_format(0, "GAPS", f);
+    vcf.records[2]->set_format(1, "GAPS", f);
 
     // record 3, same genotypes both wrong
     vcf.records[3]->samples[0]["MEAN_FWD_COVG"].push_back(20);
@@ -720,8 +792,8 @@ TEST(VCFTest, genotype_with_all_sites) {
     vcf.records[3]->samples[1]["MEAN_REV_COVG"].push_back(21);
     vcf.records[3]->samples[1]["MEAN_FWD_COVG"].push_back(1);
     vcf.records[3]->samples[1]["MEAN_REV_COVG"].push_back(2);
-    vcf.records[3]->set_format(0,"GAPS", f);
-    vcf.records[3]->set_format(1,"GAPS", f);
+    vcf.records[3]->set_format(0, "GAPS", f);
+    vcf.records[3]->set_format(1, "GAPS", f);
 
     // record 4, missing count data for first sample
     vcf.records[4]->samples[0]["MEAN_FWD_COVG"].push_back(0);
@@ -731,8 +803,8 @@ TEST(VCFTest, genotype_with_all_sites) {
     vcf.records[4]->samples[1]["MEAN_REV_COVG"].push_back(21);
     vcf.records[4]->samples[1]["MEAN_FWD_COVG"].push_back(1);
     vcf.records[4]->samples[1]["MEAN_REV_COVG"].push_back(2);
-    vcf.records[4]->set_format(0,"GAPS", f);
-    vcf.records[4]->set_format(1,"GAPS", f);
+    vcf.records[4]->set_format(0, "GAPS", f);
+    vcf.records[4]->set_format(1, "GAPS", f);
 
     // record 5, not confident for second sample
     vcf.records[5]->samples[0]["MEAN_FWD_COVG"].push_back(0);
@@ -743,45 +815,49 @@ TEST(VCFTest, genotype_with_all_sites) {
     vcf.records[5]->samples[1]["MEAN_REV_COVG"].push_back(4);
     vcf.records[5]->samples[1]["MEAN_FWD_COVG"].push_back(1);
     vcf.records[5]->samples[1]["MEAN_REV_COVG"].push_back(2);
-    vcf.records[5]->set_format(0,"GAPS", f);
-    vcf.records[5]->set_format(1,"GAPS", f);
+    vcf.records[5]->set_format(0, "GAPS", f);
+    vcf.records[5]->set_format(1, "GAPS", f);
 
     bool snps_only = false;
-    vcf.genotype({30, 30}, 0.01, 30, 0, 1, 0, 0, snps_only);
+    vcf.genotype({ 30, 30 }, 0.01, 30, 0, 1, 0, 0, snps_only);
 
     // first record now genotyped
-    EXPECT_EQ((uint16_t) 1, vcf.records[0]->samples[0]["GT"][0]);
-    EXPECT_EQ((uint16_t) 1, vcf.records[0]->samples[1]["GT"][0]);
-    bool found_confidence = vcf.records[0]->regt_samples[0].find("GT_CONF")!=vcf.records[0]->regt_samples[0].end();
+    EXPECT_EQ((uint16_t)1, vcf.records[0]->samples[0]["GT"][0]);
+    EXPECT_EQ((uint16_t)1, vcf.records[0]->samples[1]["GT"][0]);
+    bool found_confidence = vcf.records[0]->regt_samples[0].find("GT_CONF")
+        != vcf.records[0]->regt_samples[0].end();
     EXPECT_TRUE(found_confidence);
-    found_confidence = vcf.records[0]->regt_samples[1].find("GT_CONF")!=vcf.records[0]->regt_samples[1].end();
+    found_confidence = vcf.records[0]->regt_samples[1].find("GT_CONF")
+        != vcf.records[0]->regt_samples[1].end();
     EXPECT_TRUE(found_confidence);
     // both correct
-    EXPECT_EQ((uint) 2, vcf.records[1]->samples.size());
-    bool found_gt = vcf.records[1]->samples[0].find("GT") != vcf.records[1]->samples[0].end();
+    EXPECT_EQ((uint)2, vcf.records[1]->samples.size());
+    bool found_gt
+        = vcf.records[1]->samples[0].find("GT") != vcf.records[1]->samples[0].end();
     EXPECT_TRUE(found_gt);
-    found_gt = vcf.records[1]->samples[1].find("GT") != vcf.records[1]->samples[1].end();
+    found_gt
+        = vcf.records[1]->samples[1].find("GT") != vcf.records[1]->samples[1].end();
     EXPECT_TRUE(found_gt);
-    EXPECT_EQ((uint) 1, vcf.records[1]->samples[0]["GT"].size());
-    EXPECT_EQ((uint) 1, vcf.records[1]->samples[1]["GT"].size());
-    EXPECT_EQ((uint16_t) 1, vcf.records[1]->samples[0]["GT"][0]);
-    EXPECT_EQ((uint16_t) 0, vcf.records[1]->samples[1]["GT"][0]);
+    EXPECT_EQ((uint)1, vcf.records[1]->samples[0]["GT"].size());
+    EXPECT_EQ((uint)1, vcf.records[1]->samples[1]["GT"].size());
+    EXPECT_EQ((uint16_t)1, vcf.records[1]->samples[0]["GT"][0]);
+    EXPECT_EQ((uint16_t)0, vcf.records[1]->samples[1]["GT"][0]);
     // first correct
-    EXPECT_EQ((uint16_t) 1, vcf.records[2]->samples[0]["GT"][0]);
-    EXPECT_EQ((uint16_t) 0, vcf.records[2]->samples[1]["GT"][0]);
+    EXPECT_EQ((uint16_t)1, vcf.records[2]->samples[0]["GT"][0]);
+    EXPECT_EQ((uint16_t)0, vcf.records[2]->samples[1]["GT"][0]);
     // both wrong
-    EXPECT_EQ((uint16_t) 0, vcf.records[3]->samples[0]["GT"][0]);
-    EXPECT_EQ((uint16_t) 0, vcf.records[3]->samples[1]["GT"][0]);
+    EXPECT_EQ((uint16_t)0, vcf.records[3]->samples[0]["GT"][0]);
+    EXPECT_EQ((uint16_t)0, vcf.records[3]->samples[1]["GT"][0]);
     // first missing data
-    EXPECT_EQ((uint) 0, vcf.records[4]->samples[0]["GT"].size());
-    EXPECT_EQ((uint16_t) 0, vcf.records[4]->samples[1]["GT"][0]);
+    EXPECT_EQ((uint)0, vcf.records[4]->samples[0]["GT"].size());
+    EXPECT_EQ((uint16_t)0, vcf.records[4]->samples[1]["GT"][0]);
     // second not confident
-    EXPECT_EQ((uint16_t) 1, vcf.records[5]->samples[0]["GT"][0]);
-    EXPECT_EQ((uint) 0, vcf.records[5]->samples[1]["GT"].size());
-
+    EXPECT_EQ((uint16_t)1, vcf.records[5]->samples[0]["GT"][0]);
+    EXPECT_EQ((uint)0, vcf.records[5]->samples[1]["GT"].size());
 }
 
-TEST(VCFTest, clean) {
+TEST(VCFTest, clean)
+{
     VCF vcf;
 
     VCFRecord dummy;
@@ -792,36 +868,40 @@ TEST(VCFTest, clean) {
     vcf.add_sample_gt("sample", "chrom1", 5, "A", "G");
     vcf.add_sample_gt("sample", "chrom1", 79, "C", "A");
     vcf.records[2]->clear();
-    EXPECT_EQ((uint) 5, vcf.records.size());
+    EXPECT_EQ((uint)5, vcf.records.size());
 
     vcf.clean();
-    EXPECT_EQ((uint) 3, vcf.records.size());
-    EXPECT_EQ((uint) 79, vcf.records[0]->pos);
-    EXPECT_EQ((uint) 1, vcf.records[0]->alt.size());
+    EXPECT_EQ((uint)3, vcf.records.size());
+    EXPECT_EQ((uint)79, vcf.records[0]->pos);
+    EXPECT_EQ((uint)1, vcf.records[0]->alt.size());
     EXPECT_EQ("G", vcf.records[0]->alt[0]);
-    EXPECT_EQ((uint) 5, vcf.records[1]->pos);
-    EXPECT_EQ((uint) 79, vcf.records[2]->pos);
-    EXPECT_EQ((uint) 1, vcf.records[2]->alt.size());
+    EXPECT_EQ((uint)5, vcf.records[1]->pos);
+    EXPECT_EQ((uint)79, vcf.records[2]->pos);
+    EXPECT_EQ((uint)1, vcf.records[2]->alt.size());
     EXPECT_EQ("A", vcf.records[2]->alt[0]);
 }
 
-TEST(VCFTest, add_formats) {
+TEST(VCFTest, add_formats)
+{
     VCF vcf;
-    std::vector<std::string> formats = {"GT", "LIKELIHOOD", "GT_CONF", "MEAN_FWD_COVG", "MEAN_REV_COVG", "GAPS"};
+    std::vector<std::string> formats
+        = { "GT", "LIKELIHOOD", "GT_CONF", "MEAN_FWD_COVG", "MEAN_REV_COVG", "GAPS" };
 
     vcf.add_record("chrom1", 5, "A", "G");
     vcf.add_sample_gt("sample", "chrom1", 46, "CTT", "TA");
 
     vcf.add_formats(formats);
 
-    for (const auto& record: vcf.records){
-        for (const auto &f: formats){
-            EXPECT_TRUE(std::find(record->format.begin(), record->format.end(), f)!=record->format.end());
+    for (const auto& record : vcf.records) {
+        for (const auto& f : formats) {
+            EXPECT_TRUE(std::find(record->format.begin(), record->format.end(), f)
+                != record->format.end());
         }
     }
 }
 
-TEST(VCFTest, merge_multi_allelic) {
+TEST(VCFTest, merge_multi_allelic)
+{
     VCF vcf;
     // no gt
     vcf.add_record("chrom1", 5, "A", "G");
@@ -839,66 +919,72 @@ TEST(VCFTest, merge_multi_allelic) {
     unordered_map<string, vector<float>> dummy;
     vcf.records[4]->regt_samples.push_back(dummy);
     vcf.records[5]->regt_samples.push_back(dummy);
-    vcf.records[4]->regt_samples[0]["LIKELIHOOD"] = {-50, -3};
-    vcf.records[5]->regt_samples[0]["LIKELIHOOD"] = {-50, -16};
-    vcf.records[4]->regt_samples[0]["GT_CONF"] = {47};
-    vcf.records[5]->regt_samples[0]["GT_CONF"] = {56};
-    vcf.records[4]->samples[0]["MEAN_FWD_COVG"] = {2, 30};
-    vcf.records[5]->samples[0]["MEAN_FWD_COVG"] = {2, 30};
-    vcf.records[4]->samples[0]["MEAN_REV_COVG"] = {2, 30};
-    vcf.records[5]->samples[0]["MEAN_REV_COVG"] = {2, 30};
-    vcf.records[4]->regt_samples[0]["GAPS"] = {4, 0};
-    vcf.records[5]->regt_samples[0]["GAPS"] = {4, 1};
+    vcf.records[4]->regt_samples[0]["LIKELIHOOD"] = { -50, -3 };
+    vcf.records[5]->regt_samples[0]["LIKELIHOOD"] = { -50, -16 };
+    vcf.records[4]->regt_samples[0]["GT_CONF"] = { 47 };
+    vcf.records[5]->regt_samples[0]["GT_CONF"] = { 56 };
+    vcf.records[4]->samples[0]["MEAN_FWD_COVG"] = { 2, 30 };
+    vcf.records[5]->samples[0]["MEAN_FWD_COVG"] = { 2, 30 };
+    vcf.records[4]->samples[0]["MEAN_REV_COVG"] = { 2, 30 };
+    vcf.records[5]->samples[0]["MEAN_REV_COVG"] = { 2, 30 };
+    vcf.records[4]->regt_samples[0]["GAPS"] = { 4, 0 };
+    vcf.records[5]->regt_samples[0]["GAPS"] = { 4, 1 };
     // incompatible
     vcf.add_record("chrom1", 85, "A", "G");
     vcf.add_record("chrom1", 85, "T", "C");
 
     vcf.merge_multi_allelic();
-    std::vector<std::string> formats = {"GT", "LIKELIHOOD", "GT_CONF", "MEAN_FWD_COVG", "MEAN_REV_COVG", "GAPS"};
+    std::vector<std::string> formats
+        = { "GT", "LIKELIHOOD", "GT_CONF", "MEAN_FWD_COVG", "MEAN_REV_COVG", "GAPS" };
     vcf.add_formats(formats);
 
-    EXPECT_EQ((uint) 5, vcf.records.size());
-    EXPECT_EQ((uint) 5, vcf.records[0]->pos);
-    EXPECT_EQ((uint) 2, vcf.records[0]->alt.size());
-    EXPECT_EQ((uint) 1, vcf.records[0]->samples.size());
-    EXPECT_EQ((uint) 0, vcf.records[0]->samples[0].size());
+    EXPECT_EQ((uint)5, vcf.records.size());
+    EXPECT_EQ((uint)5, vcf.records[0]->pos);
+    EXPECT_EQ((uint)2, vcf.records[0]->alt.size());
+    EXPECT_EQ((uint)1, vcf.records[0]->samples.size());
+    EXPECT_EQ((uint)0, vcf.records[0]->samples[0].size());
 
-    EXPECT_EQ((uint) 46, vcf.records[1]->pos);
-    EXPECT_EQ((uint) 2, vcf.records[1]->alt.size());
-    EXPECT_EQ((uint) 1, vcf.records[1]->samples.size());
-    bool found_gt = vcf.records[1]->samples[0].find("GT") != vcf.records[1]->samples[0].end();
+    EXPECT_EQ((uint)46, vcf.records[1]->pos);
+    EXPECT_EQ((uint)2, vcf.records[1]->alt.size());
+    EXPECT_EQ((uint)1, vcf.records[1]->samples.size());
+    bool found_gt
+        = vcf.records[1]->samples[0].find("GT") != vcf.records[1]->samples[0].end();
     EXPECT_TRUE(found_gt);
-    EXPECT_EQ((uint) 0, vcf.records[1]->samples[0]["GT"].size());
+    EXPECT_EQ((uint)0, vcf.records[1]->samples[0]["GT"].size());
 
-    EXPECT_EQ((uint) 76, vcf.records[2]->pos);
-    EXPECT_EQ((uint) 2, vcf.records[2]->alt.size());
-    EXPECT_EQ((uint) 1, vcf.records[2]->samples.size());
-    found_gt = vcf.records[2]->samples[0].find("GT") != vcf.records[2]->samples[0].end();
+    EXPECT_EQ((uint)76, vcf.records[2]->pos);
+    EXPECT_EQ((uint)2, vcf.records[2]->alt.size());
+    EXPECT_EQ((uint)1, vcf.records[2]->samples.size());
+    found_gt
+        = vcf.records[2]->samples[0].find("GT") != vcf.records[2]->samples[0].end();
     EXPECT_TRUE(found_gt);
-    EXPECT_EQ((uint) 1, vcf.records[2]->samples[0]["GT"][0]);
-    EXPECT_EQ((uint) 3, vcf.records[2]->regt_samples[0].size());
-    bool found = vcf.records[2]->regt_samples[0].find("LIKELIHOOD") != vcf.records[2]->regt_samples[0].end();
+    EXPECT_EQ((uint)1, vcf.records[2]->samples[0]["GT"][0]);
+    EXPECT_EQ((uint)3, vcf.records[2]->regt_samples[0].size());
+    bool found = vcf.records[2]->regt_samples[0].find("LIKELIHOOD")
+        != vcf.records[2]->regt_samples[0].end();
     EXPECT_TRUE(found);
-    EXPECT_EQ((uint) 3, vcf.records[2]->regt_samples[0]["LIKELIHOOD"].size());
+    EXPECT_EQ((uint)3, vcf.records[2]->regt_samples[0]["LIKELIHOOD"].size());
     EXPECT_EQ(-50.0, vcf.records[2]->regt_samples[0]["LIKELIHOOD"][0]);
     EXPECT_EQ(-3.0, vcf.records[2]->regt_samples[0]["LIKELIHOOD"][1]);
     EXPECT_EQ(-16.0, vcf.records[2]->regt_samples[0]["LIKELIHOOD"][2]);
-    EXPECT_EQ((uint) 3, vcf.records[2]->regt_samples[0]["GAPS"].size());
+    EXPECT_EQ((uint)3, vcf.records[2]->regt_samples[0]["GAPS"].size());
     EXPECT_EQ(4, vcf.records[2]->regt_samples[0]["GAPS"][0]);
     EXPECT_EQ(0, vcf.records[2]->regt_samples[0]["GAPS"][1]);
     EXPECT_EQ(1, vcf.records[2]->regt_samples[0]["GAPS"][2]);
-    found = vcf.records[2]->regt_samples[0].find("GT_CONF") != vcf.records[2]->regt_samples[0].end();
+    found = vcf.records[2]->regt_samples[0].find("GT_CONF")
+        != vcf.records[2]->regt_samples[0].end();
     EXPECT_TRUE(found);
-    EXPECT_EQ((uint) 1, vcf.records[2]->regt_samples[0]["GT_CONF"].size());
+    EXPECT_EQ((uint)1, vcf.records[2]->regt_samples[0]["GT_CONF"].size());
     EXPECT_EQ(13.0, vcf.records[2]->regt_samples[0]["GT_CONF"][0]);
 
-    EXPECT_EQ((uint) 85, vcf.records[3]->pos);
-    EXPECT_EQ((uint) 1, vcf.records[3]->alt.size());
-    EXPECT_EQ((uint) 85, vcf.records[4]->pos);
-    EXPECT_EQ((uint) 1, vcf.records[4]->alt.size());
+    EXPECT_EQ((uint)85, vcf.records[3]->pos);
+    EXPECT_EQ((uint)1, vcf.records[3]->alt.size());
+    EXPECT_EQ((uint)85, vcf.records[4]->pos);
+    EXPECT_EQ((uint)1, vcf.records[4]->alt.size());
 }
 
-TEST(VCFTest, correct_dot_alleles) {
+TEST(VCFTest, correct_dot_alleles)
+{
     VCF vcf;
     // at start
     vcf.add_sample_gt("sample", "chrom1", 0, ".", "TA");
@@ -913,11 +999,11 @@ TEST(VCFTest, correct_dot_alleles) {
     vcf.add_sample_gt("sample", "chrom2", 44, ".", "TA");
 
     string vcf_ref = "TATATGTGTC"
-            "GCGACACTGC"
-            "ATGCATGCAT"
-            "AGTCCTAAAG"
-            "TCCTTAAACG"
-            "TTTATAGTCG";
+                     "GCGACACTGC"
+                     "ATGCATGCAT"
+                     "AGTCCTAAAG"
+                     "TCCTTAAACG"
+                     "TTTATAGTCG";
 
     vcf.correct_dot_alleles(vcf_ref, "chrom1");
     vcf.correct_dot_alleles(vcf_ref, "chrom2");
@@ -949,7 +1035,8 @@ TEST(VCFTest, correct_dot_alleles) {
     EXPECT_EQ(vcf.records[7]->alt[0], "TTA");
 }
 
-TEST(VCFTest, make_gt_compatible) {
+TEST(VCFTest, make_gt_compatible)
+{
     VCF vcf;
     // no gt
     vcf.add_record("chrom1", 5, "A", "G");
@@ -967,50 +1054,53 @@ TEST(VCFTest, make_gt_compatible) {
     unordered_map<string, vector<float>> dummy;
     vcf.records[4]->regt_samples.push_back(dummy);
     vcf.records[5]->regt_samples.push_back(dummy);
-    vcf.records[4]->regt_samples[0]["LIKELIHOOD"] = {-50, -3};
-    vcf.records[5]->regt_samples[0]["LIKELIHOOD"] = {-50, -16};
-    vcf.records[4]->regt_samples[0]["GT_CONF"] = {47};
-    vcf.records[5]->regt_samples[0]["GT_CONF"] = {56};
+    vcf.records[4]->regt_samples[0]["LIKELIHOOD"] = { -50, -3 };
+    vcf.records[5]->regt_samples[0]["LIKELIHOOD"] = { -50, -16 };
+    vcf.records[4]->regt_samples[0]["GT_CONF"] = { 47 };
+    vcf.records[5]->regt_samples[0]["GT_CONF"] = { 56 };
     // gt incompatible one ref, ref correct
     vcf.add_record("chrom1", 85, "A", "G");
     vcf.add_record("chrom1", 85, "A", "C");
     vcf.add_sample_gt("sample", "chrom1", 85, "A", "A");
-    vcf.records[6]->samples[0]["GT"] = {1};
+    vcf.records[6]->samples[0]["GT"] = { 1 };
     vcf.records[6]->regt_samples.push_back(dummy);
     vcf.records[7]->regt_samples.push_back(dummy);
-    vcf.records[6]->regt_samples[0]["LIKELIHOOD"] = {-5, -30};
-    vcf.records[7]->regt_samples[0]["LIKELIHOOD"] = {-5, -16};
-    vcf.records[6]->regt_samples[0]["GT_CONF"] = {47};
-    vcf.records[7]->regt_samples[0]["GT_CONF"] = {56};
+    vcf.records[6]->regt_samples[0]["LIKELIHOOD"] = { -5, -30 };
+    vcf.records[7]->regt_samples[0]["LIKELIHOOD"] = { -5, -16 };
+    vcf.records[6]->regt_samples[0]["GT_CONF"] = { 47 };
+    vcf.records[7]->regt_samples[0]["GT_CONF"] = { 56 };
     // gt incompatible one ref, ref wrong
     vcf.add_record("chrom1", 95, "A", "G");
     vcf.add_record("chrom1", 95, "A", "C");
     vcf.add_sample_gt("sample", "chrom1", 95, "A", "A");
-    vcf.records[8]->samples[0]["GT"] = {1};
+    vcf.records[8]->samples[0]["GT"] = { 1 };
     vcf.records[8]->regt_samples.push_back(dummy);
     vcf.records[9]->regt_samples.push_back(dummy);
-    vcf.records[8]->regt_samples[0]["LIKELIHOOD"] = {-50, -3};
-    vcf.records[9]->regt_samples[0]["LIKELIHOOD"] = {-50, -60};
-    vcf.records[8]->regt_samples[0]["GT_CONF"] = {47};
-    vcf.records[9]->regt_samples[0]["GT_CONF"] = {10};
+    vcf.records[8]->regt_samples[0]["LIKELIHOOD"] = { -50, -3 };
+    vcf.records[9]->regt_samples[0]["LIKELIHOOD"] = { -50, -60 };
+    vcf.records[8]->regt_samples[0]["GT_CONF"] = { 47 };
+    vcf.records[9]->regt_samples[0]["GT_CONF"] = { 10 };
 
     vcf.make_gt_compatible();
 
-    bool found_gt = vcf.records[0]->samples[0].find("GT") != vcf.records[0]->samples[0].end();
+    bool found_gt
+        = vcf.records[0]->samples[0].find("GT") != vcf.records[0]->samples[0].end();
     EXPECT_FALSE(found_gt);
-    found_gt = vcf.records[1]->samples[0].find("GT") != vcf.records[1]->samples[0].end();
+    found_gt
+        = vcf.records[1]->samples[0].find("GT") != vcf.records[1]->samples[0].end();
     EXPECT_FALSE(found_gt);
-    EXPECT_EQ((uint) 0, vcf.records[2]->samples[0]["GT"].size());
-    EXPECT_EQ((uint) 0, vcf.records[3]->samples[0]["GT"].size());
-    EXPECT_EQ((uint16_t) 1, vcf.records[4]->samples[0]["GT"][0]);
-    EXPECT_EQ((uint) 0, vcf.records[5]->samples[0]["GT"].size());
-    EXPECT_EQ((uint16_t) 0, vcf.records[6]->samples[0]["GT"][0]);
-    EXPECT_EQ((uint16_t) 0, vcf.records[7]->samples[0]["GT"][0]);
-    EXPECT_EQ((uint16_t) 1, vcf.records[8]->samples[0]["GT"][0]);
-    EXPECT_EQ((uint16_t) 0, vcf.records[9]->samples[0]["GT"].size());
+    EXPECT_EQ((uint)0, vcf.records[2]->samples[0]["GT"].size());
+    EXPECT_EQ((uint)0, vcf.records[3]->samples[0]["GT"].size());
+    EXPECT_EQ((uint16_t)1, vcf.records[4]->samples[0]["GT"][0]);
+    EXPECT_EQ((uint)0, vcf.records[5]->samples[0]["GT"].size());
+    EXPECT_EQ((uint16_t)0, vcf.records[6]->samples[0]["GT"][0]);
+    EXPECT_EQ((uint16_t)0, vcf.records[7]->samples[0]["GT"][0]);
+    EXPECT_EQ((uint16_t)1, vcf.records[8]->samples[0]["GT"][0]);
+    EXPECT_EQ((uint16_t)0, vcf.records[9]->samples[0]["GT"].size());
 }
 
-TEST(VCFTest, equals) {
+TEST(VCFTest, equals)
+{
     VCF vcf;
     vcf.add_record("chrom1", 5, "A", "G");
     vcf.add_record("chrom1", 46, "T", "TA");
@@ -1048,7 +1138,8 @@ TEST(VCFTest, equals) {
     EXPECT_EQ((vcf3 == vcf), false);
 }
 
-TEST(VCFTest, save) {
+TEST(VCFTest, save)
+{
     VCF vcf;
     vcf.add_record("chrom1", 5, "A", "G");
     vcf.add_record("chrom1", 46, "T", "TA");
@@ -1061,7 +1152,8 @@ TEST(VCFTest, save) {
     vcf.save("vcf_test.vcf");
 }
 
-TEST(VCFTest, load) {
+TEST(VCFTest, load)
+{
     VCF vcf, vcf1;
     vcf.add_record("chrom1", 5, "A", "G");
     vcf.add_record("chrom1", 46, "T", "TA");
@@ -1076,7 +1168,8 @@ TEST(VCFTest, load) {
     EXPECT_EQ(vcf == vcf1, true);
 }
 
-TEST(VCFTest, filter) {
+TEST(VCFTest, filter)
+{
     VCF vcf, vcf1, vcf2, vcf3, vcf4;
     vcf.add_record("chrom1", 5, "A", "G", "SVTYPE=SNP;GRAPHTYPE=SIMPLE");
     vcf.add_record("chrom1", 46, "T", "TA", "SVTYPE=INDEL;GRAPHTYPE=NESTED");

--- a/test/vcfrecord_test.cpp
+++ b/test/vcfrecord_test.cpp
@@ -1,239 +1,251 @@
-#include "gtest/gtest.h"
 #include "test_macro.cpp"
 #include "vcfrecord.h"
-#include <stdint.h>
-#include <iostream>
+#include "gtest/gtest.h"
 #include <cmath>
-
+#include <iostream>
+#include <stdint.h>
 
 using namespace std;
 
-TEST(VCFRecordTest, create_empty) {
+TEST(VCFRecordTest, create_empty)
+{
 
     VCFRecord vr;
     EXPECT_EQ(".", vr.chrom);
-    EXPECT_EQ((uint) 0, vr.pos);
+    EXPECT_EQ((uint)0, vr.pos);
     EXPECT_EQ(".", vr.id);
     EXPECT_EQ(".", vr.ref);
-    EXPECT_EQ((uint) 0, vr.alt.size());
+    EXPECT_EQ((uint)0, vr.alt.size());
     EXPECT_EQ(".", vr.qual);
     EXPECT_EQ(".", vr.filter);
     EXPECT_EQ(".", vr.info);
-    EXPECT_EQ((uint) 0, vr.format.size());
-    EXPECT_EQ((uint) 0, vr.samples.size());
-    EXPECT_EQ((uint) 0, vr.regt_samples.size());
+    EXPECT_EQ((uint)0, vr.format.size());
+    EXPECT_EQ((uint)0, vr.samples.size());
+    EXPECT_EQ((uint)0, vr.regt_samples.size());
 }
 
-TEST(VCFRecordTest, create_with_values) {
+TEST(VCFRecordTest, create_with_values)
+{
 
     VCFRecord vr("chrom1", 3, "A", "T");
     EXPECT_EQ("chrom1", vr.chrom);
-    EXPECT_EQ((uint) 3, vr.pos);
+    EXPECT_EQ((uint)3, vr.pos);
     EXPECT_EQ(".", vr.id);
     EXPECT_EQ("A", vr.ref);
     EXPECT_EQ("T", vr.alt[0]);
     EXPECT_EQ(".", vr.qual);
     EXPECT_EQ(".", vr.filter);
     EXPECT_EQ("SVTYPE=SNP", vr.info);
-    EXPECT_EQ((uint) 1, vr.format.size());
-    EXPECT_EQ((uint) 0, vr.samples.size());
-    EXPECT_EQ((uint) 0, vr.regt_samples.size());
+    EXPECT_EQ((uint)1, vr.format.size());
+    EXPECT_EQ((uint)0, vr.samples.size());
+    EXPECT_EQ((uint)0, vr.regt_samples.size());
 }
 
-TEST(VCFRecordTest, create_from_record) {
+TEST(VCFRecordTest, create_from_record)
+{
 
     VCFRecord template_vr("chrom1", 3, "A", "T");
     VCFRecord vr(template_vr);
     EXPECT_EQ("chrom1", vr.chrom);
-    EXPECT_EQ((uint) 3, vr.pos);
+    EXPECT_EQ((uint)3, vr.pos);
     EXPECT_EQ(".", vr.id);
     EXPECT_EQ("A", vr.ref);
     EXPECT_EQ("T", vr.alt[0]);
     EXPECT_EQ(".", vr.qual);
     EXPECT_EQ(".", vr.filter);
     EXPECT_EQ("SVTYPE=SNP", vr.info);
-    EXPECT_EQ((uint) 1, vr.format.size());
-    EXPECT_EQ((uint) 0, vr.samples.size());
-    EXPECT_EQ((uint) 0, vr.regt_samples.size());
+    EXPECT_EQ((uint)1, vr.format.size());
+    EXPECT_EQ((uint)0, vr.samples.size());
+    EXPECT_EQ((uint)0, vr.regt_samples.size());
 }
 
-TEST(VCFRecordTest, create_from_record_with_samples) {
+TEST(VCFRecordTest, create_from_record_with_samples)
+{
 
     VCFRecord template_vr("chrom1", 3, "A", "T");
     unordered_map<string, vector<uint16_t>> empty_map;
     template_vr.samples.push_back(empty_map);
-    template_vr.samples[0]["GT"] = {0};
+    template_vr.samples[0]["GT"] = { 0 };
     template_vr.samples.push_back(empty_map);
-    template_vr.samples[1]["GT"] = {1};
+    template_vr.samples[1]["GT"] = { 1 };
     unordered_map<string, vector<float>> empty_map2;
     template_vr.regt_samples.push_back(empty_map2);
-    template_vr.regt_samples[0]["GT_CONF"] = {4.0};
+    template_vr.regt_samples[0]["GT_CONF"] = { 4.0 };
     template_vr.regt_samples.push_back(empty_map2);
-    template_vr.regt_samples[1]["GT_CONF"] = {6.3};
+    template_vr.regt_samples[1]["GT_CONF"] = { 6.3 };
     VCFRecord vr(template_vr);
     EXPECT_EQ("chrom1", vr.chrom);
-    EXPECT_EQ((uint) 3, vr.pos);
+    EXPECT_EQ((uint)3, vr.pos);
     EXPECT_EQ(".", vr.id);
     EXPECT_EQ("A", vr.ref);
     EXPECT_EQ("T", vr.alt[0]);
     EXPECT_EQ(".", vr.qual);
     EXPECT_EQ(".", vr.filter);
     EXPECT_EQ("SVTYPE=SNP", vr.info);
-    EXPECT_EQ((uint) 1, vr.format.size());
-    EXPECT_EQ((uint) 2, vr.samples.size());
-    EXPECT_EQ((uint) 2, vr.regt_samples.size());
+    EXPECT_EQ((uint)1, vr.format.size());
+    EXPECT_EQ((uint)2, vr.samples.size());
+    EXPECT_EQ((uint)2, vr.regt_samples.size());
 }
 
-TEST(VCFRecordTest, clear_simple) {
+TEST(VCFRecordTest, clear_simple)
+{
     VCFRecord vr("chrom1", 3, "A", "T");
     vr.clear();
     EXPECT_EQ(".", vr.chrom);
-    EXPECT_EQ((uint) 0, vr.pos);
+    EXPECT_EQ((uint)0, vr.pos);
     EXPECT_EQ(".", vr.id);
     EXPECT_EQ(".", vr.ref);
-    EXPECT_EQ((uint) 0, vr.alt.size());
+    EXPECT_EQ((uint)0, vr.alt.size());
     EXPECT_EQ(".", vr.qual);
     EXPECT_EQ(".", vr.filter);
     EXPECT_EQ(".", vr.info);
-    EXPECT_EQ((uint) 0, vr.format.size());
-    EXPECT_EQ((uint) 0, vr.samples.size());
-    EXPECT_EQ((uint) 0, vr.regt_samples.size());
+    EXPECT_EQ((uint)0, vr.format.size());
+    EXPECT_EQ((uint)0, vr.samples.size());
+    EXPECT_EQ((uint)0, vr.regt_samples.size());
 }
 
-TEST(VCFRecordTest, clear_with_samples) {
+TEST(VCFRecordTest, clear_with_samples)
+{
     VCFRecord vr("chrom1", 3, "A", "T");
     unordered_map<string, vector<uint16_t>> empty_map;
     vr.samples.push_back(empty_map);
-    vr.samples[0]["GT"] = {0};
+    vr.samples[0]["GT"] = { 0 };
     vr.samples.push_back(empty_map);
-    vr.samples[1]["GT"] = {1};
+    vr.samples[1]["GT"] = { 1 };
     vr.clear();
     EXPECT_EQ(".", vr.chrom);
-    EXPECT_EQ((uint) 0, vr.pos);
+    EXPECT_EQ((uint)0, vr.pos);
     EXPECT_EQ(".", vr.id);
     EXPECT_EQ(".", vr.ref);
-    EXPECT_EQ((uint) 0, vr.alt.size());
+    EXPECT_EQ((uint)0, vr.alt.size());
     EXPECT_EQ(".", vr.qual);
     EXPECT_EQ(".", vr.filter);
     EXPECT_EQ(".", vr.info);
-    EXPECT_EQ((uint) 0, vr.format.size());
-    EXPECT_EQ((uint) 0, vr.samples.size());
-    EXPECT_EQ((uint) 0, vr.regt_samples.size());
+    EXPECT_EQ((uint)0, vr.format.size());
+    EXPECT_EQ((uint)0, vr.samples.size());
+    EXPECT_EQ((uint)0, vr.regt_samples.size());
 }
 
-TEST(VCFRecordTest, clear_with_sample_confs) {
+TEST(VCFRecordTest, clear_with_sample_confs)
+{
     VCFRecord vr("chrom1", 3, "A", "T");
     unordered_map<string, vector<uint16_t>> empty_map;
     vr.samples.push_back(empty_map);
-    vr.samples[0]["GT"] = {0};
+    vr.samples[0]["GT"] = { 0 };
     vr.samples.push_back(empty_map);
-    vr.samples[1]["GT"] = {1};
+    vr.samples[1]["GT"] = { 1 };
     unordered_map<string, vector<float>> empty_map_f;
     vr.regt_samples.push_back(empty_map_f);
-    vr.regt_samples[0]["LIKELIHOOD"] = {0, 4, 5};
+    vr.regt_samples[0]["LIKELIHOOD"] = { 0, 4, 5 };
     vr.regt_samples.push_back(empty_map_f);
-    vr.regt_samples[1]["LIKELIHOOD"] = {1, 2};
-    vr.add_formats({"GT", "LIKELIHOOD"});
+    vr.regt_samples[1]["LIKELIHOOD"] = { 1, 2 };
+    vr.add_formats({ "GT", "LIKELIHOOD" });
     vr.clear();
     EXPECT_EQ(".", vr.chrom);
-    EXPECT_EQ((uint) 0, vr.pos);
+    EXPECT_EQ((uint)0, vr.pos);
     EXPECT_EQ(".", vr.id);
     EXPECT_EQ(".", vr.ref);
-    EXPECT_EQ((uint) 0, vr.alt.size());
+    EXPECT_EQ((uint)0, vr.alt.size());
     EXPECT_EQ(".", vr.qual);
     EXPECT_EQ(".", vr.filter);
     EXPECT_EQ(".", vr.info);
-    EXPECT_EQ((uint) 0, vr.format.size());
-    EXPECT_EQ((uint) 0, vr.samples.size());
-    EXPECT_EQ((uint) 0, vr.regt_samples.size());
+    EXPECT_EQ((uint)0, vr.format.size());
+    EXPECT_EQ((uint)0, vr.samples.size());
+    EXPECT_EQ((uint)0, vr.regt_samples.size());
 }
 
-TEST(VCFRecordTest, clear_sample) {
+TEST(VCFRecordTest, clear_sample)
+{
     VCFRecord vr("chrom1", 3, "A", "T");
     unordered_map<string, vector<uint16_t>> empty_map;
     vr.samples.push_back(empty_map);
-    vr.samples[0]["GT"] = {0};
+    vr.samples[0]["GT"] = { 0 };
     vr.samples.push_back(empty_map);
-    vr.samples[1]["GT"] = {1};
+    vr.samples[1]["GT"] = { 1 };
 
     // index out of range, nothin happens
     vr.clear_sample(3);
-    EXPECT_EQ((uint) 3, vr.pos);
+    EXPECT_EQ((uint)3, vr.pos);
     EXPECT_EQ("A", vr.ref);
-    EXPECT_EQ((uint) 1, vr.alt.size());
+    EXPECT_EQ((uint)1, vr.alt.size());
     EXPECT_EQ("T", vr.alt[0]);
-    EXPECT_EQ((uint) 2, vr.samples.size());
-    EXPECT_EQ((uint) 1, vr.samples[0].size());
-    EXPECT_EQ((uint) 1, vr.samples[1].size());
-    EXPECT_EQ((uint) 0, vr.regt_samples.size());
+    EXPECT_EQ((uint)2, vr.samples.size());
+    EXPECT_EQ((uint)1, vr.samples[0].size());
+    EXPECT_EQ((uint)1, vr.samples[1].size());
+    EXPECT_EQ((uint)0, vr.regt_samples.size());
 
     // index in range
     vr.clear_sample(1);
-    EXPECT_EQ((uint) 3, vr.pos);
+    EXPECT_EQ((uint)3, vr.pos);
     EXPECT_EQ("A", vr.ref);
-    EXPECT_EQ((uint) 1, vr.alt.size());
+    EXPECT_EQ((uint)1, vr.alt.size());
     EXPECT_EQ("T", vr.alt[0]);
-    EXPECT_EQ((uint) 2, vr.samples.size());
-    EXPECT_EQ((uint) 1, vr.samples[0].size());
-    EXPECT_EQ((uint) 0, vr.samples[1].size());
-    EXPECT_EQ((uint) 0, vr.regt_samples.size());
+    EXPECT_EQ((uint)2, vr.samples.size());
+    EXPECT_EQ((uint)1, vr.samples[0].size());
+    EXPECT_EQ((uint)0, vr.samples[1].size());
+    EXPECT_EQ((uint)0, vr.regt_samples.size());
 
     // index in range, nothing to do
     vr.clear_sample(1);
-    EXPECT_EQ((uint) 3, vr.pos);
+    EXPECT_EQ((uint)3, vr.pos);
     EXPECT_EQ("A", vr.ref);
-    EXPECT_EQ((uint) 1, vr.alt.size());
+    EXPECT_EQ((uint)1, vr.alt.size());
     EXPECT_EQ("T", vr.alt[0]);
-    EXPECT_EQ((uint) 2, vr.samples.size());
-    EXPECT_EQ((uint) 1, vr.samples[0].size());
-    EXPECT_EQ((uint) 0, vr.samples[1].size());
-    EXPECT_EQ((uint) 0, vr.regt_samples.size());
+    EXPECT_EQ((uint)2, vr.samples.size());
+    EXPECT_EQ((uint)1, vr.samples[0].size());
+    EXPECT_EQ((uint)0, vr.samples[1].size());
+    EXPECT_EQ((uint)0, vr.regt_samples.size());
 
     // index in range, last sample
     vr.clear_sample(0);
-    EXPECT_EQ((uint) 0, vr.pos);
+    EXPECT_EQ((uint)0, vr.pos);
     EXPECT_EQ(".", vr.ref);
-    EXPECT_EQ((uint) 0, vr.alt.size());
-    EXPECT_EQ((uint) 0, vr.samples.size());
-    EXPECT_EQ((uint) 0, vr.regt_samples.size());
+    EXPECT_EQ((uint)0, vr.alt.size());
+    EXPECT_EQ((uint)0, vr.samples.size());
+    EXPECT_EQ((uint)0, vr.regt_samples.size());
 }
 
-TEST(VCFRecordTest, add_formats_none) {
+TEST(VCFRecordTest, add_formats_none)
+{
     VCFRecord vr("chrom1", 3, "A", "T");
     vector<string> new_formats = {};
     vr.add_formats(new_formats);
-    vector<string> expected_formats = {"GT"};
+    vector<string> expected_formats = { "GT" };
     EXPECT_ITERABLE_EQ(vector<string>, expected_formats, vr.format);
 }
 
-TEST(VCFRecordTest, add_formats_some) {
+TEST(VCFRecordTest, add_formats_some)
+{
     VCFRecord vr("chrom1", 3, "A", "T");
-    vector<string> new_formats = {"hi", "there"};
+    vector<string> new_formats = { "hi", "there" };
     vr.add_formats(new_formats);
-    vector<string> expected_formats = {"GT", "hi", "there"};
+    vector<string> expected_formats = { "GT", "hi", "there" };
     EXPECT_ITERABLE_EQ(vector<string>, expected_formats, vr.format);
 }
 
-TEST(VCFRecordTest, add_formats_some_repeat) {
+TEST(VCFRecordTest, add_formats_some_repeat)
+{
     VCFRecord vr("chrom1", 3, "A", "T");
-    vector<string> new_formats = {"hi", "there"};
+    vector<string> new_formats = { "hi", "there" };
     vr.add_formats(new_formats);
     vr.add_formats(new_formats);
-    vector<string> expected_formats = {"GT", "hi", "there"};
+    vector<string> expected_formats = { "GT", "hi", "there" };
     EXPECT_ITERABLE_EQ(vector<string>, expected_formats, vr.format);
 }
 
-TEST(VCFRecordTest, add_formats_some_overlapping) {
+TEST(VCFRecordTest, add_formats_some_overlapping)
+{
     VCFRecord vr("chrom1", 3, "A", "T");
-    vector<string> new_formats = {"hi", "there"};
+    vector<string> new_formats = { "hi", "there" };
     vr.add_formats(new_formats);
-    new_formats = {"hi", "again"};
+    new_formats = { "hi", "again" };
     vr.add_formats(new_formats);
-    vector<string> expected_formats = {"GT", "hi", "there", "again"};
+    vector<string> expected_formats = { "GT", "hi", "there", "again" };
     EXPECT_ITERABLE_EQ(vector<string>, expected_formats, vr.format);
 }
 
-TEST(VCFRecordTest, add_format_death_no_samples) {
+TEST(VCFRecordTest, add_format_death_no_samples)
+{
     VCFRecord vr("chrom1", 3, "A", "T");
     uint16_t v = 20;
     EXPECT_DEATH(vr.set_format(0, "hello", v), "");
@@ -241,7 +253,8 @@ TEST(VCFRecordTest, add_format_death_no_samples) {
     EXPECT_DEATH(vr.set_format(0, "hello", w), "");
 }
 
-TEST(VCFRecordTest, add_format_cap_too_big) {
+TEST(VCFRecordTest, add_format_cap_too_big)
+{
     VCFRecord vr("chrom1", 3, "A", "T");
     uint32_t v = 60000000;
     unordered_map<string, vector<uint16_t>> m;
@@ -250,50 +263,54 @@ TEST(VCFRecordTest, add_format_cap_too_big) {
     EXPECT_EQ(vr.get_format_u(0, "hello")[0], std::numeric_limits<uint16_t>::max() - 1);
 }
 
-TEST(VCFRecordTest, add_format_new_uint) {
+TEST(VCFRecordTest, add_format_new_uint)
+{
     VCFRecord vr("chrom1", 3, "A", "T");
     unordered_map<string, vector<uint16_t>> m;
     vr.samples.push_back(m);
     uint16_t v = 20;
     vr.set_format(0, "hello", v);
     EXPECT_EQ(vr.samples.size(), 1);
-    EXPECT_TRUE(vr.samples[0].find("hello")!=vr.samples[0].end());
-    std::vector<uint16_t> exp_v = {v};
+    EXPECT_TRUE(vr.samples[0].find("hello") != vr.samples[0].end());
+    std::vector<uint16_t> exp_v = { v };
     EXPECT_ITERABLE_EQ(std::vector<uint16_t>, vr.samples[0]["hello"], exp_v);
-    std::vector<std::string> exp_f = {"GT", "hello"};
+    std::vector<std::string> exp_f = { "GT", "hello" };
     EXPECT_ITERABLE_EQ(std::vector<std::string>, vr.format, exp_f);
 }
 
-TEST(VCFRecordTest, add_format_old_uint_overwritten) {
+TEST(VCFRecordTest, add_format_old_uint_overwritten)
+{
     VCFRecord vr("chrom1", 3, "A", "T");
     unordered_map<string, vector<uint16_t>> m;
-    m["hello"] = {10};
+    m["hello"] = { 10 };
     vr.samples.push_back(m);
     uint16_t v = 20;
     vr.set_format(0, "hello", v);
     EXPECT_EQ(vr.samples.size(), 1);
-    EXPECT_TRUE(vr.samples[0].find("hello")!=vr.samples[0].end());
-    std::vector<uint16_t> exp_v = {v};
+    EXPECT_TRUE(vr.samples[0].find("hello") != vr.samples[0].end());
+    std::vector<uint16_t> exp_v = { v };
     EXPECT_ITERABLE_EQ(std::vector<uint16_t>, vr.samples[0]["hello"], exp_v);
-    std::vector<std::string> exp_f = {"GT", "hello"};
+    std::vector<std::string> exp_f = { "GT", "hello" };
     EXPECT_ITERABLE_EQ(std::vector<std::string>, vr.format, exp_f);
 }
 
-TEST(VCFRecordTest, add_format_new_float) {
+TEST(VCFRecordTest, add_format_new_float)
+{
     VCFRecord vr("chrom1", 3, "A", "T");
     unordered_map<string, vector<uint16_t>> m;
     vr.samples.push_back(m);
     float v = 20.0;
     vr.set_format(0, "hello", v);
     EXPECT_EQ(vr.regt_samples.size(), 1);
-    EXPECT_TRUE(vr.regt_samples[0].find("hello")!=vr.regt_samples[0].end());
-    std::vector<float> exp_v = {v};
+    EXPECT_TRUE(vr.regt_samples[0].find("hello") != vr.regt_samples[0].end());
+    std::vector<float> exp_v = { v };
     EXPECT_ITERABLE_EQ(std::vector<float>, vr.regt_samples[0]["hello"], exp_v);
-    std::vector<std::string> exp_f = {"GT", "hello"};
+    std::vector<std::string> exp_f = { "GT", "hello" };
     EXPECT_ITERABLE_EQ(std::vector<std::string>, vr.format, exp_f);
 }
 
-TEST(VCFRecordTest, add_format_old_float_overwritten) {
+TEST(VCFRecordTest, add_format_old_float_overwritten)
+{
     VCFRecord vr("chrom1", 3, "A", "T");
     unordered_map<string, vector<float>> m;
     m["hello"] = {};
@@ -302,14 +319,15 @@ TEST(VCFRecordTest, add_format_old_float_overwritten) {
     float v = 20.0;
     vr.set_format(0, "hello", v);
     EXPECT_EQ(vr.regt_samples.size(), 1);
-    EXPECT_TRUE(vr.regt_samples[0].find("hello")!=vr.regt_samples[0].end());
-    std::vector<float> exp_v = {v};
+    EXPECT_TRUE(vr.regt_samples[0].find("hello") != vr.regt_samples[0].end());
+    std::vector<float> exp_v = { v };
     EXPECT_ITERABLE_EQ(std::vector<float>, vr.regt_samples[0]["hello"], exp_v);
-    std::vector<std::string> exp_f = {"GT", "hello"};
+    std::vector<std::string> exp_f = { "GT", "hello" };
     EXPECT_ITERABLE_EQ(std::vector<std::string>, vr.format, exp_f);
 }
 
-TEST(VCFRecordTest, append_format_old_uint) {
+TEST(VCFRecordTest, append_format_old_uint)
+{
     VCFRecord vr("chrom1", 3, "A", "T");
     unordered_map<string, vector<uint16_t>> m;
     vr.samples.push_back(m);
@@ -318,14 +336,15 @@ TEST(VCFRecordTest, append_format_old_uint) {
     v = 20;
     vr.append_format(0, "hello", v);
     EXPECT_EQ(vr.samples.size(), 1);
-    EXPECT_TRUE(vr.samples[0].find("hello")!=vr.samples[0].end());
-    std::vector<uint16_t> exp_v = {10, 20};
+    EXPECT_TRUE(vr.samples[0].find("hello") != vr.samples[0].end());
+    std::vector<uint16_t> exp_v = { 10, 20 };
     EXPECT_ITERABLE_EQ(std::vector<uint16_t>, vr.samples[0]["hello"], exp_v);
-    std::vector<std::string> exp_f = {"GT", "hello"};
+    std::vector<std::string> exp_f = { "GT", "hello" };
     EXPECT_ITERABLE_EQ(std::vector<std::string>, vr.format, exp_f);
 }
 
-TEST(VCFRecordTest, append_format_old_float) {
+TEST(VCFRecordTest, append_format_old_float)
+{
     VCFRecord vr("chrom1", 3, "A", "T");
     unordered_map<string, vector<float>> m;
     vr.regt_samples.push_back(m);
@@ -334,14 +353,15 @@ TEST(VCFRecordTest, append_format_old_float) {
     v = 20.0;
     vr.append_format(0, "hello", v);
     EXPECT_EQ(vr.regt_samples.size(), 1);
-    EXPECT_TRUE(vr.regt_samples[0].find("hello")!=vr.regt_samples[0].end());
-    std::vector<float> exp_v = {10.0, 20.0};
+    EXPECT_TRUE(vr.regt_samples[0].find("hello") != vr.regt_samples[0].end());
+    std::vector<float> exp_v = { 10.0, 20.0 };
     EXPECT_ITERABLE_EQ(std::vector<float>, vr.regt_samples[0]["hello"], exp_v);
-    std::vector<std::string> exp_f = {"GT", "hello"};
+    std::vector<std::string> exp_f = { "GT", "hello" };
     EXPECT_ITERABLE_EQ(std::vector<std::string>, vr.format, exp_f);
 }
 
-TEST(VCFRecordTest, get_format_float) {
+TEST(VCFRecordTest, get_format_float)
+{
     VCFRecord vr("chrom1", 3, "A", "T");
     unordered_map<string, vector<float>> m;
     m.reserve(3);
@@ -349,20 +369,21 @@ TEST(VCFRecordTest, get_format_float) {
     float v = 10.0;
     vr.set_format(0, "hello", v);
 
-    auto res = vr.get_format_f(1,"hello");
+    auto res = vr.get_format_f(1, "hello");
     EXPECT_EQ(res.size(), 0);
     EXPECT_TRUE(res.empty());
 
-    res = vr.get_format_f(0,"help");
+    res = vr.get_format_f(0, "help");
     EXPECT_EQ(res.size(), 0);
     EXPECT_TRUE(res.empty());
 
-    res = vr.get_format_f(0,"hello");
+    res = vr.get_format_f(0, "hello");
     EXPECT_EQ(res.size(), 1);
     EXPECT_FALSE(res.empty());
 }
 
-TEST(VCFRecordTest, get_format_uint) {
+TEST(VCFRecordTest, get_format_uint)
+{
     VCFRecord vr("chrom1", 3, "A", "T");
     unordered_map<string, vector<uint16_t>> m;
     m.reserve(3);
@@ -370,315 +391,341 @@ TEST(VCFRecordTest, get_format_uint) {
     uint16_t v = 10;
     vr.set_format(0, "hello", v);
 
-    auto res = vr.get_format_u(1,"hello");
+    auto res = vr.get_format_u(1, "hello");
     EXPECT_EQ(res.size(), 0);
     EXPECT_TRUE(res.empty());
 
-    res = vr.get_format_u(0,"help");
+    res = vr.get_format_u(0, "help");
     EXPECT_EQ(res.size(), 0);
     EXPECT_TRUE(res.empty());
 
-    res = vr.get_format_u(0,"hello");
+    res = vr.get_format_u(0, "hello");
     EXPECT_EQ(res.size(), 1);
     EXPECT_FALSE(res.empty());
 }
 
-TEST(VCFRecordLikelihoodTest, does_not_crash_with_no_samples) {
+TEST(VCFRecordLikelihoodTest, does_not_crash_with_no_samples)
+{
     VCFRecord vr("chrom1", 3, "A", "T");
     EXPECT_NO_FATAL_FAILURE(vr.likelihood({}, 0.01, 0));
 }
 
-TEST(VCFRecordLikelihoodTest, does_not_run_if_info_missing) {
+TEST(VCFRecordLikelihoodTest, does_not_run_if_info_missing)
+{
     VCFRecord vr("chrom1", 3, "A", "T");
     unordered_map<string, vector<uint16_t>> m;
-    m["nothing"] = {0};
+    m["nothing"] = { 0 };
     vr.samples.push_back(m);
     assert(vr.samples.size() > 0);
-    std::vector<float> f = {0.0, 0.0};
-    vr.set_format(0,"GAPS", f);
-    vr.likelihood({1}, 0.01, 0);
+    std::vector<float> f = { 0.0, 0.0 };
+    vr.set_format(0, "GAPS", f);
+    vr.likelihood({ 1 }, 0.01, 0);
     bool found_likelihood = !vr.get_format_f(0, "LIKELIHOOD").empty();
     EXPECT_FALSE(found_likelihood);
 
-    vr.samples[0]["GT"] = {1};
-    vr.likelihood({1}, 0.01, 0);
+    vr.samples[0]["GT"] = { 1 };
+    vr.likelihood({ 1 }, 0.01, 0);
     found_likelihood = !vr.get_format_f(0, "LIKELIHOOD").empty();
     EXPECT_FALSE(found_likelihood);
 
-    vr.samples[0]["MEAN_FWD_COVG"] = {1, 1};
-    vr.samples[0]["MEAN_REV_COVG"] = {1};
-    vr.likelihood({1}, 0.01, 0);
+    vr.samples[0]["MEAN_FWD_COVG"] = { 1, 1 };
+    vr.samples[0]["MEAN_REV_COVG"] = { 1 };
+    vr.likelihood({ 1 }, 0.01, 0);
     found_likelihood = !vr.get_format_f(0, "LIKELIHOOD").empty();
     EXPECT_FALSE(found_likelihood);
 
     vr.samples[0].erase("MEAN_FWD_COVG");
-    vr.samples[0]["MEAN_REV_COVG"] = {1, 1};
-    vr.likelihood({1}, 0.01, 0);
+    vr.samples[0]["MEAN_REV_COVG"] = { 1, 1 };
+    vr.likelihood({ 1 }, 0.01, 0);
     found_likelihood = !vr.get_format_f(0, "LIKELIHOOD").empty();
     EXPECT_FALSE(found_likelihood);
 
-    vr.samples[0]["MEAN_FWD_COVG"] = {1};
-    vr.likelihood({1}, 0.01, 0);
+    vr.samples[0]["MEAN_FWD_COVG"] = { 1 };
+    vr.likelihood({ 1 }, 0.01, 0);
     found_likelihood = !vr.get_format_f(0, "LIKELIHOOD").empty();
     EXPECT_FALSE(found_likelihood);
 
-    vr.samples[0]["MEAN_FWD_COVG"] = {1, 1};
+    vr.samples[0]["MEAN_FWD_COVG"] = { 1, 1 };
     vr.samples[0].erase("MEAN_REV_COVG");
-    vr.likelihood({1}, 0.01, 0);
+    vr.likelihood({ 1 }, 0.01, 0);
     found_likelihood = !vr.get_format_f(0, "LIKELIHOOD").empty();
     EXPECT_FALSE(found_likelihood);
 }
 
-TEST(VCFRecordLikelihoodTest, adds_likelihood_with_info) {
+TEST(VCFRecordLikelihoodTest, adds_likelihood_with_info)
+{
     VCFRecord vr("chrom1", 3, "A", "T");
     unordered_map<string, vector<uint16_t>> m;
     vr.samples.push_back(m);
-    vr.samples[0]["MEAN_FWD_COVG"] = {1, 2};
-    vr.samples[0]["MEAN_REV_COVG"] = {1, 2};
-    std::vector<float> f = {0.0, 0.0};
-    vr.set_format(0,"GAPS", f);
-    vr.likelihood({1}, 0.01, 0);
+    vr.samples[0]["MEAN_FWD_COVG"] = { 1, 2 };
+    vr.samples[0]["MEAN_REV_COVG"] = { 1, 2 };
+    std::vector<float> f = { 0.0, 0.0 };
+    vr.set_format(0, "GAPS", f);
+    vr.likelihood({ 1 }, 0.01, 0);
     bool found_likelihood = !vr.get_format_f(0, "LIKELIHOOD").empty();
     EXPECT_TRUE(found_likelihood);
 }
 
-TEST(VCFRecordLikelihoodTest, gets_correct_likelihood_simple_case) {
+TEST(VCFRecordLikelihoodTest, gets_correct_likelihood_simple_case)
+{
     VCFRecord vr("chrom1", 3, "A", "T");
     unordered_map<string, vector<uint16_t>> m;
     vr.samples.push_back(m);
-    vr.samples[0]["MEAN_FWD_COVG"] = {1, 2};
-    vr.samples[0]["MEAN_REV_COVG"] = {1, 2};
-    std::vector<float> f = {0.0, 0.0};
-    vr.set_format(0,"GAPS", f);
-    vr.likelihood({1}, 0.01, 0);
-    float exp_likelihood = -1 - log(2) + 4 * log(0.01) + log(1-exp(-(float(1))));
+    vr.samples[0]["MEAN_FWD_COVG"] = { 1, 2 };
+    vr.samples[0]["MEAN_REV_COVG"] = { 1, 2 };
+    std::vector<float> f = { 0.0, 0.0 };
+    vr.set_format(0, "GAPS", f);
+    vr.likelihood({ 1 }, 0.01, 0);
+    float exp_likelihood = -1 - log(2) + 4 * log(0.01) + log(1 - exp(-(float(1))));
     EXPECT_FLOAT_EQ(exp_likelihood, vr.regt_samples[0]["LIKELIHOOD"][0]);
-    exp_likelihood = -1 - log(4) - log(3) - log(2) + 2 * log(0.01) + log(1-exp(-(float(1))));
+    exp_likelihood
+        = -1 - log(4) - log(3) - log(2) + 2 * log(0.01) + log(1 - exp(-(float(1))));
     EXPECT_FLOAT_EQ(exp_likelihood, vr.regt_samples[0]["LIKELIHOOD"][1]);
 }
 
-TEST(VCFRecordLikelihoodTest, gets_correct_likelihood_with_min_covg_threshold) {
+TEST(VCFRecordLikelihoodTest, gets_correct_likelihood_with_min_covg_threshold)
+{
     VCFRecord vr("chrom1", 3, "A", "T");
     unordered_map<string, vector<uint16_t>> m;
     vr.samples.push_back(m);
-    vr.samples[0]["MEAN_FWD_COVG"] = {1, 2};
-    vr.samples[0]["MEAN_REV_COVG"] = {1, 2};
-    std::vector<float> f = {0.0, 0.0};
-    vr.set_format(0,"GAPS", f);
-    vr.likelihood({1}, 0.01, 3);
+    vr.samples[0]["MEAN_FWD_COVG"] = { 1, 2 };
+    vr.samples[0]["MEAN_REV_COVG"] = { 1, 2 };
+    std::vector<float> f = { 0.0, 0.0 };
+    vr.set_format(0, "GAPS", f);
+    vr.likelihood({ 1 }, 0.01, 3);
 
-    float exp_likelihood = 4 * log(0.01) - 1 + log(1-exp(-(float(1))));
+    float exp_likelihood = 4 * log(0.01) - 1 + log(1 - exp(-(float(1))));
     EXPECT_FLOAT_EQ(exp_likelihood, vr.regt_samples[0]["LIKELIHOOD"][0]);
-    exp_likelihood = - 1 - log(4) - log(3) - log(2) + log(1-exp(-(float(1))));
+    exp_likelihood = -1 - log(4) - log(3) - log(2) + log(1 - exp(-(float(1))));
     EXPECT_FLOAT_EQ(exp_likelihood, vr.regt_samples[0]["LIKELIHOOD"][1]);
 }
 
-TEST(VCFRecordLikelihoodTest, handles_ref_covg_0) {
+TEST(VCFRecordLikelihoodTest, handles_ref_covg_0)
+{
     VCFRecord vr("chrom1", 3, "A", "T");
     unordered_map<string, vector<uint16_t>> m;
     vr.samples.push_back(m);
-    vr.samples[0]["MEAN_FWD_COVG"] = {0, 2};
-    vr.samples[0]["MEAN_REV_COVG"] = {0, 2};
-    std::vector<float> f = {0.0, 0.0};
-    vr.set_format(0,"GAPS", f);
-    vr.likelihood({1}, 0.01, 0);
-    float exp_likelihood = -1 + 4 * log(0.01) + log(1-exp(-(float(1))));
+    vr.samples[0]["MEAN_FWD_COVG"] = { 0, 2 };
+    vr.samples[0]["MEAN_REV_COVG"] = { 0, 2 };
+    std::vector<float> f = { 0.0, 0.0 };
+    vr.set_format(0, "GAPS", f);
+    vr.likelihood({ 1 }, 0.01, 0);
+    float exp_likelihood = -1 + 4 * log(0.01) + log(1 - exp(-(float(1))));
     EXPECT_FLOAT_EQ(exp_likelihood, vr.regt_samples[0]["LIKELIHOOD"][0]);
-    exp_likelihood = -1 - log(4) - log(3) - log(2) + log(1-exp(-(float(1))));
+    exp_likelihood = -1 - log(4) - log(3) - log(2) + log(1 - exp(-(float(1))));
     EXPECT_FLOAT_EQ(exp_likelihood, vr.regt_samples[0]["LIKELIHOOD"][1]);
 }
 
-TEST(VCFRecordLikelihoodTest, handles_alt_covg_0) {
+TEST(VCFRecordLikelihoodTest, handles_alt_covg_0)
+{
     VCFRecord vr("chrom1", 3, "A", "T");
     unordered_map<string, vector<uint16_t>> m;
     vr.samples.push_back(m);
-    vr.samples[0]["MEAN_FWD_COVG"] = {1, 0};
-    vr.samples[0]["MEAN_REV_COVG"] = {1, 0};
-    std::vector<float> f = {0.0, 0.0};
-    vr.set_format(0,"GAPS", f);
-    vr.likelihood({1}, 0.01, 0);
-    float exp_likelihood = -1 + 2 * log(0.01) + log(1-exp(-(float(1))));
+    vr.samples[0]["MEAN_FWD_COVG"] = { 1, 0 };
+    vr.samples[0]["MEAN_REV_COVG"] = { 1, 0 };
+    std::vector<float> f = { 0.0, 0.0 };
+    vr.set_format(0, "GAPS", f);
+    vr.likelihood({ 1 }, 0.01, 0);
+    float exp_likelihood = -1 + 2 * log(0.01) + log(1 - exp(-(float(1))));
     EXPECT_FLOAT_EQ(exp_likelihood, vr.regt_samples[0]["LIKELIHOOD"][1]);
-    exp_likelihood = -1 - log(2) + log(1-exp(-(float(1))));
+    exp_likelihood = -1 - log(2) + log(1 - exp(-(float(1))));
     EXPECT_FLOAT_EQ(exp_likelihood, vr.regt_samples[0]["LIKELIHOOD"][0]);
 }
 
-TEST(VCFRecordLikelihoodTest, gets_correct_likelihood_gaps) {
+TEST(VCFRecordLikelihoodTest, gets_correct_likelihood_gaps)
+{
     VCFRecord vr("chrom1", 3, "A", "T");
     unordered_map<string, vector<uint16_t>> m;
     vr.samples.push_back(m);
-    vr.samples[0]["MEAN_FWD_COVG"] = {1, 2};
-    vr.samples[0]["MEAN_REV_COVG"] = {1, 2};
-    std::vector<float> f = {0.5, 0.8};
-    vr.set_format(0,"GAPS", f);
-    vr.likelihood({1}, 0.01, 0);
-    float exp_likelihood = -1 - log(2) + 4 * log(0.01) + 0.5*log(1-exp(-(float(1)))) - 0.5;
+    vr.samples[0]["MEAN_FWD_COVG"] = { 1, 2 };
+    vr.samples[0]["MEAN_REV_COVG"] = { 1, 2 };
+    std::vector<float> f = { 0.5, 0.8 };
+    vr.set_format(0, "GAPS", f);
+    vr.likelihood({ 1 }, 0.01, 0);
+    float exp_likelihood
+        = -1 - log(2) + 4 * log(0.01) + 0.5 * log(1 - exp(-(float(1)))) - 0.5;
     EXPECT_FLOAT_EQ(exp_likelihood, vr.regt_samples[0]["LIKELIHOOD"][0]);
-    exp_likelihood = -1 - log(4) - log(3) - log(2) + 2 * log(0.01) + 0.2*log(1-exp(-(float(1)))) - 0.8;
+    exp_likelihood = -1 - log(4) - log(3) - log(2) + 2 * log(0.01)
+        + 0.2 * log(1 - exp(-(float(1)))) - 0.8;
     EXPECT_FLOAT_EQ(exp_likelihood, vr.regt_samples[0]["LIKELIHOOD"][1]);
 }
 
-TEST(VCFRecordLikelihoodTest, death_not_enough_covgs) {
+TEST(VCFRecordLikelihoodTest, death_not_enough_covgs)
+{
     VCFRecord vr("chrom1", 3, "A", "T");
     unordered_map<string, vector<uint16_t>> m;
     vr.samples.push_back(m);
     vr.samples.push_back(m);
-    vr.samples[0]["MEAN_FWD_COVG"] = {1, 2};
-    vr.samples[0]["MEAN_REV_COVG"] = {1, 2};
-    vr.samples[1]["MEAN_FWD_COVG"] = {1, 2};
-    vr.samples[1]["MEAN_REV_COVG"] = {1, 2};
-    std::vector<float> f = {0.5, 0.8};
-    vr.set_format(0,"GAPS", f);
-    vr.set_format(1,"GAPS", f);
-    EXPECT_DEATH(vr.likelihood({1}, 0.01, 0), "");
+    vr.samples[0]["MEAN_FWD_COVG"] = { 1, 2 };
+    vr.samples[0]["MEAN_REV_COVG"] = { 1, 2 };
+    vr.samples[1]["MEAN_FWD_COVG"] = { 1, 2 };
+    vr.samples[1]["MEAN_REV_COVG"] = { 1, 2 };
+    std::vector<float> f = { 0.5, 0.8 };
+    vr.set_format(0, "GAPS", f);
+    vr.set_format(1, "GAPS", f);
+    EXPECT_DEATH(vr.likelihood({ 1 }, 0.01, 0), "");
 }
 
-TEST(VCFRecordLikelihoodTest, samples_with_different_depths) {
+TEST(VCFRecordLikelihoodTest, samples_with_different_depths)
+{
     VCFRecord vr("chrom1", 3, "A", "T");
     unordered_map<string, vector<uint16_t>> m;
     vr.samples.push_back(m);
     vr.samples.push_back(m);
-    vr.samples[0]["MEAN_FWD_COVG"] = {1, 2};
-    vr.samples[0]["MEAN_REV_COVG"] = {1, 2};
-    vr.samples[1]["MEAN_FWD_COVG"] = {1, 2};
-    vr.samples[1]["MEAN_REV_COVG"] = {1, 2};
-    std::vector<float> f = {0.5, 0.8};
-    vr.set_format(0,"GAPS", f);
-    vr.set_format(1,"GAPS", f);
-    vr.likelihood({1,2}, 0.01, 0);
+    vr.samples[0]["MEAN_FWD_COVG"] = { 1, 2 };
+    vr.samples[0]["MEAN_REV_COVG"] = { 1, 2 };
+    vr.samples[1]["MEAN_FWD_COVG"] = { 1, 2 };
+    vr.samples[1]["MEAN_REV_COVG"] = { 1, 2 };
+    std::vector<float> f = { 0.5, 0.8 };
+    vr.set_format(0, "GAPS", f);
+    vr.set_format(1, "GAPS", f);
+    vr.likelihood({ 1, 2 }, 0.01, 0);
 
-    float exp_likelihood = -1 - log(2) + 4 * log(0.01) + 0.5*log(1-exp(-(float(1)))) - 0.5;
+    float exp_likelihood
+        = -1 - log(2) + 4 * log(0.01) + 0.5 * log(1 - exp(-(float(1)))) - 0.5;
     EXPECT_FLOAT_EQ(exp_likelihood, vr.regt_samples[0]["LIKELIHOOD"][0]);
-    exp_likelihood = -1 - log(4) - log(3) - log(2) + 2 * log(0.01) + 0.2*log(1-exp(-(float(1)))) - 0.8;
+    exp_likelihood = -1 - log(4) - log(3) - log(2) + 2 * log(0.01)
+        + 0.2 * log(1 - exp(-(float(1)))) - 0.8;
     EXPECT_FLOAT_EQ(exp_likelihood, vr.regt_samples[0]["LIKELIHOOD"][1]);
-    exp_likelihood = 2*log(2) -2 - log(2) + 4 * log(0.01) + 0.5*log(1-exp(-(float(2)))) - 2*0.5;
+    exp_likelihood = 2 * log(2) - 2 - log(2) + 4 * log(0.01)
+        + 0.5 * log(1 - exp(-(float(2)))) - 2 * 0.5;
     EXPECT_FLOAT_EQ(exp_likelihood, vr.regt_samples[1]["LIKELIHOOD"][0]);
-    exp_likelihood = 4*log(2) -2 - log(4) - log(3) - log(2) + 2 * log(0.01) + 0.2*log(1-exp(-(float(2)))) - 2*0.8;
+    exp_likelihood = 4 * log(2) - 2 - log(4) - log(3) - log(2) + 2 * log(0.01)
+        + 0.2 * log(1 - exp(-(float(2)))) - 2 * 0.8;
     EXPECT_FLOAT_EQ(exp_likelihood, vr.regt_samples[1]["LIKELIHOOD"][1]);
 }
 
-TEST(VCFRecordConfidenceTest, does_not_run_if_info_missing) {
+TEST(VCFRecordConfidenceTest, does_not_run_if_info_missing)
+{
     VCFRecord vr("chrom1", 3, "A", "T");
     unordered_map<string, vector<float>> m;
     vr.regt_samples.push_back(m);
     vr.confidence();
-    bool found_confidence = !vr.get_format_f(0,"GT_CONF").empty();
+    bool found_confidence = !vr.get_format_f(0, "GT_CONF").empty();
     EXPECT_FALSE(found_confidence);
-    std::vector<float> f = {-1.0};
-    vr.set_format(0,"LIKELIHOOD", f);
+    std::vector<float> f = { -1.0 };
+    vr.set_format(0, "LIKELIHOOD", f);
     EXPECT_DEATH(vr.confidence(), "");
 }
 
-TEST(VCFRecordConfidenceTest, adds_confidence_with_info) {
+TEST(VCFRecordConfidenceTest, adds_confidence_with_info)
+{
     VCFRecord vr("chrom1", 3, "A", "T");
     unordered_map<string, vector<float>> m;
     unordered_map<string, vector<uint16_t>> m2;
     m.reserve(3);
     m2.reserve(3);
     vr.regt_samples.push_back(m);
-    vr.regt_samples[0]["LIKELIHOOD"] = {-1.0, -2.5};
+    vr.regt_samples[0]["LIKELIHOOD"] = { -1.0, -2.5 };
     vr.samples.push_back(m2);
-    vr.samples[0]["MEAN_FWD_COVG"] = {0,0};
-    vr.samples[0]["MEAN_REV_COVG"] = {0,0};
+    vr.samples[0]["MEAN_FWD_COVG"] = { 0, 0 };
+    vr.samples[0]["MEAN_REV_COVG"] = { 0, 0 };
     vr.confidence();
-    bool found_confidence = !vr.get_format_f(0,"GT_CONF").empty();
+    bool found_confidence = !vr.get_format_f(0, "GT_CONF").empty();
     EXPECT_TRUE(found_confidence);
 }
 
-TEST(VCFRecordConfidenceTest, gets_correct_confidence_simple_case) {
+TEST(VCFRecordConfidenceTest, gets_correct_confidence_simple_case)
+{
     VCFRecord vr("chrom1", 3, "A", "T");
     unordered_map<string, vector<float>> m;
     unordered_map<string, vector<uint16_t>> m2;
     vr.regt_samples.push_back(m);
-    vr.regt_samples[0]["LIKELIHOOD"] = {-1.0, 0.0};
+    vr.regt_samples[0]["LIKELIHOOD"] = { -1.0, 0.0 };
     vr.samples.push_back(m2);
-    vr.samples[0]["MEAN_FWD_COVG"] = {0,0};
-    vr.samples[0]["MEAN_REV_COVG"] = {0,0};
+    vr.samples[0]["MEAN_FWD_COVG"] = { 0, 0 };
+    vr.samples[0]["MEAN_REV_COVG"] = { 0, 0 };
     vr.confidence();
     float exp_confidence = 1;
     EXPECT_FLOAT_EQ(exp_confidence, vr.regt_samples[0]["GT_CONF"][0]);
 }
 
-TEST(VCFRecordConfidenceTest, gets_correct_confidence_two_alts) {
+TEST(VCFRecordConfidenceTest, gets_correct_confidence_two_alts)
+{
     VCFRecord vr("chrom1", 3, "A", "T");
     vr.alt.push_back("C");
     unordered_map<string, vector<float>> m;
     unordered_map<string, vector<uint16_t>> m2;
     vr.regt_samples.push_back(m);
-    vr.regt_samples[0]["LIKELIHOOD"] = {-14.0, -6.0, -3.0};
+    vr.regt_samples[0]["LIKELIHOOD"] = { -14.0, -6.0, -3.0 };
     vr.samples.push_back(m2);
-    vr.samples[0]["MEAN_FWD_COVG"] = {0,0,0};
-    vr.samples[0]["MEAN_REV_COVG"] = {0,0,0};
+    vr.samples[0]["MEAN_FWD_COVG"] = { 0, 0, 0 };
+    vr.samples[0]["MEAN_REV_COVG"] = { 0, 0, 0 };
     vr.confidence();
     float exp_confidence = 3;
     EXPECT_FLOAT_EQ(exp_confidence, vr.regt_samples[0]["GT_CONF"][0]);
 }
 
-TEST(VCFRecordConfidenceTest, gets_correct_confidence_min_total) {
+TEST(VCFRecordConfidenceTest, gets_correct_confidence_min_total)
+{
     VCFRecord vr("chrom1", 3, "A", "T");
     vr.alt.push_back("C");
     unordered_map<string, vector<float>> m;
     unordered_map<string, vector<uint16_t>> m2;
     vr.regt_samples.push_back(m);
-    vr.regt_samples[0]["LIKELIHOOD"] = {-14.0, -6.0, -3.0};
+    vr.regt_samples[0]["LIKELIHOOD"] = { -14.0, -6.0, -3.0 };
     vr.samples.push_back(m2);
-    vr.samples[0]["MEAN_FWD_COVG"] = {0,0,1};
-    vr.samples[0]["MEAN_REV_COVG"] = {0,0,1};
-    vr.confidence(3,0);
+    vr.samples[0]["MEAN_FWD_COVG"] = { 0, 0, 1 };
+    vr.samples[0]["MEAN_REV_COVG"] = { 0, 0, 1 };
+    vr.confidence(3, 0);
     float exp_confidence = 0;
     EXPECT_FLOAT_EQ(exp_confidence, vr.regt_samples[0]["GT_CONF"][0]);
-    vr.confidence(2,0);
+    vr.confidence(2, 0);
     exp_confidence = 3;
     EXPECT_FLOAT_EQ(exp_confidence, vr.regt_samples[0]["GT_CONF"][0]);
 }
 
-TEST(VCFRecordConfidenceTest, gets_correct_confidence_min_diff) {
+TEST(VCFRecordConfidenceTest, gets_correct_confidence_min_diff)
+{
     VCFRecord vr("chrom1", 3, "A", "T");
     vr.alt.push_back("C");
     unordered_map<string, vector<float>> m;
     unordered_map<string, vector<uint16_t>> m2;
     vr.regt_samples.push_back(m);
-    vr.regt_samples[0]["LIKELIHOOD"] = {-14.0, -6.0, -3.0};
+    vr.regt_samples[0]["LIKELIHOOD"] = { -14.0, -6.0, -3.0 };
     vr.samples.push_back(m2);
-    vr.samples[0]["MEAN_FWD_COVG"] = {0,2,4};
-    vr.samples[0]["MEAN_REV_COVG"] = {0,0,1};
-    vr.confidence(0,4);
+    vr.samples[0]["MEAN_FWD_COVG"] = { 0, 2, 4 };
+    vr.samples[0]["MEAN_REV_COVG"] = { 0, 0, 1 };
+    vr.confidence(0, 4);
     float exp_confidence = 0;
     EXPECT_FLOAT_EQ(exp_confidence, vr.regt_samples[0]["GT_CONF"][0]);
-    vr.confidence(0,3);
+    vr.confidence(0, 3);
     exp_confidence = 3;
     EXPECT_FLOAT_EQ(exp_confidence, vr.regt_samples[0]["GT_CONF"][0]);
 }
 
-TEST(VCFRecordConfidenceTest, handles_ref_covg_0) {
+TEST(VCFRecordConfidenceTest, handles_ref_covg_0)
+{
     VCFRecord vr("chrom1", 3, "A", "T");
     std::unordered_map<std::string, std::vector<float>> m;
     unordered_map<string, vector<uint16_t>> m2;
     vr.regt_samples.push_back(m);
-    vr.regt_samples[0]["LIKELIHOOD"] = {std::numeric_limits<float>::lowest(), -1.5};
+    vr.regt_samples[0]["LIKELIHOOD"] = { std::numeric_limits<float>::lowest(), -1.5 };
     vr.samples.push_back(m2);
-    vr.samples[0]["MEAN_FWD_COVG"] = {0,0};
-    vr.samples[0]["MEAN_REV_COVG"] = {0,0};
+    vr.samples[0]["MEAN_FWD_COVG"] = { 0, 0 };
+    vr.samples[0]["MEAN_REV_COVG"] = { 0, 0 };
     vr.confidence();
     float exp_confidence = -std::numeric_limits<float>::lowest() - 1.5;
     EXPECT_FLOAT_EQ(exp_confidence, vr.regt_samples[0]["GT_CONF"][0]);
 }
 
-TEST(VCFRecordConfidenceTest, handles_alt_covg_0) {
+TEST(VCFRecordConfidenceTest, handles_alt_covg_0)
+{
     VCFRecord vr("chrom1", 3, "A", "T");
     std::unordered_map<std::string, std::vector<float>> m;
     unordered_map<string, vector<uint16_t>> m2;
     vr.regt_samples.push_back(m);
-    vr.regt_samples[0]["LIKELIHOOD"] = {-1.5, std::numeric_limits<float>::lowest()};
+    vr.regt_samples[0]["LIKELIHOOD"] = { -1.5, std::numeric_limits<float>::lowest() };
     vr.samples.push_back(m2);
-    vr.samples[0]["MEAN_FWD_COVG"] = {0,0};
-    vr.samples[0]["MEAN_REV_COVG"] = {0,0};
+    vr.samples[0]["MEAN_FWD_COVG"] = { 0, 0 };
+    vr.samples[0]["MEAN_REV_COVG"] = { 0, 0 };
     vr.confidence();
     float exp_confidence = -std::numeric_limits<float>::lowest() - 1.5;
     EXPECT_FLOAT_EQ(exp_confidence, vr.regt_samples[0]["GT_CONF"][0]);
 }
 
-TEST(VCFRecordRegenotypeTest, correctly_genotypes) {
+TEST(VCFRecordRegenotypeTest, correctly_genotypes)
+{
     // sample 0 missing confidence
     // sample 1 confidence below threshold
     // sample 2 confidence above threshold, but has correct GT 0 already
@@ -694,40 +741,40 @@ TEST(VCFRecordRegenotypeTest, correctly_genotypes) {
         vr.samples.push_back(m);
     }
 
-    vr.samples[0]["MEAN_FWD_COVG"] = {0, 2};
-    vr.samples[0]["MEAN_REV_COVG"] = {1, 3};
-    vr.regt_samples[0]["LIKELIHOOD"] = {4, 5};
-    vr.samples[0]["GT"] = {1};
+    vr.samples[0]["MEAN_FWD_COVG"] = { 0, 2 };
+    vr.samples[0]["MEAN_REV_COVG"] = { 1, 3 };
+    vr.regt_samples[0]["LIKELIHOOD"] = { 4, 5 };
+    vr.samples[0]["GT"] = { 1 };
 
-    vr.samples[1]["MEAN_FWD_COVG"] = {0, 2};
-    vr.samples[1]["MEAN_REV_COVG"] = {1, 3};
-    vr.regt_samples[1]["LIKELIHOOD"] = {4, 5};
-    vr.samples[1]["GT"] = {1};
-    vr.regt_samples[1]["GT_CONF"] = {1};
+    vr.samples[1]["MEAN_FWD_COVG"] = { 0, 2 };
+    vr.samples[1]["MEAN_REV_COVG"] = { 1, 3 };
+    vr.regt_samples[1]["LIKELIHOOD"] = { 4, 5 };
+    vr.samples[1]["GT"] = { 1 };
+    vr.regt_samples[1]["GT_CONF"] = { 1 };
 
-    vr.samples[2]["MEAN_FWD_COVG"] = {0, 2};
-    vr.samples[2]["MEAN_REV_COVG"] = {1, 3};
-    vr.regt_samples[2]["LIKELIHOOD"] = {6, 4};
-    vr.samples[2]["GT"] = {0};
-    vr.regt_samples[2]["GT_CONF"] = {2};
+    vr.samples[2]["MEAN_FWD_COVG"] = { 0, 2 };
+    vr.samples[2]["MEAN_REV_COVG"] = { 1, 3 };
+    vr.regt_samples[2]["LIKELIHOOD"] = { 6, 4 };
+    vr.samples[2]["GT"] = { 0 };
+    vr.regt_samples[2]["GT_CONF"] = { 2 };
 
-    vr.samples[3]["MEAN_FWD_COVG"] = {0, 2};
-    vr.samples[3]["MEAN_REV_COVG"] = {1, 3};
-    vr.regt_samples[3]["LIKELIHOOD"] = {4, 6};
-    vr.samples[3]["GT"] = {1};
-    vr.regt_samples[3]["GT_CONF"] = {2};
+    vr.samples[3]["MEAN_FWD_COVG"] = { 0, 2 };
+    vr.samples[3]["MEAN_REV_COVG"] = { 1, 3 };
+    vr.regt_samples[3]["LIKELIHOOD"] = { 4, 6 };
+    vr.samples[3]["GT"] = { 1 };
+    vr.regt_samples[3]["GT_CONF"] = { 2 };
 
-    vr.samples[4]["MEAN_FWD_COVG"] = {0, 2};
-    vr.samples[4]["MEAN_REV_COVG"] = {1, 3};
-    vr.regt_samples[4]["LIKELIHOOD"] = {6, 4};
-    vr.samples[4]["GT"] = {1};
-    vr.regt_samples[4]["GT_CONF"] = {2};
+    vr.samples[4]["MEAN_FWD_COVG"] = { 0, 2 };
+    vr.samples[4]["MEAN_REV_COVG"] = { 1, 3 };
+    vr.regt_samples[4]["LIKELIHOOD"] = { 6, 4 };
+    vr.samples[4]["GT"] = { 1 };
+    vr.regt_samples[4]["GT_CONF"] = { 2 };
 
-    vr.samples[5]["MEAN_FWD_COVG"] = {0, 2};
-    vr.samples[5]["MEAN_REV_COVG"] = {1, 3};
-    vr.regt_samples[5]["LIKELIHOOD"] = {4, 6};
-    vr.samples[5]["GT"] = {0};
-    vr.regt_samples[5]["GT_CONF"] = {2};
+    vr.samples[5]["MEAN_FWD_COVG"] = { 0, 2 };
+    vr.samples[5]["MEAN_REV_COVG"] = { 1, 3 };
+    vr.regt_samples[5]["LIKELIHOOD"] = { 4, 6 };
+    vr.samples[5]["GT"] = { 0 };
+    vr.regt_samples[5]["GT_CONF"] = { 2 };
 
     vr.genotype(1);
     EXPECT_EQ(vr.samples[0]["MEAN_FWD_COVG"][0], 0);
@@ -736,7 +783,7 @@ TEST(VCFRecordRegenotypeTest, correctly_genotypes) {
     EXPECT_EQ(vr.samples[0]["MEAN_REV_COVG"][1], 3);
     EXPECT_EQ(vr.regt_samples[0]["LIKELIHOOD"][0], 4);
     EXPECT_EQ(vr.regt_samples[0]["LIKELIHOOD"][1], 5);
-    EXPECT_EQ(vr.samples[0]["GT"].size(), (uint) 0);
+    EXPECT_EQ(vr.samples[0]["GT"].size(), (uint)0);
 
     EXPECT_EQ(vr.samples[1]["MEAN_FWD_COVG"][0], 0);
     EXPECT_EQ(vr.samples[1]["MEAN_REV_COVG"][0], 1);
@@ -744,7 +791,7 @@ TEST(VCFRecordRegenotypeTest, correctly_genotypes) {
     EXPECT_EQ(vr.samples[1]["MEAN_REV_COVG"][1], 3);
     EXPECT_EQ(vr.regt_samples[1]["LIKELIHOOD"][0], 4);
     EXPECT_EQ(vr.regt_samples[1]["LIKELIHOOD"][1], 5);
-    EXPECT_EQ(vr.samples[1]["GT"].size(), (uint) 0);
+    EXPECT_EQ(vr.samples[1]["GT"].size(), (uint)0);
 
     EXPECT_EQ(vr.samples[2]["MEAN_FWD_COVG"][0], 0);
     EXPECT_EQ(vr.samples[2]["MEAN_REV_COVG"][0], 1);
@@ -779,8 +826,8 @@ TEST(VCFRecordRegenotypeTest, correctly_genotypes) {
     EXPECT_EQ(vr.samples[5]["GT"][0], 1);
 }
 
-
-TEST(VCFRecordTest, equals) {
+TEST(VCFRecordTest, equals)
+{
     VCFRecord vr;
     EXPECT_EQ(vr, vr);
 
@@ -808,10 +855,10 @@ TEST(VCFRecordTest, equals) {
     EXPECT_EQ(vr5, vr5);
     EXPECT_EQ((vr5 == vr1), false);
     EXPECT_EQ((vr1 == vr5), false);
-
 }
 
-TEST(VCFRecordTest, less_than) {
+TEST(VCFRecordTest, less_than)
+{
     VCFRecord vr1("chrom1", 3, "A", "T");
     VCFRecord vr2("chrom2", 3, "A", "T");
     EXPECT_EQ((vr2 < vr1), false);
@@ -830,29 +877,31 @@ TEST(VCFRecordTest, less_than) {
     EXPECT_EQ((vr1 < vr5), false);
 }
 
-TEST(VCFRecordTest, ostream) {
+TEST(VCFRecordTest, ostream)
+{
     VCFRecord vr("chrom1", 3, "A", "T");
-    vector<string> v = {"chrom1", "4", ".", "A", "T", ".", ".", "SVTYPE=SNP", "GT"};
+    vector<string> v = { "chrom1", "4", ".", "A", "T", ".", ".", "SVTYPE=SNP", "GT" };
     stringstream out;
     out << vr;
     string rr;
-    for (const auto &s : v) {
+    for (const auto& s : v) {
         out >> rr;
         EXPECT_EQ(s, rr);
     }
 }
 
-TEST(VCFRecordTest, ostream_with_sample_not_all_info_in_formats) {
+TEST(VCFRecordTest, ostream_with_sample_not_all_info_in_formats)
+{
     VCFRecord vr("chrom1", 3, "A", "T");
     unordered_map<string, vector<uint16_t>> m;
-    m["GT"] = {1};
-    m["pringle"] = {2};
+    m["GT"] = { 1 };
+    m["pringle"] = { 2 };
     vr.samples.push_back(m);
-    vector<string> v = {"chrom1", "4", ".", "A", "T", ".", ".", "SVTYPE=SNP", "GT"};
+    vector<string> v = { "chrom1", "4", ".", "A", "T", ".", ".", "SVTYPE=SNP", "GT" };
     stringstream out;
     out << vr;
     string rr;
-    for (const auto &s : v) {
+    for (const auto& s : v) {
         out >> rr;
         EXPECT_EQ(s, rr);
     }
@@ -862,43 +911,46 @@ TEST(VCFRecordTest, ostream_with_sample_not_all_info_in_formats) {
     EXPECT_EQ(u, ru);
 }
 
-TEST(VCFRecordTest, ostream_with_sample_including_all_formats) {
+TEST(VCFRecordTest, ostream_with_sample_including_all_formats)
+{
     VCFRecord vr("chrom1", 3, "A", "T");
     unordered_map<string, vector<uint16_t>> m;
-    m["GT"] = {0};
-    m["pringle"] = {2};
+    m["GT"] = { 0 };
+    m["pringle"] = { 2 };
     vr.samples.push_back(m);
-    vr.add_formats({"pringle"});
-    vector<string> v = {"chrom1", "4", ".", "A", "T", ".", ".", "SVTYPE=SNP", "GT:pringle"};
-    vector<uint16_t> vu = {0, 2};
+    vr.add_formats({ "pringle" });
+    vector<string> v
+        = { "chrom1", "4", ".", "A", "T", ".", ".", "SVTYPE=SNP", "GT:pringle" };
+    vector<uint16_t> vu = { 0, 2 };
     stringstream out;
     out << vr;
     string rr;
-    for (const auto &s : v) {
+    for (const auto& s : v) {
         out >> rr;
         EXPECT_EQ(s, rr);
     }
     uint ru;
-    for (const auto &s : vu) {
+    for (const auto& s : vu) {
         out >> ru;
         EXPECT_EQ(s, ru);
         out.ignore(1, ':');
     }
-
 }
 
-TEST(VCFRecordTest, ostream_with_sample_more_formats_than_info) {
+TEST(VCFRecordTest, ostream_with_sample_more_formats_than_info)
+{
     VCFRecord vr("chrom1", 3, "A", "T");
     unordered_map<string, vector<uint16_t>> m;
-    m["GT"] = {0};
+    m["GT"] = { 0 };
     vr.samples.push_back(m);
-    vr.add_formats({"pringle"});
-    vector<string> v = {"chrom1", "4", ".", "A", "T", ".", ".", "SVTYPE=SNP", "GT:pringle"};
-    vector<uint16_t> vu = {0};
+    vr.add_formats({ "pringle" });
+    vector<string> v
+        = { "chrom1", "4", ".", "A", "T", ".", ".", "SVTYPE=SNP", "GT:pringle" };
+    vector<uint16_t> vu = { 0 };
     stringstream out;
     out << vr;
     string rr;
-    for (const auto &s : v) {
+    for (const auto& s : v) {
         out >> rr;
         EXPECT_EQ(s, rr);
     }
@@ -910,20 +962,22 @@ TEST(VCFRecordTest, ostream_with_sample_more_formats_than_info) {
     EXPECT_EQ(":.", rr);
 }
 
-TEST(VCFRecordTest, ostream_with_sample_more_formats_than_info_regt) {
+TEST(VCFRecordTest, ostream_with_sample_more_formats_than_info_regt)
+{
     VCFRecord vr("chrom1", 3, "A", "T");
     unordered_map<string, vector<uint16_t>> m;
-    m["GT"] = {0};
+    m["GT"] = { 0 };
     vr.samples.push_back(m);
     unordered_map<string, vector<float>> n;
-    n["pringle"] = {0.1};
+    n["pringle"] = { 0.1 };
     vr.regt_samples.push_back(n);
-    vr.add_formats({"pringle"});
-    vector<string> v = {"chrom1", "4", ".", "A", "T", ".", ".", "SVTYPE=SNP", "GT:pringle"};
+    vr.add_formats({ "pringle" });
+    vector<string> v
+        = { "chrom1", "4", ".", "A", "T", ".", ".", "SVTYPE=SNP", "GT:pringle" };
     stringstream out;
     out << vr;
     string rr;
-    for (const auto &s : v) {
+    for (const auto& s : v) {
         out >> rr;
         EXPECT_EQ(s, rr);
     }
@@ -937,20 +991,22 @@ TEST(VCFRecordTest, ostream_with_sample_more_formats_than_info_regt) {
     EXPECT_EQ(f, rf);
 }
 
-TEST(VCFRecordTest, ostream_with_zero_pos) {
+TEST(VCFRecordTest, ostream_with_zero_pos)
+{
     VCFRecord vr("chrom1", 0, "A", "T");
     unordered_map<string, vector<uint16_t>> m;
-    m["GT"] = {0};
+    m["GT"] = { 0 };
     vr.samples.push_back(m);
     unordered_map<string, vector<float>> n;
-    n["pringle"] = {0.1};
+    n["pringle"] = { 0.1 };
     vr.regt_samples.push_back(n);
-    vr.add_formats({"pringle"});
-    vector<string> v = {"chrom1", "1", ".", "A", "T", ".", ".", "SVTYPE=SNP", "GT:pringle"};
+    vr.add_formats({ "pringle" });
+    vector<string> v
+        = { "chrom1", "1", ".", "A", "T", ".", ".", "SVTYPE=SNP", "GT:pringle" };
     stringstream out;
     out << vr;
     string rr;
-    for (const auto &s : v) {
+    for (const auto& s : v) {
         out >> rr;
         EXPECT_EQ(s, rr);
     }
@@ -963,6 +1019,3 @@ TEST(VCFRecordTest, ostream_with_zero_pos) {
     out >> rf;
     EXPECT_EQ(f, rf);
 }
-
-
-


### PR DESCRIPTION
Reformatted all files with `clang-format` [closes #188 ].

Additionally, added a format check step to the Travis CI build (and tweaked some other things).

I have also set up a pre-commit git hook locally. What this does it run a check before you can commit locally to see if you have formatted all of the files associated with the commit.

Add the following code snippet inside the pandora project directory as `.git/hooks/pre-commit`

```sh
#!/bin/sh
# pre-commit hook that checks the files being commited have been formatted with 
# clang-format and the project style
git diff --cached --name-only --diff-filter=ACMRT |
  grep -E '\.cpp|\.h' |
  xargs -n1 clang-format -style=file -output-replacements-xml |
  grep "<replacement " >/dev/null
if [ $? -ne 1 ]; then
    echo "PreCommitError: The .cpp and .h files you are trying to commit did not match clang-format required style."
    exit 1
fi
```
and then run `chmod +x .git/hooks/pre-commit`

Also, if you haven't set it up already, you can tell CLion to use `clang-format as it's engine for reformatting https://www.jetbrains.com/help/clion/clangformat-as-alternative-formatter.html