### PR TITLE
Move variant discovery to its own subcommand

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ Input/Output:
 
 Parameter Estimation:
   -e,--error-rate FLOAT       Estimated error rate for reads [default: 0.11]
-  -g,--genome-size INT        Estimated length of the genome - used for coverage estimation [default: 5000000]
+  -g,--genome-size STR/INT    Estimated length of the genome - used for coverage estimation. Can pass string such as 4.4m, 100k etc. [default: 5000000]
   --bin                       Use binomial model for kmer coverages [default: negative binomial]
 
 Mapping:
@@ -231,7 +231,7 @@ Input/Output:
 
 Parameter Estimation:
   -e,--error-rate FLOAT       Estimated error rate for reads [default: 0.11]
-  -g,--genome-size INT        Estimated length of the genome - used for coverage estimation [default: 5000000]
+  -g,--genome-size STR/INT    Estimated length of the genome - used for coverage estimation. Can pass string such as 4.4m, 100k etc. [default: 5000000]
   --bin                       Use binomial model for kmer coverages [default: negative binomial]
 
 Mapping:

--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ Input/Output:
   -C,--comparison-paths       Save a fasta file for a random selection of paths through loci
   --coverages                 Save a file of coverages for each loci present - one number per base
   -M,--mapped-reads           Save a fasta file for each loci containing read parts which overlapped it
-  
+
 Parameter Estimation:
   -e,--error-rate FLOAT       Estimated error rate for reads [default: 0.11]
   -g,--genome-size INT        Estimated length of the genome - used for coverage estimation [default: 5000000]
@@ -189,6 +189,8 @@ Consensus/Variant Calling:
   --snps                      When genotyping, only include SNP sites
   -d,--discover               Add a step to discover de novo variants
   --discover-k INT            Kmer size to use when disovering de novo variants [default: 11]
+  --max-ins INT               Maximum insertion size allowed when discovering de novo variants. Warning: setting too long could cause performance degradation [default: 15]
+  --min-dbg-dp INT            Minimum depth on a node/kmer in the de Bruijn graph used for discovering de novo variants [default: 1]
   --kmer-avg INT              Maximum number of kmers to average over when selecting the maximum likelihood path [default: 100]
 
 Genotyping:

--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ This takes a fasta/q of Nanopore or Illumina reads and compares to the index. It
 
 ```
 $ pandora map --help
-Quasi-map reads to an indexed PRG, infer the sequence of present loci in the sample, and (optionally) genotype/discover variants.
+Quasi-map reads to an indexed PRG, infer the sequence of present loci in the sample, and optionally genotype variants.
 Usage: ./pandora map [OPTIONS] <TARGET> <QUERY>
 
 Positionals:
@@ -165,7 +165,6 @@ Input/Output:
   --kg                        Save kmer graphs with forward and reverse coverage annotations for found loci
   --loci-vcf                  Save a VCF file for each found loci
   -C,--comparison-paths       Save a fasta file for a random selection of paths through loci
-  --coverages                 Save a file of coverages for each loci present - one number per base
   -M,--mapped-reads           Save a fasta file for each loci containing read parts which overlapped it
 
 Parameter Estimation:
@@ -187,10 +186,6 @@ Filtering:
 Consensus/Variant Calling:
   --genotype                  Add extra step to carefully genotype sites.
   --snps                      When genotyping, only include SNP sites
-  -d,--discover               Add a step to discover de novo variants
-  --discover-k INT            Kmer size to use when disovering de novo variants [default: 11]
-  --max-ins INT               Maximum insertion size allowed when discovering de novo variants. Warning: setting too long could cause performance degradation [default: 15]
-  --min-dbg-dp INT            Minimum depth on a node/kmer in the de Bruijn graph used for discovering de novo variants [default: 1]
   --kmer-avg INT              Maximum number of kmers to average over when selecting the maximum likelihood path [default: 100]
 
 Genotyping:
@@ -257,4 +252,59 @@ Genotyping:
   -F INT                      Minimum allele coverage, as a fraction of the expected coverage, allowed when genotyping [default: 0]
   -E,--gt-error-rate FLOAT    When genotyping, assume that coverage on alternative alleles arises as a result of an error process with rate -E. [default: 0.01]
   -G,--gt-conf INT            Minimum genotype confidence (GT_CONF) required to make a call [default: 1]
+```
+
+### Discover novel variants
+
+This will look for regions in the pangraph where the reads do not map and attempt to locally assemble these regions to find novel variants.
+
+```
+$ pandora discover --help
+Quasi-map reads to an indexed PRG, infer the sequence of present loci in the sample and discover novel variants.
+Usage: ./pandora discover [OPTIONS] <TARGET> <QUERY>
+
+Positionals:
+  <TARGET> FILE [required]    An indexed PRG file (in fasta format)
+  <QUERY> FILE [required]     Fast{a,q} file containing reads to quasi-map
+
+Options:
+  -h,--help                   Print this help message and exit
+  --discover-k INT            K-mer size to use when discovering novel variants [default: 11]
+  --max-ins INT               Max. insertion size for novel variants. Warning: setting too long may impair performance [default: 15]
+  --covg-threshold INT        Positions with coverage less than this will be tagged for variant discovery [default: 3]
+  -l INT                      Min. length of consecutive positions below coverage threshold to trigger variant discovery [default: 1]
+  -L INT                      Max. length of consecutive positions below coverage threshold to trigger variant discovery [default: 50]
+  -P,--pad INT                Padding either side of candidate variant intervals [default: 22]
+  -d,--merge INT              Merge candidate variant intervals within distance [default: 22]
+  --min-dbg-dp INT            Minimum node/kmer depth in the de Bruijn graph used for discovering variants [default: 2]
+  -v                          Verbosity of logging. Repeat for increased verbosity
+
+Indexing:
+  -w INT                      Window size for (w,k)-minimizers (must be <=k) [default: 14]
+  -k INT                      K-mer size for (w,k)-minimizers [default: 15]
+
+Input/Output:
+  -o,--outdir DIR             Directory to write output files to [default: pandora_discover]
+  -t,--threads INT            Maximum number of threads to use [default: 1]
+  --kg                        Save kmer graphs with forward and reverse coverage annotations for found loci
+  -M,--mapped-reads           Save a fasta file for each loci containing read parts which overlapped it
+
+Parameter Estimation:
+  -e,--error-rate FLOAT       Estimated error rate for reads [default: 0.11]
+  -g,--genome-size STR/INT    Estimated length of the genome - used for coverage estimation. Can pass string such as 4.4m, 100k etc. [default: 5000000]
+  --bin                       Use binomial model for kmer coverages [default: negative binomial]
+
+Mapping:
+  -m,--max-diff INT           Maximum distance (bp) between consecutive hits within a cluster [default: 250]
+  -c,--min-cluster-size INT   Minimum size of a cluster of hits between a read and a loci to consider the loci present [default: 10]
+
+Preset:
+  -I,--illumina               Reads are from Illumina. Alters error rate used and adjusts for shorter reads
+
+Filtering:
+  --clean                     Add a step to clean and detangle the pangraph
+  --max-covg INT              Maximum coverage of reads to accept [default: 600]
+
+Consensus/Variant Calling:
+  --kmer-avg INT              Maximum number of kmers to average over when selecting the maximum likelihood path [default: 100]
 ```

--- a/include/denovo_discovery/candidate_region.h
+++ b/include/denovo_discovery/candidate_region.h
@@ -87,26 +87,37 @@ private:
     Fastaq generate_fasta_for_denovo_paths();
 };
 
-std::vector<Interval> identify_low_coverage_intervals(
-    const std::vector<uint32_t>& covg_at_each_position,
-    const uint32_t& min_required_covg = 3, const uint32_t& min_length = 1,
-    const uint32_t& max_length = 76);
-
-using CandidateRegions = std::unordered_map<CandidateRegionIdentifier, CandidateRegion>;
-
-CandidateRegions find_candidate_regions_for_pan_node(
-    const TmpPanNode& pangraph_node_components,
-    const uint_least16_t& candidate_region_interval_padding = 0);
-
+using CandidateRegions
+= std::unordered_map<CandidateRegionIdentifier, CandidateRegion>;
 using ReadId = uint32_t;
-using PileupConstructionMap
-    = std::map<ReadId, std::vector<std::pair<CandidateRegion*, const ReadCoordinate*>>>;
+using PileupConstructionMap = std::map<ReadId,
+    std::vector<std::pair<CandidateRegion*, const ReadCoordinate*>>>;
 
-PileupConstructionMap construct_pileup_construction_map(
-    CandidateRegions& candidate_regions);
+class Discover {
+private:
+    const uint32_t min_required_covg;
+    const uint32_t min_candidate_len;
+    const uint32_t max_candidate_len;
+    const uint16_t candidate_padding;
+    const uint32_t merge_dist;
+public:
 
-void load_all_candidate_regions_pileups_from_fastq(const fs::path& reads_filepath,
-    const CandidateRegions& candidate_regions,
-    const PileupConstructionMap& pileup_construction_map, uint32_t threads = 1);
+    Discover(uint32_t, uint32_t, uint32_t, uint16_t, uint32_t);
+
+    std::vector<Interval> identify_low_coverage_intervals(
+        const std::vector<uint32_t>& covg_at_each_position);
+
+
+    CandidateRegions find_candidate_regions_for_pan_node(
+        const TmpPanNode& pangraph_node_components);
+
+
+    PileupConstructionMap pileup_construction_map(
+        CandidateRegions& candidate_regions);
+
+    void load_candidate_region_pileups(const fs::path& reads_filepath,
+        const CandidateRegions& candidate_regions,
+        const PileupConstructionMap& pileup_construction_map, uint32_t threads = 1);
+};
 
 #endif // PANDORA_CANDIDATE_REGION_H

--- a/include/denovo_discovery/candidate_region.h
+++ b/include/denovo_discovery/candidate_region.h
@@ -87,11 +87,10 @@ private:
     Fastaq generate_fasta_for_denovo_paths();
 };
 
-using CandidateRegions
-= std::unordered_map<CandidateRegionIdentifier, CandidateRegion>;
+using CandidateRegions = std::unordered_map<CandidateRegionIdentifier, CandidateRegion>;
 using ReadId = uint32_t;
-using PileupConstructionMap = std::map<ReadId,
-    std::vector<std::pair<CandidateRegion*, const ReadCoordinate*>>>;
+using PileupConstructionMap
+    = std::map<ReadId, std::vector<std::pair<CandidateRegion*, const ReadCoordinate*>>>;
 
 class Discover {
 private:
@@ -100,20 +99,18 @@ private:
     const uint32_t max_candidate_len;
     const uint16_t candidate_padding;
     const uint32_t merge_dist;
-public:
 
-    Discover(uint32_t, uint32_t, uint32_t, uint16_t, uint32_t);
+public:
+    Discover(uint32_t min_required_covg, uint32_t min_candidate_len,
+        uint32_t max_candidate_len, uint16_t candidate_padding, uint32_t merge_dist);
 
     std::vector<Interval> identify_low_coverage_intervals(
         const std::vector<uint32_t>& covg_at_each_position);
 
-
     CandidateRegions find_candidate_regions_for_pan_node(
         const TmpPanNode& pangraph_node_components);
 
-
-    PileupConstructionMap pileup_construction_map(
-        CandidateRegions& candidate_regions);
+    PileupConstructionMap pileup_construction_map(CandidateRegions& candidate_regions);
 
     void load_candidate_region_pileups(const fs::path& reads_filepath,
         const CandidateRegions& candidate_regions,

--- a/include/denovo_discovery/candidate_region.h
+++ b/include/denovo_discovery/candidate_region.h
@@ -89,8 +89,8 @@ private:
 
 std::vector<Interval> identify_low_coverage_intervals(
     const std::vector<uint32_t>& covg_at_each_position,
-    const uint32_t& min_required_covg = 2, const uint32_t& min_length = 1,
-    const uint32_t& max_length = 20);
+    const uint32_t& min_required_covg = 3, const uint32_t& min_length = 1,
+    const uint32_t& max_length = 76);
 
 using CandidateRegions = std::unordered_map<CandidateRegionIdentifier, CandidateRegion>;
 
@@ -107,6 +107,6 @@ PileupConstructionMap construct_pileup_construction_map(
 
 void load_all_candidate_regions_pileups_from_fastq(const fs::path& reads_filepath,
     const CandidateRegions& candidate_regions,
-    const PileupConstructionMap& pileup_construction_map, const uint32_t threads = 1);
+    const PileupConstructionMap& pileup_construction_map, uint32_t threads = 1);
 
 #endif // PANDORA_CANDIDATE_REGION_H

--- a/include/denovo_discovery/denovo_discovery.h
+++ b/include/denovo_discovery/denovo_discovery.h
@@ -14,7 +14,7 @@ namespace fs = boost::filesystem;
 
 class DenovoDiscovery {
 public:
-    const uint_least8_t min_covg_for_node_in_assembly_graph { 2 };
+    const uint_least8_t min_covg_for_node_in_assembly_graph { 1 };
     bool clean_assembly_graph { false };
     const uint8_t max_insertion_size;
 

--- a/include/denovo_discovery/denovo_discovery.h
+++ b/include/denovo_discovery/denovo_discovery.h
@@ -14,12 +14,12 @@ namespace fs = boost::filesystem;
 
 class DenovoDiscovery {
 public:
-    const uint_least8_t min_covg_for_node_in_assembly_graph { 1 };
+    const uint16_t min_covg_for_node_in_assembly_graph;
     bool clean_assembly_graph { false };
-    const uint8_t max_insertion_size;
+    const uint16_t max_insertion_size;
 
     DenovoDiscovery(const uint32_t& kmer_size, const double& read_error_rate,
-        const uint8_t max_insertion_size = 15);
+        uint16_t max_insertion_size = 15, uint16_t min_covg_for_node_in_assembly_graph = 1);
 
     void find_paths_through_candidate_region(
         CandidateRegion& candidate_region, const fs::path& denovo_output_directory);

--- a/include/denovo_discovery/discover_main.h
+++ b/include/denovo_discovery/discover_main.h
@@ -1,0 +1,51 @@
+#ifndef PANDORA_DISCOVER_MAIN_H
+#define PANDORA_DISCOVER_MAIN_H
+#include <boost/filesystem.hpp>
+#include <boost/log/core.hpp>
+#include <boost/log/expressions.hpp>
+#include <boost/log/trivial.hpp>
+#include "CLI11.hpp"
+#include "utils.h"
+#include "index.h"
+#include "pangenome/pangraph.h"
+#include "noise_filtering.h"
+#include "estimate_parameters.h"
+#include "denovo_discovery/candidate_region.h"
+#include "denovo_discovery/denovo_discovery.h"
+
+namespace fs = boost::filesystem;
+
+/// Collection of all options of discover subcommand.
+struct DiscoverOptions {
+    std::string prgfile;
+    std::string readsfile;
+    std::string outdir { "pandora_discover" };
+    uint32_t window_size { 14 };
+    uint32_t kmer_size { 15 };
+    uint32_t threads { 1 };
+    uint8_t verbosity { 0 };
+    float error_rate { 0.11 };
+    uint32_t genome_size { 5000000 };
+    uint32_t max_diff { 250 };
+    bool output_kg { false };
+    bool output_mapped_read_fa { false };
+    bool illumina { false };
+    bool clean { false };
+    bool binomial { false };
+    uint32_t max_covg { 600 };
+    uint32_t denovo_kmer_size { 11 };
+    uint16_t max_insertion_size { 15 };
+    uint16_t min_covg_for_node_in_assembly_graph { 2 };
+    uint32_t min_candidate_covg { 3 };
+    uint32_t min_candidate_len { 1 };
+    uint32_t max_candidate_len { 50 };
+    uint16_t candidate_padding { 22 };
+    uint32_t merge_dist { 22 };
+    uint32_t min_cluster_size { 10 };
+    uint32_t max_num_kmers_to_avg { 100 };
+};
+
+void setup_discover_subcommand(CLI::App& app);
+int pandora_discover(DiscoverOptions& opt);
+
+#endif // PANDORA_DISCOVER_MAIN_H

--- a/include/interval.h
+++ b/include/interval.h
@@ -12,7 +12,7 @@ struct Interval {
     uint32_t start;
     uint32_t length; // in pilot, longest prg was 208,562 characters long
 
-    Interval(uint32_t = 0, uint32_t = 0);
+    Interval(uint32_t s = 0, uint32_t e = 0);
 
     // non-inclusive
     uint32_t get_end() const;
@@ -28,6 +28,8 @@ struct Interval {
     bool operator<(const Interval& y) const;
 
     bool empty() const;
+
+    bool is_close(const Interval& other, uint32_t dist = 0) const;
 };
 
 // Merge intervals within dist of each other. Changes the vector inplace.

--- a/include/interval.h
+++ b/include/interval.h
@@ -3,14 +3,18 @@
 
 #include <cstdint>
 #include <iostream>
+#include <vector>
+#include <limits>
+#include <cassert>
+#include <algorithm>
 
 struct Interval {
     uint32_t start;
-    uint32_t length;
-    // in pilot, longest prg was 208,562 characters long
+    uint32_t length; // in pilot, longest prg was 208,562 characters long
 
     Interval(uint32_t = 0, uint32_t = 0);
 
+    // non-inclusive
     uint32_t get_end() const;
 
     friend std::ostream& operator<<(std::ostream& out, const Interval& i);
@@ -25,5 +29,9 @@ struct Interval {
 
     bool empty() const;
 };
+
+// Merge intervals within dist of each other. Changes the vector inplace.
+// Time complexity: O(N log(N)) Sort the vector, then a single linear pass through
+void merge_intervals_within(std::vector<Interval>&, uint32_t);
 
 #endif

--- a/include/map_main.h
+++ b/include/map_main.h
@@ -43,7 +43,6 @@ struct MapOptions {
     bool output_kg { false };
     bool output_vcf { false };
     bool output_comparison_paths { false };
-    bool output_covgs { false };
     bool output_mapped_read_fa { false };
     bool illumina { false };
     bool clean { false };
@@ -52,10 +51,6 @@ struct MapOptions {
     bool genotype { false };
     bool local_genotype { false };
     bool snps_only { false };
-    bool discover { false };
-    uint32_t denovo_kmer_size { 11 };
-    uint16_t max_insertion_size { 15 };
-    uint16_t min_covg_for_node_in_assembly_graph { 1 };
     uint32_t min_cluster_size { 10 };
     uint32_t max_num_kmers_to_avg { 100 };
     uint32_t min_allele_covg_gt { 0 };

--- a/include/map_main.h
+++ b/include/map_main.h
@@ -54,6 +54,8 @@ struct MapOptions {
     bool snps_only { false };
     bool discover { false };
     uint32_t denovo_kmer_size { 11 };
+    uint16_t max_insertion_size { 15 };
+    uint16_t min_covg_for_node_in_assembly_graph { 1 };
     uint32_t min_cluster_size { 10 };
     uint32_t max_num_kmers_to_avg { 100 };
     uint32_t min_allele_covg_gt { 0 };

--- a/include/utils.h
+++ b/include/utils.h
@@ -100,4 +100,13 @@ void open_file_for_writing(const std::string& file_path, std::ofstream& stream);
 
 std::vector<std::string> get_vector_of_strings_from_file(const std::string& file_path);
 
+// string to genome size
+// effectively a copy of
+// https://github.com/lh3/minimap2/blob/6a4b9f9082b66597185a97c847b548250363d65a/main.c#L84
+uint32_t strtogs(const char*);
+
+// used to transofmr the CLI string
+// https://cliutils.github.io/CLI11/book/chapters/validators.html
+std::string transform_cli_gsize(std::string);
+
 #endif

--- a/src/compare_main.cpp
+++ b/src/compare_main.cpp
@@ -58,12 +58,13 @@ void setup_compare_subcommand(CLI::App& app)
         ->capture_default_str()
         ->group("Parameter Estimation");
 
-    // todo: how necessary is this opt if we remove max_cog?
     compare_subcmd
         ->add_option("-g,--genome-size", opt->genome_size,
-            "Estimated length of the genome - used for coverage estimation")
+            "Estimated length of the genome - used for coverage estimation. Can pass "
+            "string such as 4.4m, 100k etc.")
+        ->transform(transform_cli_gsize)
         ->capture_default_str()
-        ->type_name("INT")
+        ->type_name("STR/INT")
         ->group("Parameter Estimation");
 
     compare_subcmd

--- a/src/denovo_discovery/candidate_region.cpp
+++ b/src/denovo_discovery/candidate_region.cpp
@@ -100,6 +100,14 @@ CandidateRegions find_candidate_regions_for_pan_node(
     const auto covgs_along_localnode_path { get_covgs_along_localnode_path(
         pangraph_node, local_node_max_likelihood_path, kmer_node_max_likelihood_path,
         sample_id) };
+
+    uint i { 1 };
+    BOOST_LOG_TRIVIAL(trace) << "Coverage along localnode path";
+    for (const auto& cov : covgs_along_localnode_path) {
+        BOOST_LOG_TRIVIAL(trace) << i << ": " << cov;
+        i++;
+    }
+
     const auto candidate_intervals { identify_low_coverage_intervals(
         covgs_along_localnode_path) };
 
@@ -322,6 +330,6 @@ void load_all_candidate_regions_pileups_from_fastq(const fs::path& reads_filepat
             }
         }
     }
-    BOOST_LOG_TRIVIAL(info) << " Loaded all candidate regions pileups from "
+    BOOST_LOG_TRIVIAL(info) << "Loaded all candidate regions pileups from "
                             << reads_filepath.string();
 }

--- a/src/denovo_discovery/candidate_region.cpp
+++ b/src/denovo_discovery/candidate_region.cpp
@@ -284,9 +284,6 @@ void load_all_candidate_regions_pileups_from_fastq(const fs::path& reads_filepat
             {
                 // TODO: we need to read only until the max read id
                 for (auto& id_and_sequence : sequencesBuffer) {
-                    if (id && id % 100000 == 0) {
-                        BOOST_LOG_TRIVIAL(info) << id << " reads processed...";
-                    }
                     try {
                         fh.get_next();
                     } catch (std::out_of_range& err) {

--- a/src/denovo_discovery/denovo_discovery.cpp
+++ b/src/denovo_discovery/denovo_discovery.cpp
@@ -125,9 +125,10 @@ void DenovoDiscovery::find_paths_through_candidate_region(
             }
         }
     }
-    BOOST_LOG_TRIVIAL(debug) << "Could not find any combination of start and end "
-                                "k-mers. Skipping local assembly for "
-                             << candidate_region.get_name();
+    BOOST_LOG_TRIVIAL(debug)
+        << "Could not find any combination of start and end "
+           "k-mers with a path between them. Skipping local assembly for "
+        << candidate_region.get_name();
     remove_graph_file(GATB_graph_filepath);
 }
 

--- a/src/denovo_discovery/denovo_discovery.cpp
+++ b/src/denovo_discovery/denovo_discovery.cpp
@@ -133,8 +133,10 @@ void DenovoDiscovery::find_paths_through_candidate_region(
 }
 
 DenovoDiscovery::DenovoDiscovery(const uint32_t& kmer_size,
-    const double& read_error_rate, const uint8_t max_insertion_size)
-    : max_insertion_size { max_insertion_size }
+    const double& read_error_rate, const uint16_t max_insertion_size,
+    const uint16_t min_covg_for_node_in_assembly_graph)
+    : min_covg_for_node_in_assembly_graph { min_covg_for_node_in_assembly_graph }
+    , max_insertion_size { max_insertion_size }
     , kmer_size { kmer_size }
     , read_error_rate { read_error_rate }
 {

--- a/src/denovo_discovery/denovo_discovery.cpp
+++ b/src/denovo_discovery/denovo_discovery.cpp
@@ -60,18 +60,27 @@ void DenovoDiscovery::find_paths_through_candidate_region(
 
     for (uint_least16_t start_idx = 0; start_idx < start_kmers.size(); start_idx++) {
         const auto& current_start_kmer { start_kmers[start_idx] };
+        BOOST_LOG_TRIVIAL(trace)
+            << "Searching for start anchor kmer " << current_start_kmer;
         std::tie(start_node, start_found) = graph.get_node(current_start_kmer);
 
         if (not start_found) {
+            BOOST_LOG_TRIVIAL(trace)
+                << "Did not find start anchor kmer " << current_start_kmer;
             continue;
         }
+        BOOST_LOG_TRIVIAL(trace) << "Found start anchor kmer " << current_start_kmer;
 
         for (uint_least16_t end_idx = 0; end_idx < end_kmers.size(); end_idx++) {
             const auto& current_end_kmer { end_kmers[end_idx] };
 
+            BOOST_LOG_TRIVIAL(trace)
+                << "Searching for end anchor kmer " << current_end_kmer;
             std::tie(end_node, end_found) = graph.get_node(current_end_kmer);
 
             if (end_found) {
+                BOOST_LOG_TRIVIAL(trace)
+                    << "Found end anchor kmer " << current_end_kmer;
                 DenovoPaths denovo_paths;
                 FoundPaths abandoned;
                 std::tie(denovo_paths, abandoned) = graph.get_paths_between(
@@ -110,6 +119,9 @@ void DenovoDiscovery::find_paths_through_candidate_region(
                     remove_graph_file(GATB_graph_filepath);
                     return;
                 }
+            } else {
+                BOOST_LOG_TRIVIAL(trace)
+                    << "Did not find end anchor kmer " << current_end_kmer;
             }
         }
     }

--- a/src/denovo_discovery/local_assembly.cpp
+++ b/src/denovo_discovery/local_assembly.cpp
@@ -61,7 +61,6 @@ std::pair<Node, bool> LocalAssemblyGraph::get_node(const std::string& query_kmer
 DfsTree LocalAssemblyGraph::depth_first_search_from(
     const Node& start_node, bool reverse)
 {
-    BOOST_LOG_TRIVIAL(debug) << "Starting DFS...";
     std::stack<Node> nodes_to_explore({ start_node });
 
     std::unordered_set<std::string> explored_nodes;
@@ -86,7 +85,6 @@ DfsTree LocalAssemblyGraph::depth_first_search_from(
             nodes_to_explore.push(children_of_current_node[i]);
         }
     }
-    BOOST_LOG_TRIVIAL(debug) << "DFS finished.";
     return tree_of_nodes_visited;
 }
 
@@ -98,8 +96,6 @@ nodes
 BfsDistanceMap LocalAssemblyGraph::breadth_first_search_from(
     const Node& start_node, bool reverse)
 {
-    BOOST_LOG_TRIVIAL(debug) << "Starting BFS...";
-
     std::unordered_set<std::string> explored_nodes;
     BfsDistanceMap node_to_distance_to_the_start_node;
     std::map<std::string, std::string> child_kmer_to_parent_kmer;
@@ -134,7 +130,6 @@ BfsDistanceMap LocalAssemblyGraph::breadth_first_search_from(
                 = current_kmer;
         }
     }
-    BOOST_LOG_TRIVIAL(debug) << "BFS finished.";
     return node_to_distance_to_the_start_node;
 }
 
@@ -159,8 +154,14 @@ std::pair<DenovoPaths, FoundPaths> LocalAssemblyGraph::get_paths_between(
     // check if end node is in forward tree, if not just return
     bool end_kmer_not_reachable_from_start_kmer = tree.find(end_kmer) == tree.end();
     if (end_kmer_not_reachable_from_start_kmer) {
+        BOOST_LOG_TRIVIAL(trace)
+            << "End kmer " << end_kmer << " is not reachable from start kmer "
+            << start_kmer << " in the de novo de Bruijn graph";
         return std::make_pair(paths_between_queries, abandoned);
     }
+    BOOST_LOG_TRIVIAL(trace) << "A valid path exists between start anchor kmer "
+                             << start_kmer << " and end anchor kmer " << end_kmer
+                             << " in the de novo de Bruijn graph";
 
     auto node_to_distance_to_the_end_node { breadth_first_search_from(end_node, true) };
 

--- a/src/fastaq.cpp
+++ b/src/fastaq.cpp
@@ -28,8 +28,8 @@ char Fastaq::covg_to_score(
     }
     // Rachel's original (and default) coverage to ASCII conversion function
     if (2 * global_covg < covg) {
-        BOOST_LOG_TRIVIAL(debug)
-            << "Found a base with a coverage way too high, so giving it a score of 0";
+        BOOST_LOG_TRIVIAL(trace) << "Found a base with a coverage way too high ("
+                                 << covg << "), so giving it a score of 0";
         return '!';
     }
 

--- a/src/localgraph.cpp
+++ b/src/localgraph.cpp
@@ -354,7 +354,7 @@ std::vector<LocalNodePtr> LocalGraph::nodes_along_string(
         // found no successful path, so return an empty vector
         return npath;
     } else {
-        BOOST_LOG_TRIVIAL(debug) << "have " << w.size() << "candidates";
+        BOOST_LOG_TRIVIAL(debug) << "have " << w.size() << " candidates";
         // find the most exact match, the one which covers all sequence with minimal
         // extra to end of graph, or longest
         auto longest_length = 0;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -8,6 +8,7 @@
 #include "get_vcf_ref_main.h"
 #include "random_main.h"
 #include "merge_index_main.h"
+#include "denovo_discovery/discover_main.h"
 
 class MyFormatter : public CLI::Formatter {
 public:
@@ -58,6 +59,7 @@ int main(int argc, char* argv[])
     setup_index_subcommand(app);
     setup_map_subcommand(app);
     setup_compare_subcommand(app);
+    setup_discover_subcommand(app);
     setup_walk_subcommand(app);
     setup_seq2path_subcommand(app);
     setup_get_vcf_ref_subcommand(app);

--- a/src/map_main.cpp
+++ b/src/map_main.cpp
@@ -146,6 +146,22 @@ void setup_map_subcommand(CLI::App& app)
         ->type_name("INT")
         ->group("Consensus/Variant Calling");
 
+    description = "Max. insertion size when discovering de novo variants. Warning: "
+                  "setting too long may impair performance";
+    map_subcmd->add_option("--max-ins", opt->max_insertion_size, description)
+        ->capture_default_str()
+        ->type_name("INT")
+        ->group("Consensus/Variant Calling");
+
+    description = "Minimum node/kmer depth in the de Bruijn graph used for discovering "
+                  "de novo variants";
+    map_subcmd
+        ->add_option(
+            "--min-dbg-dp", opt->min_covg_for_node_in_assembly_graph, description)
+        ->capture_default_str()
+        ->type_name("INT")
+        ->group("Consensus/Variant Calling");
+
     description
         = "Minimum size of a cluster of hits between a read and a loci to consider "
           "the loci present";
@@ -430,7 +446,8 @@ int pandora_map(MapOptions& opt)
     }
 
     if (opt.discover) {
-        DenovoDiscovery denovo { opt.denovo_kmer_size, opt.error_rate };
+        DenovoDiscovery denovo { opt.denovo_kmer_size, opt.error_rate,
+            opt.max_insertion_size, opt.min_covg_for_node_in_assembly_graph };
         const fs::path denovo_output_directory { fs::path(opt.outdir)
             / "denovo_paths" };
         fs::create_directories(denovo_output_directory);

--- a/src/map_main.cpp
+++ b/src/map_main.cpp
@@ -58,12 +58,13 @@ void setup_map_subcommand(CLI::App& app)
         ->capture_default_str()
         ->group("Parameter Estimation");
 
-    // todo: how necessary is this opt if we remove max_cog?
     map_subcmd
         ->add_option("-g,--genome-size", opt->genome_size,
-            "Estimated length of the genome - used for coverage estimation")
+            "Estimated length of the genome - used for coverage estimation. Can pass "
+            "string such as 4.4m, 100k etc.")
+        ->transform(transform_cli_gsize)
         ->capture_default_str()
-        ->type_name("INT")
+        ->type_name("STR/INT")
         ->group("Parameter Estimation");
 
     map_subcmd

--- a/src/map_main.cpp
+++ b/src/map_main.cpp
@@ -276,11 +276,11 @@ int pandora_map(MapOptions& opt)
                             << "/pandora.pangraph.gfa";
     write_pangraph_gfa(opt.outdir + "/pandora.pangraph.gfa", pangraph);
 
-    BOOST_LOG_TRIVIAL(info) << "Update LocalPRGs with hits...";
+    BOOST_LOG_TRIVIAL(info) << "Updating local PRGs with hits...";
     uint32_t sample_id = 0;
     pangraph->add_hits_to_kmergraphs(prgs);
 
-    BOOST_LOG_TRIVIAL(info) << "Estimate parameters for kmer graph model...";
+    BOOST_LOG_TRIVIAL(info) << "Estimating parameters for kmer graph model...";
     auto exp_depth_covg = estimate_parameters(pangraph, opt.outdir, opt.kmer_size,
         opt.error_rate, covg, opt.binomial, sample_id);
     genotyping_options.add_exp_depth_covg(exp_depth_covg);
@@ -389,7 +389,8 @@ int pandora_map(MapOptions& opt)
     // build the pileup for candidate regions multithreadly
     if (opt.discover) {
         BOOST_LOG_TRIVIAL(info)
-            << "Building read pileups for candidate de novo regions...";
+            << "Building read pileups for " << candidate_regions.size()
+            << " candidate de novo regions...";
         // the construct_pileup_construction_map function is intentionally left
         // single threaded since it would require too much synchronization
         const auto pileup_construction_map

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -620,3 +620,31 @@ std::vector<std::string> get_vector_of_strings_from_file(const std::string& file
 
     return lines;
 }
+
+uint32_t strtogs(const char* str)
+{
+    double x;
+    char* p;
+    x = strtod(str, &p);
+
+    if (x < 0) {
+        throw std::logic_error("Negative number passed for genome size");
+    }
+
+    if (*p == 'G' || *p == 'g') {
+        x *= 1e9;
+    } else if (*p == 'M' || *p == 'm') {
+        x *= 1e6;
+    } else if (*p == 'K' || *p == 'k') {
+        x *= 1e3;
+    }
+    if (x > UINT32_MAX) {
+        throw std::runtime_error(
+            "Cannot handle genome size larger than 32-bit unsigned integer");
+    }
+    return (uint32_t)(x + .499);
+}
+
+std::string transform_cli_gsize(std::string str) {
+    return int_to_string(strtogs(str.c_str()));
+}

--- a/test/denovo_discovery/candidate_region_test.cpp
+++ b/test/denovo_discovery/candidate_region_test.cpp
@@ -156,9 +156,13 @@ TEST(IdentifyLowCoverageIntervalsTest, emptyCovgsReturnEmpty)
 {
     const auto min_len { 5 };
     const auto min_covg { 0 };
+    const auto max_len { 99 };
+    const auto pad { 0 };
+    const auto dist { 0 };
+    Discover discover { min_covg, min_len, max_len, pad, dist };
     const std::vector<uint32_t> covgs;
 
-    const auto actual { identify_low_coverage_intervals(covgs, min_covg, min_len) };
+    const auto actual { discover.identify_low_coverage_intervals(covgs) };
     const std::vector<Interval> expected;
 
     EXPECT_EQ(actual, expected);
@@ -168,9 +172,13 @@ TEST(IdentifyLowCoverageIntervalsTest, singleCovgPositionAboveThresholdReturnEmp
 {
     const auto min_len { 1 };
     const auto min_covg { 1 };
+    const auto max_len { 99 };
+    const auto pad { 0 };
+    const auto dist { 0 };
+    Discover discover { min_covg, min_len, max_len, pad, dist };
     const std::vector<uint32_t> covgs { 2 };
 
-    const auto actual { identify_low_coverage_intervals(covgs, min_covg, min_len) };
+    const auto actual { discover.identify_low_coverage_intervals(covgs) };
     const std::vector<Interval> expected;
 
     EXPECT_EQ(actual, expected);
@@ -181,9 +189,13 @@ TEST(IdentifyLowCoverageIntervalsTest,
 {
     const auto min_len { 1 };
     const auto min_covg { 3 };
+    const auto max_len { 99 };
+    const auto pad { 0 };
+    const auto dist { 0 };
+    Discover discover { min_covg, min_len, max_len, pad, dist };
     const std::vector<uint32_t> covgs { 2 };
 
-    const auto actual { identify_low_coverage_intervals(covgs, min_covg, min_len) };
+    const auto actual { discover.identify_low_coverage_intervals(covgs) };
     const std::vector<Interval> expected { Interval(0, 1) };
 
     EXPECT_EQ(actual, expected);
@@ -193,9 +205,13 @@ TEST(IdentifyLowCoverageIntervalsTest, allPositionsAboveThresholdReturnEmpty)
 {
     const auto min_len { 1 };
     const auto min_covg { 1 };
+    const auto max_len { 99 };
+    const auto pad { 0 };
+    const auto dist { 0 };
+    Discover discover { min_covg, min_len, max_len, pad, dist };
     const std::vector<uint32_t> covgs { 2, 2, 2, 2 };
 
-    const auto actual { identify_low_coverage_intervals(covgs, min_covg, min_len) };
+    const auto actual { discover.identify_low_coverage_intervals(covgs) };
     const std::vector<Interval> expected;
 
     EXPECT_EQ(actual, expected);
@@ -206,9 +222,13 @@ TEST(IdentifyLowCoverageIntervalsTest,
 {
     const auto min_len { 1 };
     const auto min_covg { 3 };
+    const auto max_len { 99 };
+    const auto pad { 0 };
+    const auto dist { 0 };
+    Discover discover { min_covg, min_len, max_len, pad, dist };
     const std::vector<uint32_t> covgs { 2, 2, 2, 2 };
 
-    const auto actual { identify_low_coverage_intervals(covgs, min_covg, min_len) };
+    const auto actual { discover.identify_low_coverage_intervals(covgs) };
     const std::vector<Interval> expected { Interval(0, 4) };
 
     EXPECT_EQ(actual, expected);
@@ -219,9 +239,13 @@ TEST(IdentifyLowCoverageIntervalsTest,
 {
     const auto min_len { 10 };
     const auto min_covg { 3 };
+    const auto max_len { 99 };
+    const auto pad { 0 };
+    const auto dist { 0 };
+    Discover discover { min_covg, min_len, max_len, pad, dist };
     const std::vector<uint32_t> covgs { 2, 2, 2, 2 };
 
-    const auto actual { identify_low_coverage_intervals(covgs, min_covg, min_len) };
+    const auto actual { discover.identify_low_coverage_intervals(covgs) };
     const std::vector<Interval> expected;
 
     EXPECT_EQ(actual, expected);
@@ -232,9 +256,13 @@ TEST(IdentifyLowCoverageIntervalsTest,
 {
     const auto min_len { 3 };
     const auto min_covg { 3 };
+    const auto max_len { 99 };
+    const auto pad { 0 };
+    const auto dist { 0 };
+    Discover discover { min_covg, min_len, max_len, pad, dist };
     const std::vector<uint32_t> covgs { 2, 2, 4, 4, 4 };
 
-    const auto actual { identify_low_coverage_intervals(covgs, min_covg, min_len) };
+    const auto actual { discover.identify_low_coverage_intervals(covgs) };
     const std::vector<Interval> expected;
 
     EXPECT_EQ(actual, expected);
@@ -245,9 +273,13 @@ TEST(IdentifyLowCoverageIntervalsTest,
 {
     const auto min_len { 3 };
     const auto min_covg { 3 };
+    const auto max_len { 99 };
+    const auto pad { 0 };
+    const auto dist { 0 };
+    Discover discover { min_covg, min_len, max_len, pad, dist };
     const std::vector<uint32_t> covgs { 4, 2, 2, 4, 4 };
 
-    const auto actual { identify_low_coverage_intervals(covgs, min_covg, min_len) };
+    const auto actual { discover.identify_low_coverage_intervals(covgs) };
     const std::vector<Interval> expected;
 
     EXPECT_EQ(actual, expected);
@@ -258,9 +290,13 @@ TEST(IdentifyLowCoverageIntervalsTest,
 {
     const auto min_len { 3 };
     const auto min_covg { 3 };
+    const auto max_len { 99 };
+    const auto pad { 0 };
+    const auto dist { 0 };
+    Discover discover { min_covg, min_len, max_len, pad, dist };
     const std::vector<uint32_t> covgs { 4, 4, 4, 2, 2 };
 
-    const auto actual { identify_low_coverage_intervals(covgs, min_covg, min_len) };
+    const auto actual { discover.identify_low_coverage_intervals(covgs) };
     const std::vector<Interval> expected;
 
     EXPECT_EQ(actual, expected);
@@ -271,9 +307,13 @@ TEST(IdentifyLowCoverageIntervalsTest,
 {
     const auto min_len { 2 };
     const auto min_covg { 3 };
+    const auto max_len { 99 };
+    const auto pad { 0 };
+    const auto dist { 0 };
+    Discover discover { min_covg, min_len, max_len, pad, dist };
     const std::vector<uint32_t> covgs { 2, 2, 4, 4, 4 };
 
-    const auto actual { identify_low_coverage_intervals(covgs, min_covg, min_len) };
+    const auto actual { discover.identify_low_coverage_intervals(covgs) };
     const std::vector<Interval> expected { Interval(0, 2) };
 
     EXPECT_EQ(actual, expected);
@@ -284,9 +324,13 @@ TEST(IdentifyLowCoverageIntervalsTest,
 {
     const auto min_len { 1 };
     const auto min_covg { 3 };
+    const auto max_len { 99 };
+    const auto pad { 0 };
+    const auto dist { 0 };
+    Discover discover { min_covg, min_len, max_len, pad, dist };
     const std::vector<uint32_t> covgs { 4, 2, 2, 4, 4 };
 
-    const auto actual { identify_low_coverage_intervals(covgs, min_covg, min_len) };
+    const auto actual { discover.identify_low_coverage_intervals(covgs) };
     const std::vector<Interval> expected { Interval(1, 3) };
 
     EXPECT_EQ(actual, expected);
@@ -297,9 +341,13 @@ TEST(IdentifyLowCoverageIntervalsTest,
 {
     const auto min_len { 2 };
     const auto min_covg { 3 };
+    const auto max_len { 99 };
+    const auto pad { 0 };
+    const auto dist { 0 };
+    Discover discover { min_covg, min_len, max_len, pad, dist };
     const std::vector<uint32_t> covgs { 4, 4, 4, 2, 2 };
 
-    const auto actual { identify_low_coverage_intervals(covgs, min_covg, min_len) };
+    const auto actual { discover.identify_low_coverage_intervals(covgs) };
     const std::vector<Interval> expected { Interval(3, 5) };
 
     EXPECT_EQ(actual, expected);
@@ -310,9 +358,13 @@ TEST(IdentifyLowCoverageIntervalsTest,
 {
     const auto min_len { 2 };
     const auto min_covg { 3 };
+    const auto max_len { 99 };
+    const auto pad { 0 };
+    const auto dist { 0 };
+    Discover discover { min_covg, min_len, max_len, pad, dist };
     const std::vector<uint32_t> covgs { 2, 2, 4, 4, 4, 2, 2 };
 
-    const auto actual { identify_low_coverage_intervals(covgs, min_covg, min_len) };
+    const auto actual { discover.identify_low_coverage_intervals(covgs) };
     const std::vector<Interval> expected { Interval(0, 2), Interval(5, 7) };
 
     EXPECT_EQ(actual, expected);
@@ -322,9 +374,13 @@ TEST(IdentifyLowCoverageIntervalsTest, twoRegionsBelowThresholdReturnTwoInterval
 {
     const auto min_len { 2 };
     const auto min_covg { 3 };
+    const auto max_len { 99 };
+    const auto pad { 0 };
+    const auto dist { 0 };
+    Discover discover { min_covg, min_len, max_len, pad, dist };
     const std::vector<uint32_t> covgs { 4, 2, 1, 1, 4, 1, 2, 4 };
 
-    const auto actual { identify_low_coverage_intervals(covgs, min_covg, min_len) };
+    const auto actual { discover.identify_low_coverage_intervals(covgs) };
     const std::vector<Interval> expected { Interval(1, 4), Interval(5, 7) };
 
     EXPECT_EQ(actual, expected);
@@ -335,9 +391,13 @@ TEST(IdentifyLowCoverageIntervalsTest,
 {
     const auto min_len { 3 };
     const auto min_covg { 3 };
+    const auto max_len { 99 };
+    const auto pad { 0 };
+    const auto dist { 0 };
+    Discover discover { min_covg, min_len, max_len, pad, dist };
     const std::vector<uint32_t> covgs { 4, 2, 1, 1, 4, 1, 2, 4 };
 
-    const auto actual { identify_low_coverage_intervals(covgs, min_covg, min_len) };
+    const auto actual { discover.identify_low_coverage_intervals(covgs) };
     const std::vector<Interval> expected { Interval(1, 4) };
 
     EXPECT_EQ(actual, expected);
@@ -348,10 +408,12 @@ TEST(IdentifyLowCoverageIntervalsTest,
     const auto min_len { 2 };
     const auto max_len { 4 };
     const auto min_covg { 3 };
+    const auto pad { 0 };
+    const auto dist { 0 };
+    Discover discover { min_covg, min_len, max_len, pad, dist };
     const std::vector<uint32_t> covgs { 4, 2, 1, 1, 1, 4, 1, 2, 4 };
 
-    const auto actual { identify_low_coverage_intervals(
-        covgs, min_covg, min_len, max_len) };
+    const auto actual { discover.identify_low_coverage_intervals(covgs) };
     const std::vector<Interval> expected { Interval(1, 5), Interval(6, 8) };
 
     EXPECT_EQ(actual, expected);
@@ -363,16 +425,24 @@ TEST(IdentifyLowCoverageIntervalsTest,
     const auto min_len { 2 };
     const auto max_len { 4 };
     const auto min_covg { 3 };
+    const auto pad { 0 };
+    const auto dist { 0 };
+    Discover discover { min_covg, min_len, max_len, pad, dist };
     const std::vector<uint32_t> covgs { 4, 2, 1, 1, 1, 2, 4, 1, 2, 4 };
 
-    const auto actual { identify_low_coverage_intervals(
-        covgs, min_covg, min_len, max_len) };
+    const auto actual { discover.identify_low_coverage_intervals(covgs) };
     const std::vector<Interval> expected { Interval(7, 9) };
 
     EXPECT_EQ(actual, expected);
 }
 TEST(FindCandidateRegionsForPanNodeTest, emptyPanNodeReturnsNoCandidates)
 {
+    const auto min_len { 2 };
+    const auto max_len { 4 };
+    const auto min_covg { 3 };
+    const auto pad { 0 };
+    const auto dist { 0 };
+    Discover discover { min_covg, min_len, max_len, pad, dist };
     const auto num_samples { 1 };
     const auto prg_id { 3 };
     auto local_prg_ptr { std::make_shared<LocalPRG>(prg_id, "test", "") };
@@ -386,13 +456,20 @@ TEST(FindCandidateRegionsForPanNodeTest, emptyPanNodeReturnsNoCandidates)
         kmer_node_max_likelihood_path, local_node_max_likelihood_path };
 
     const CandidateRegions expected;
-    const auto actual { find_candidate_regions_for_pan_node(pangraph_node_components) };
+    const auto actual { discover.find_candidate_regions_for_pan_node(
+        pangraph_node_components) };
 
     EXPECT_EQ(actual, expected);
 }
 
 TEST(FindCandidateRegionsForPanNodeTest, noCoverageReturnWholePrgAsCandidate)
 {
+    const auto min_len { 2 };
+    const auto max_len { 99 };
+    const auto min_covg { 3 };
+    const auto pad { 0 };
+    const auto dist { 0 };
+    Discover discover { min_covg, min_len, max_len, pad, dist };
     const auto num_samples { 1 };
     const auto prg_id { 3 };
     auto local_prg_ptr { std::make_shared<LocalPRG>(
@@ -420,7 +497,8 @@ TEST(FindCandidateRegionsForPanNodeTest, noCoverageReturnWholePrgAsCandidate)
     expected_candidate.max_likelihood_sequence = expected_sequence;
     const CandidateRegions expected { std::make_pair(
         expected_candidate.get_id(), expected_candidate) };
-    const auto actual { find_candidate_regions_for_pan_node(pangraph_node_components) };
+    const auto actual { discover.find_candidate_regions_for_pan_node(
+        pangraph_node_components) };
     const auto actual_sequence {
         actual.at(expected_candidate.get_id()).max_likelihood_sequence
     };
@@ -431,6 +509,12 @@ TEST(FindCandidateRegionsForPanNodeTest, noCoverageReturnWholePrgAsCandidate)
 
 TEST(FindCandidateRegionsForPanNodeTest, highCoverageReturnEmpty)
 {
+    const auto min_len { 2 };
+    const auto max_len { 4 };
+    const auto min_covg { 3 };
+    const auto pad { 0 };
+    const auto dist { 0 };
+    Discover discover { min_covg, min_len, max_len, pad, dist };
     const auto num_samples { 1 };
     const auto prg_id { 3 };
     auto local_prg_ptr { std::make_shared<LocalPRG>(
@@ -460,7 +544,8 @@ TEST(FindCandidateRegionsForPanNodeTest, highCoverageReturnEmpty)
         kmer_node_max_likelihood_path, local_node_max_likelihood_path };
 
     const CandidateRegions expected;
-    const auto actual { find_candidate_regions_for_pan_node(pangraph_node_components) };
+    const auto actual { discover.find_candidate_regions_for_pan_node(
+        pangraph_node_components) };
 
     EXPECT_EQ(actual, expected);
 }
@@ -468,6 +553,12 @@ TEST(FindCandidateRegionsForPanNodeTest, highCoverageReturnEmpty)
 TEST(
     FindCandidateRegionsForPanNodeTest, noCoverageOnFiveBasesReturnFiveBasesAsCandidate)
 {
+    const auto min_len { 2 };
+    const auto max_len { 99 };
+    const auto min_covg { 3 };
+    const auto pad { 0 };
+    const auto dist { 0 };
+    Discover discover { min_covg, min_len, max_len, pad, dist };
     const auto num_samples { 1 };
     const auto prg_id { 3 };
     auto local_prg_ptr { std::make_shared<LocalPRG>(
@@ -502,7 +593,8 @@ TEST(
     CandidateRegion expected_candidate { Interval(3, 8), pangraph_node->get_name() };
     const CandidateRegions expected { std::make_pair(
         expected_candidate.get_id(), expected_candidate) };
-    const auto actual { find_candidate_regions_for_pan_node(pangraph_node_components) };
+    const auto actual { discover.find_candidate_regions_for_pan_node(
+        pangraph_node_components) };
     const auto actual_sequence {
         actual.at(expected_candidate.get_id()).get_max_likelihood_sequence_with_flanks()
     };
@@ -514,6 +606,12 @@ TEST(
 TEST(FindCandidateRegionsForPanNodeTest,
     noCoverageOnFiveBasesReturnFiveBasesPlusPaddingAsCandidate)
 {
+    const auto min_len { 2 };
+    const auto max_len { 40 };
+    const auto min_covg { 3 };
+    const auto pad { 1 };
+    const auto dist { 0 };
+    Discover discover { min_covg, min_len, max_len, pad, dist };
     const auto prg_id { 3 };
     auto local_prg_ptr { std::make_shared<LocalPRG>(
         prg_id, "test", "AAAA 5 GGG 6 CCC 5 TTTT") };
@@ -553,13 +651,12 @@ TEST(FindCandidateRegionsForPanNodeTest,
     const TmpPanNode pangraph_node_components { pangraph_node, local_prg_ptr,
         kmer_node_max_likelihood_path, local_node_max_likelihood_path };
 
-    const auto interval_padding { 1 };
     CandidateRegion expected_candidate { Interval(3, 8), pangraph_node->get_name(),
-        interval_padding };
+        pad };
     const CandidateRegions expected { std::make_pair(
         expected_candidate.get_id(), expected_candidate) };
-    const auto actual { find_candidate_regions_for_pan_node(
-        pangraph_node_components, interval_padding) };
+    const auto actual { discover.find_candidate_regions_for_pan_node(
+        pangraph_node_components) };
     const auto actual_sequence {
         actual.at(expected_candidate.get_id()).get_max_likelihood_sequence_with_flanks()
     };
@@ -575,6 +672,12 @@ TEST(FindCandidateRegionsForPanNodeTest,
 TEST(FindCandidateRegionsForPanNodeTest,
     noCoverageOnStartFiveBasesReturnFiveBasesAsCandidate)
 {
+    const auto min_len { 2 };
+    const auto max_len { 99 };
+    const auto min_covg { 3 };
+    const auto pad { 0 };
+    const auto dist { 0 };
+    Discover discover { min_covg, min_len, max_len, pad, dist };
     const auto prg_id { 3 };
     auto local_prg_ptr { std::make_shared<LocalPRG>(
         prg_id, "test", "AAAA 5 GGG 6 CCC 5 TTTT") };
@@ -614,13 +717,12 @@ TEST(FindCandidateRegionsForPanNodeTest,
     const TmpPanNode pangraph_node_components { pangraph_node, local_prg_ptr,
         kmer_node_max_likelihood_path, local_node_max_likelihood_path };
 
-    const auto interval_padding { 0 };
     CandidateRegion expected_candidate { Interval(0, 5), pangraph_node->get_name(),
-        interval_padding };
+        pad };
     const CandidateRegions expected { std::make_pair(
         expected_candidate.get_id(), expected_candidate) };
-    const auto actual { find_candidate_regions_for_pan_node(
-        pangraph_node_components, interval_padding) };
+    const auto actual { discover.find_candidate_regions_for_pan_node(
+        pangraph_node_components) };
     const auto actual_sequence {
         actual.at(expected_candidate.get_id()).get_max_likelihood_sequence_with_flanks()
     };
@@ -636,6 +738,12 @@ TEST(FindCandidateRegionsForPanNodeTest,
 TEST(FindCandidateRegionsForPanNodeTest,
     noCoverageOnEndFiveBasesReturnFiveBasesAsCandidate)
 {
+    const auto min_len { 2 };
+    const auto max_len { 99 };
+    const auto min_covg { 3 };
+    const auto pad { 0 };
+    const auto dist { 0 };
+    Discover discover { min_covg, min_len, max_len, pad, dist };
     const auto prg_id { 3 };
     auto local_prg_ptr { std::make_shared<LocalPRG>(
         prg_id, "test", "AAAA 5 GGG 6 CCC 5 TTTT") };
@@ -675,13 +783,12 @@ TEST(FindCandidateRegionsForPanNodeTest,
     const TmpPanNode pangraph_node_components { pangraph_node, local_prg_ptr,
         kmer_node_max_likelihood_path, local_node_max_likelihood_path };
 
-    const auto interval_padding { 0 };
     CandidateRegion expected_candidate { Interval(6, 11), pangraph_node->get_name(),
-        interval_padding };
+        pad };
     const CandidateRegions expected { std::make_pair(
         expected_candidate.get_id(), expected_candidate) };
-    const auto actual { find_candidate_regions_for_pan_node(
-        pangraph_node_components, interval_padding) };
+    const auto actual { discover.find_candidate_regions_for_pan_node(
+        pangraph_node_components) };
     const auto actual_sequence {
         actual.at(expected_candidate.get_id()).get_max_likelihood_sequence_with_flanks()
     };
@@ -697,6 +804,12 @@ TEST(FindCandidateRegionsForPanNodeTest,
 TEST(FindCandidateRegionsForPanNodeTest,
     noCoverageOnFiveBasesWithinDoubleNestingReturnFiveBasesPlusPaddingAsCandidate)
 {
+    const auto min_len { 2 };
+    const auto max_len { 40 };
+    const auto min_covg { 3 };
+    const auto pad { 1 };
+    const auto dist { 0 };
+    Discover discover { min_covg, min_len, max_len, pad, dist };
     const auto prg_id { 3 };
     auto local_prg_ptr { std::make_shared<LocalPRG>(
         prg_id, "test", "AAAA 5 CCCC 6 GG 7 XXX 8 YYY 7 GG 5 TTTT") };
@@ -736,13 +849,12 @@ TEST(FindCandidateRegionsForPanNodeTest,
     const TmpPanNode pangraph_node_components { pangraph_node, local_prg_ptr,
         kmer_node_max_likelihood_path, local_node_max_likelihood_path };
 
-    const auto interval_padding { 1 };
     CandidateRegion expected_candidate { Interval(5, 10), pangraph_node->get_name(),
-        interval_padding };
+        pad };
     const CandidateRegions expected { std::make_pair(
         expected_candidate.get_id(), expected_candidate) };
-    const auto actual { find_candidate_regions_for_pan_node(
-        pangraph_node_components, interval_padding) };
+    const auto actual { discover.find_candidate_regions_for_pan_node(
+        pangraph_node_components) };
     const auto actual_sequence {
         actual.at(expected_candidate.get_id()).get_max_likelihood_sequence_with_flanks()
     };
@@ -758,6 +870,12 @@ TEST(FindCandidateRegionsForPanNodeTest,
 TEST(FindCandidateRegionsForPanNodeTest,
     noCoverageOnTwoFiveBaseRegionsWithinDoubleNestingReturnTwoRegionsAsCandidate)
 {
+    const auto min_len { 2 };
+    const auto max_len { 40 };
+    const auto min_covg { 3 };
+    const auto pad { 0 };
+    const auto dist { 0 };
+    Discover discover { min_covg, min_len, max_len, pad, dist };
     const auto prg_id { 3 };
     auto local_prg_ptr { std::make_shared<LocalPRG>(
         prg_id, "test", "AAAA 5 CCCC 6 GG 7 XXX 8 YYY 7 GG 5 TTTTT") };
@@ -797,16 +915,15 @@ TEST(FindCandidateRegionsForPanNodeTest,
     const TmpPanNode pangraph_node_components { pangraph_node, local_prg_ptr,
         kmer_node_max_likelihood_path, local_node_max_likelihood_path };
 
-    const auto interval_padding { 0 };
     CandidateRegion expected_candidate1 { Interval(0, 5), pangraph_node->get_name(),
-        interval_padding };
+        pad };
     CandidateRegion expected_candidate2 { Interval(8, 13), pangraph_node->get_name(),
-        interval_padding };
+        pad };
     const CandidateRegions expected { std::make_pair(expected_candidate1.get_id(),
                                           expected_candidate1),
         std::make_pair(expected_candidate2.get_id(), expected_candidate2) };
-    const auto actual { find_candidate_regions_for_pan_node(
-        pangraph_node_components, interval_padding) };
+    const auto actual { discover.find_candidate_regions_for_pan_node(
+        pangraph_node_components) };
 
     EXPECT_EQ(actual, expected);
     std::vector<std::string> actual_max_likelihood_sequences;
@@ -922,8 +1039,14 @@ TEST(AddPileupEntryForCandidateRegionTest, oneReadOneReadCoordOutsideReadPileupE
 
 TEST(LoadAllCandidateRegionsPileupsFromFastq, emptyCandidateRegionReturnsEmptyPileup)
 {
+    const auto min_len { 2 };
+    const auto max_len { 4 };
+    const auto min_covg { 3 };
+    const auto pad { 0 };
+    const auto dist { 0 };
+    Discover discover { min_covg, min_len, max_len, pad, dist };
     Fastaq temp_fastq { false, true };
-    auto read_name { "0" };
+    const auto* read_name { "0" };
     std::string read_sequence { "AATTCCGG" };
     const auto global_covg { 2 };
     const std::vector<uint32_t> read_covg(read_sequence.length(), global_covg);
@@ -935,8 +1058,8 @@ TEST(LoadAllCandidateRegionsPileupsFromFastq, emptyCandidateRegionReturnsEmptyPi
     temp_fastq.save(temp_reads_filepath.string());
 
     CandidateRegions candidate_regions;
-    auto pileup_construction_map = construct_pileup_construction_map(candidate_regions);
-    load_all_candidate_regions_pileups_from_fastq(
+    auto pileup_construction_map = discover.pileup_construction_map(candidate_regions);
+    discover.load_candidate_region_pileups(
         temp_reads_filepath, candidate_regions, pileup_construction_map);
 
     const auto temp_removed_successfully { fs::remove(temp_reads_filepath) };
@@ -948,7 +1071,12 @@ TEST(LoadAllCandidateRegionsPileupsFromFastq, emptyCandidateRegionReturnsEmptyPi
 TEST(AddPileupEntryForCandidateRegionTest,
     oneCandidateZeroReadsInFilePileupHasZeroEntries)
 {
-
+    const auto min_len { 2 };
+    const auto max_len { 4 };
+    const auto min_covg { 3 };
+    const auto pad { 0 };
+    const auto dist { 0 };
+    Discover discover { min_covg, min_len, max_len, pad, dist };
     Fastaq temp_fastq { false, true };
     const fs::path temp_reads_filepath { fs::unique_path() };
     temp_fastq.save(temp_reads_filepath.string());
@@ -961,8 +1089,8 @@ TEST(AddPileupEntryForCandidateRegionTest,
 
     CandidateRegions candidate_regions { std::make_pair(
         candidate.get_id(), candidate) };
-    auto pileup_construction_map = construct_pileup_construction_map(candidate_regions);
-    load_all_candidate_regions_pileups_from_fastq(
+    auto pileup_construction_map = discover.pileup_construction_map(candidate_regions);
+    discover.load_candidate_region_pileups(
         temp_reads_filepath, candidate_regions, pileup_construction_map);
 
     const auto temp_removed_successfully { fs::remove(temp_reads_filepath) };
@@ -977,7 +1105,12 @@ TEST(AddPileupEntryForCandidateRegionTest,
 TEST(AddPileupEntryForCandidateRegionTest,
     oneCandidateTwoReadsInFileOneReadInCandidatePileupHasOneEntry)
 {
-
+    const auto min_len { 2 };
+    const auto max_len { 4 };
+    const auto min_covg { 3 };
+    const auto pad { 0 };
+    const auto dist { 0 };
+    Discover discover { min_covg, min_len, max_len, pad, dist };
     Fastaq temp_fastq { false, true };
     auto read_name { "0" };
     std::string read_sequence { "AATTCCGG" };
@@ -998,8 +1131,8 @@ TEST(AddPileupEntryForCandidateRegionTest,
 
     CandidateRegions candidate_regions { std::make_pair(
         candidate.get_id(), candidate) };
-    auto pileup_construction_map = construct_pileup_construction_map(candidate_regions);
-    load_all_candidate_regions_pileups_from_fastq(
+    auto pileup_construction_map = discover.pileup_construction_map(candidate_regions);
+    discover.load_candidate_region_pileups(
         temp_reads_filepath, candidate_regions, pileup_construction_map);
 
     const auto temp_removed_successfully { fs::remove(temp_reads_filepath) };
@@ -1014,7 +1147,12 @@ TEST(AddPileupEntryForCandidateRegionTest,
 TEST(AddPileupEntryForCandidateRegionTest,
     oneCandidateTwoReadsInFileTwoReadsInCandidatePileupHasTwoEntries)
 {
-
+    const auto min_len { 2 };
+    const auto max_len { 4 };
+    const auto min_covg { 3 };
+    const auto pad { 0 };
+    const auto dist { 0 };
+    Discover discover { min_covg, min_len, max_len, pad, dist };
     Fastaq temp_fastq { false, true };
     auto read_name { "0" };
     std::string read_sequence { "AATTCCGG" };
@@ -1035,8 +1173,8 @@ TEST(AddPileupEntryForCandidateRegionTest,
 
     CandidateRegions candidate_regions { std::make_pair(
         candidate.get_id(), candidate) };
-    auto pileup_construction_map = construct_pileup_construction_map(candidate_regions);
-    load_all_candidate_regions_pileups_from_fastq(
+    auto pileup_construction_map = discover.pileup_construction_map(candidate_regions);
+    discover.load_candidate_region_pileups(
         temp_reads_filepath, candidate_regions, pileup_construction_map);
 
     const auto temp_removed_successfully { fs::remove(temp_reads_filepath) };
@@ -1051,7 +1189,12 @@ TEST(AddPileupEntryForCandidateRegionTest,
 TEST(AddPileupEntryForCandidateRegionTest,
     twoCandidatesZeroReadsInFilePileupHasZeroEntries)
 {
-
+    const auto min_len { 2 };
+    const auto max_len { 4 };
+    const auto min_covg { 3 };
+    const auto pad { 0 };
+    const auto dist { 0 };
+    Discover discover { min_covg, min_len, max_len, pad, dist };
     Fastaq temp_fastq { false, true };
     const fs::path temp_reads_filepath { fs::unique_path() };
     temp_fastq.save(temp_reads_filepath.string());
@@ -1071,8 +1214,8 @@ TEST(AddPileupEntryForCandidateRegionTest,
     CandidateRegions candidate_regions { std::make_pair(
                                              candidate_1.get_id(), candidate_1),
         std::make_pair(candidate_2.get_id(), candidate_2) };
-    auto pileup_construction_map = construct_pileup_construction_map(candidate_regions);
-    load_all_candidate_regions_pileups_from_fastq(
+    auto pileup_construction_map = discover.pileup_construction_map(candidate_regions);
+    discover.load_candidate_region_pileups(
         temp_reads_filepath, candidate_regions, pileup_construction_map);
 
     const auto temp_removed_successfully { fs::remove(temp_reads_filepath) };
@@ -1089,7 +1232,12 @@ TEST(AddPileupEntryForCandidateRegionTest,
 TEST(AddPileupEntryForCandidateRegionTest,
     twoCandidatesTwoReadsInFileOneReadInOneCandidatePileupHasOneEntryInOneCandidate)
 {
-
+    const auto min_len { 2 };
+    const auto max_len { 4 };
+    const auto min_covg { 3 };
+    const auto pad { 0 };
+    const auto dist { 0 };
+    Discover discover { min_covg, min_len, max_len, pad, dist };
     Fastaq temp_fastq { false, true };
     auto read_name { "0" };
     std::string read_sequence { "AATTCCGG" };
@@ -1113,8 +1261,8 @@ TEST(AddPileupEntryForCandidateRegionTest,
     CandidateRegions candidate_regions { std::make_pair(
                                              candidate_1.get_id(), candidate_1),
         std::make_pair(candidate_2.get_id(), candidate_2) };
-    auto pileup_construction_map = construct_pileup_construction_map(candidate_regions);
-    load_all_candidate_regions_pileups_from_fastq(
+    auto pileup_construction_map = discover.pileup_construction_map(candidate_regions);
+    discover.load_candidate_region_pileups(
         temp_reads_filepath, candidate_regions, pileup_construction_map);
 
     const auto temp_removed_successfully { fs::remove(temp_reads_filepath) };
@@ -1132,7 +1280,12 @@ TEST(AddPileupEntryForCandidateRegionTest,
 TEST(AddPileupEntryForCandidateRegionTest,
     twoCandidatesTwoReadsInFileOneReadInEachCandidatePileupHasOneEntryInEachCandidate)
 {
-
+    const auto min_len { 2 };
+    const auto max_len { 4 };
+    const auto min_covg { 3 };
+    const auto pad { 0 };
+    const auto dist { 0 };
+    Discover discover { min_covg, min_len, max_len, pad, dist };
     Fastaq temp_fastq { false, true };
     auto read_name { "0" };
     std::string read_sequence { "AATTCCGG" };
@@ -1156,8 +1309,8 @@ TEST(AddPileupEntryForCandidateRegionTest,
     CandidateRegions candidate_regions { std::make_pair(
                                              candidate_1.get_id(), candidate_1),
         std::make_pair(candidate_2.get_id(), candidate_2) };
-    auto pileup_construction_map = construct_pileup_construction_map(candidate_regions);
-    load_all_candidate_regions_pileups_from_fastq(
+    auto pileup_construction_map = discover.pileup_construction_map(candidate_regions);
+    discover.load_candidate_region_pileups(
         temp_reads_filepath, candidate_regions, pileup_construction_map);
 
     const auto temp_removed_successfully { fs::remove(temp_reads_filepath) };
@@ -1175,7 +1328,12 @@ TEST(AddPileupEntryForCandidateRegionTest,
 TEST(AddPileupEntryForCandidateRegionTest,
     twoCandidatesTwoReadsInFileOneReadInEachCandidatePileupHasOneEntryInEachCandidateUsingFourThreads)
 {
-
+    const auto min_len { 2 };
+    const auto max_len { 4 };
+    const auto min_covg { 3 };
+    const auto pad { 0 };
+    const auto dist { 0 };
+    Discover discover { min_covg, min_len, max_len, pad, dist };
     const uint32_t threads = 4;
     Fastaq temp_fastq { false, true };
     auto read_name { "0" };
@@ -1204,8 +1362,8 @@ TEST(AddPileupEntryForCandidateRegionTest,
     CandidateRegions candidate_regions { std::make_pair(
                                              candidate_1.get_id(), candidate_1),
         std::make_pair(candidate_2.get_id(), candidate_2) };
-    auto pileup_construction_map = construct_pileup_construction_map(candidate_regions);
-    load_all_candidate_regions_pileups_from_fastq(
+    auto pileup_construction_map = discover.pileup_construction_map(candidate_regions);
+    discover.load_candidate_region_pileups(
         temp_reads_filepath, candidate_regions, pileup_construction_map, threads);
 
     const auto temp_removed_successfully { fs::remove(temp_reads_filepath) };
@@ -1268,8 +1426,14 @@ TEST(WriteDenovoPathsToFileTest, twoReadsWritesTwoReadsToFile)
 
 TEST(ConstructPileupConstructionMapTest, emptyInEmptyOut)
 {
+    const auto min_len { 2 };
+    const auto max_len { 4 };
+    const auto min_covg { 3 };
+    const auto pad { 0 };
+    const auto dist { 0 };
+    Discover discover { min_covg, min_len, max_len, pad, dist };
     CandidateRegions empty_candidate_regions;
-    const auto actual { construct_pileup_construction_map(empty_candidate_regions) };
+    const auto actual { discover.pileup_construction_map(empty_candidate_regions) };
     PileupConstructionMap expected;
     EXPECT_EQ(actual, expected);
 }
@@ -1302,6 +1466,12 @@ void compare_maps(const PileupConstructionMap& map1, const PileupConstructionMap
 
 TEST(ConstructPileupConstructionMapTest, oneCandidateRegionOneReadCoordinate)
 {
+    const auto min_len { 2 };
+    const auto max_len { 4 };
+    const auto min_covg { 3 };
+    const auto pad { 0 };
+    const auto dist { 0 };
+    Discover discover { min_covg, min_len, max_len, pad, dist };
     CandidateRegion candidate { Interval(0, 3), "test" };
     const uint32_t read_id = 0;
     ReadCoordinate read_coord { read_id, 5, 20, true };
@@ -1309,7 +1479,7 @@ TEST(ConstructPileupConstructionMapTest, oneCandidateRegionOneReadCoordinate)
     CandidateRegions candidate_regions { std::make_pair(
         candidate.get_id(), candidate) };
 
-    const auto actual { construct_pileup_construction_map(candidate_regions) };
+    const auto actual { discover.pileup_construction_map(candidate_regions) };
     PileupConstructionMap expected;
     expected[read_id].emplace_back(&candidate, &read_coord);
     compare_maps(actual, expected);
@@ -1317,6 +1487,12 @@ TEST(ConstructPileupConstructionMapTest, oneCandidateRegionOneReadCoordinate)
 
 TEST(ConstructPileupConstructionMapTest, oneCandidateRegionTwoReadCoordinatesSameReadId)
 {
+    const auto min_len { 2 };
+    const auto max_len { 4 };
+    const auto min_covg { 3 };
+    const auto pad { 0 };
+    const auto dist { 0 };
+    Discover discover { min_covg, min_len, max_len, pad, dist };
     CandidateRegion candidate { Interval(0, 3), "test" };
     const uint32_t read_id = 0;
     ReadCoordinate read_coord_1 { read_id, 5, 20, true };
@@ -1326,7 +1502,7 @@ TEST(ConstructPileupConstructionMapTest, oneCandidateRegionTwoReadCoordinatesSam
     CandidateRegions candidate_regions { std::make_pair(
         candidate.get_id(), candidate) };
 
-    const auto actual { construct_pileup_construction_map(candidate_regions) };
+    const auto actual { discover.pileup_construction_map(candidate_regions) };
     PileupConstructionMap expected;
     expected[read_id].emplace_back(&candidate, &read_coord_1);
     expected[read_id].emplace_back(&candidate, &read_coord_2);
@@ -1337,6 +1513,12 @@ TEST(ConstructPileupConstructionMapTest, oneCandidateRegionTwoReadCoordinatesSam
 TEST(ConstructPileupConstructionMapTest,
     oneCandidateRegionTwoReadCoordinatesDifferentReadId)
 {
+    const auto min_len { 2 };
+    const auto max_len { 4 };
+    const auto min_covg { 3 };
+    const auto pad { 0 };
+    const auto dist { 0 };
+    Discover discover { min_covg, min_len, max_len, pad, dist };
     CandidateRegion candidate { Interval(0, 3), "test" };
     const uint32_t read_id_1 = 0;
     ReadCoordinate read_coord_1 { read_id_1, 5, 20, true };
@@ -1347,7 +1529,7 @@ TEST(ConstructPileupConstructionMapTest,
     CandidateRegions candidate_regions { std::make_pair(
         candidate.get_id(), candidate) };
 
-    const auto actual { construct_pileup_construction_map(candidate_regions) };
+    const auto actual { discover.pileup_construction_map(candidate_regions) };
     PileupConstructionMap expected;
     expected[read_id_1].emplace_back(&candidate, &read_coord_1);
     expected[read_id_2].emplace_back(&candidate, &read_coord_2);
@@ -1358,6 +1540,12 @@ TEST(ConstructPileupConstructionMapTest,
 TEST(ConstructPileupConstructionMapTest,
     twoCandidateRegionsOneReadCoordinateEachDifferentReadId)
 {
+    const auto min_len { 2 };
+    const auto max_len { 4 };
+    const auto min_covg { 3 };
+    const auto pad { 0 };
+    const auto dist { 0 };
+    Discover discover { min_covg, min_len, max_len, pad, dist };
     CandidateRegion candidate_1 { Interval(0, 3), "test" };
     const uint32_t read_id_1 = 0;
     ReadCoordinate read_coord_1 { read_id_1, 5, 20, true };
@@ -1370,7 +1558,7 @@ TEST(ConstructPileupConstructionMapTest,
                                              candidate_1.get_id(), candidate_1),
         std::make_pair(candidate_2.get_id(), candidate_2) };
 
-    const auto actual { construct_pileup_construction_map(candidate_regions) };
+    const auto actual { discover.pileup_construction_map(candidate_regions) };
     PileupConstructionMap expected;
     expected[read_id_1].emplace_back(&candidate_1, &read_coord_1);
     expected[read_id_2].emplace_back(&candidate_2, &read_coord_2);
@@ -1381,6 +1569,12 @@ TEST(ConstructPileupConstructionMapTest,
 TEST(ConstructPileupConstructionMapTest,
     twoCandidateRegionsOneReadCoordinateEachSameReadId)
 {
+    const auto min_len { 2 };
+    const auto max_len { 4 };
+    const auto min_covg { 3 };
+    const auto pad { 0 };
+    const auto dist { 0 };
+    Discover discover { min_covg, min_len, max_len, pad, dist };
     CandidateRegion candidate_1 { Interval(0, 3), "test" };
     const uint32_t read_id = 0;
     ReadCoordinate read_coord_1 { read_id, 5, 20, true };
@@ -1392,7 +1586,7 @@ TEST(ConstructPileupConstructionMapTest,
                                              candidate_1.get_id(), candidate_1),
         std::make_pair(candidate_2.get_id(), candidate_2) };
 
-    const auto actual { construct_pileup_construction_map(candidate_regions) };
+    const auto actual { discover.pileup_construction_map(candidate_regions) };
     PileupConstructionMap expected;
     expected[read_id].emplace_back(&candidate_1, &read_coord_1);
     expected[read_id].emplace_back(&candidate_2, &read_coord_2);

--- a/test/denovo_discovery/denovo_discovery_test.cpp
+++ b/test/denovo_discovery/denovo_discovery_test.cpp
@@ -250,7 +250,9 @@ TEST(
 {
     const int k { 9 };
     const double error_rate { 0.11 };
-    DenovoDiscovery denovo { k, error_rate };
+    const auto max_insert { 15 };
+    const auto min_dbg_dp { 2 };
+    DenovoDiscovery denovo { k, error_rate, max_insert, min_dbg_dp };
     CandidateRegion candidate_region { Interval(0, 1), "test" };
     candidate_region.max_likelihood_sequence = "ATGCGCTGAGAGTCGGACT";
     candidate_region.pileup = { "ATGCGCTGAGAGTCGGACT", "ATGCGCTGATAGTCGGACT" };
@@ -268,7 +270,9 @@ TEST(FindPathsThroughCandidateRegionTest,
 {
     const int k { 9 };
     const double error_rate { 0.11 };
-    DenovoDiscovery denovo { k, error_rate };
+    const auto max_insert { 15 };
+    const auto min_dbg_dp { 2 };
+    DenovoDiscovery denovo { k, error_rate, max_insert, min_dbg_dp };
     CandidateRegion candidate_region { Interval(0, 1), "test" };
     candidate_region.max_likelihood_sequence = "ATGCGCTGAGAGTCGGACT";
     candidate_region.pileup

--- a/test/interval_test.cpp
+++ b/test/interval_test.cpp
@@ -1,5 +1,5 @@
 #include "gtest/gtest.h"
-#include <stdint.h>
+#include <cstdint>
 #include <iostream>
 #include "interval.h"
 
@@ -121,4 +121,188 @@ TEST(intervalEmptyTest, nonEmptyIntervalReturnsFalse)
     const Interval non_empty_interval { 1, 4 };
 
     EXPECT_FALSE(non_empty_interval.empty());
+}
+
+class MergeIntervalsTest : public ::testing::Test {
+protected:
+    void SetUp() override
+    {
+        single_.insert(single_.end(), { Interval(0, 1) });
+        unsorted_disjoint_.insert(
+            unsorted_disjoint_.end(), { Interval(4, 6), Interval(0, 2) });
+        contained_.insert(contained_.end(), { Interval(0, 10), Interval(4, 6) });
+        overlap_.insert(overlap_.end(), { Interval(0, 3), Interval(2, 5) });
+        overlap_and_disjoint_.insert(overlap_and_disjoint_.end(),
+            { Interval(0, 3), Interval(2, 5), Interval(7, 10) });
+        disjoint_overlap_disjoint_.insert(disjoint_overlap_disjoint_.end(),
+            { Interval(0, 3), Interval(6, 9), Interval(8, 11), Interval(16, 20),
+                Interval(30, 34) });
+    }
+    std::vector<Interval> empty_;
+    std::vector<Interval> single_;
+    std::vector<Interval> unsorted_disjoint_;
+    std::vector<Interval> contained_;
+    std::vector<Interval> overlap_;
+    std::vector<Interval> overlap_and_disjoint_;
+    std::vector<Interval> disjoint_overlap_disjoint_;
+};
+
+TEST_F(MergeIntervalsTest, HandlesEmptyInput)
+{
+    const auto dist { 0 };
+
+    merge_intervals_within(empty_, dist);
+    const auto actual { empty_ };
+    const std::vector<Interval> expected;
+
+    EXPECT_EQ(actual, expected);
+}
+
+TEST_F(MergeIntervalsTest, SingleElementDoesNothing)
+{
+    const auto dist { 0 };
+
+    const auto expected = single_;
+    merge_intervals_within(single_, dist);
+    const auto actual = single_;
+
+    EXPECT_EQ(actual, expected);
+}
+
+TEST_F(MergeIntervalsTest, UnsortedDisjointIntervalsReturnsSortedIntervals)
+{
+    const auto dist { 0 };
+
+    std::vector<Interval> expected = unsorted_disjoint_;
+    std::sort(expected.begin(), expected.end());
+    merge_intervals_within(unsorted_disjoint_, dist);
+    const auto actual = unsorted_disjoint_;
+
+    EXPECT_EQ(actual, expected);
+}
+
+TEST_F(MergeIntervalsTest, DisjointWithDistEdgeCase)
+{
+    const auto dist { 2 };
+
+    std::vector<Interval> expected = unsorted_disjoint_;
+    std::sort(expected.begin(), expected.end());
+    merge_intervals_within(unsorted_disjoint_, dist);
+    const auto actual = unsorted_disjoint_;
+
+    EXPECT_EQ(actual, expected);
+}
+
+TEST_F(MergeIntervalsTest, DisjointWithDistCausingOverlap)
+{
+    const auto dist { 3 };
+
+    merge_intervals_within(unsorted_disjoint_, dist);
+    const auto actual = unsorted_disjoint_;
+    const std::vector<Interval> expected = { Interval(0, 6) };
+
+    EXPECT_EQ(actual, expected);
+}
+
+TEST_F(MergeIntervalsTest, ContainedIntervalIsMerged)
+{
+    const auto dist { 0 };
+
+    merge_intervals_within(contained_, dist);
+    const auto actual = contained_;
+    const std::vector<Interval> expected = { Interval(0, 10) };
+
+    EXPECT_EQ(actual, expected);
+}
+
+TEST_F(MergeIntervalsTest, OverlappingIsMerged)
+{
+    const auto dist { 0 };
+
+    merge_intervals_within(overlap_, dist);
+    const auto actual = overlap_;
+    const std::vector<Interval> expected = { Interval(0, 5) };
+
+    EXPECT_EQ(actual, expected);
+}
+
+TEST_F(MergeIntervalsTest, OverlapAndDisjointNoDistOnlyOverlapMerged)
+{
+    const auto dist { 0 };
+
+    merge_intervals_within(overlap_and_disjoint_, dist);
+    const auto actual = overlap_and_disjoint_;
+    const std::vector<Interval> expected = { Interval(0, 5), Interval(7, 10) };
+
+    EXPECT_EQ(actual, expected);
+}
+
+TEST_F(MergeIntervalsTest, OverlapAndDisjointEdgeDistOnlyOverlapMerged)
+{
+    const auto dist { 2 };
+
+    merge_intervals_within(overlap_and_disjoint_, dist);
+    const auto actual = overlap_and_disjoint_;
+    const std::vector<Interval> expected = { Interval(0, 5), Interval(7, 10) };
+
+    EXPECT_EQ(actual, expected);
+}
+
+TEST_F(MergeIntervalsTest, OverlapAndDisjointOverlapDistMergeAll)
+{
+    const auto dist { 3 };
+
+    merge_intervals_within(overlap_and_disjoint_, dist);
+    const auto actual = overlap_and_disjoint_;
+    const std::vector<Interval> expected = { Interval(0, 10) };
+
+    EXPECT_EQ(actual, expected);
+}
+
+TEST_F(MergeIntervalsTest, ManyDisjointAndOverlappingNoDistOnlyMergeOverlaps)
+{
+    const auto dist { 0 };
+
+    merge_intervals_within(disjoint_overlap_disjoint_, dist);
+    const auto actual = disjoint_overlap_disjoint_;
+    const std::vector<Interval> expected
+        = { Interval(0, 3), Interval(6, 11), Interval(16, 20), Interval(30, 34) };
+
+    EXPECT_EQ(actual, expected);
+}
+
+TEST_F(
+    MergeIntervalsTest, ManyDisjointAndOverlappingSmallDistMergeOverlapsAndOneDisjoint)
+{
+    const auto dist { 5 };
+
+    merge_intervals_within(disjoint_overlap_disjoint_, dist);
+    const auto actual = disjoint_overlap_disjoint_;
+    const std::vector<Interval> expected
+        = { Interval(0, 11), Interval(16, 20), Interval(30, 34) };
+
+    EXPECT_EQ(actual, expected);
+}
+
+TEST_F(
+    MergeIntervalsTest, ManyDisjointAndOverlappingMediumDistMergeOverlapsAndTwoDisjoint)
+{
+    const auto dist { 9 };
+
+    merge_intervals_within(disjoint_overlap_disjoint_, dist);
+    const auto actual = disjoint_overlap_disjoint_;
+    const std::vector<Interval> expected = { Interval(0, 20), Interval(30, 34) };
+
+    EXPECT_EQ(actual, expected);
+}
+
+TEST_F(MergeIntervalsTest, ManyDisjointAndOverlappingLargeDistMergeAll)
+{
+    const auto dist { 100 };
+
+    merge_intervals_within(disjoint_overlap_disjoint_, dist);
+    const auto actual = disjoint_overlap_disjoint_;
+    const std::vector<Interval> expected = { Interval(0, 34) };
+
+    EXPECT_EQ(actual, expected);
 }

--- a/test/interval_test.cpp
+++ b/test/interval_test.cpp
@@ -19,10 +19,8 @@ TEST(IntervalTest, create)
     j = 8;
     EXPECT_EQ(i.length, j);
 
-    // should fail if end is before start
-    EXPECT_DEATH(Interval(9, 1), "");
-    // input should be non-negative
-    EXPECT_DEATH(Interval(-1, 10), "");
+    EXPECT_THROW(Interval(9, 1), std::logic_error);
+    EXPECT_THROW(Interval(-1, 10), std::logic_error);
 }
 
 TEST(IntervalTest, write)
@@ -121,6 +119,91 @@ TEST(intervalEmptyTest, nonEmptyIntervalReturnsFalse)
     const Interval non_empty_interval { 1, 4 };
 
     EXPECT_FALSE(non_empty_interval.empty());
+}
+
+class IsCloseTest : public ::testing::Test {
+protected:
+    Interval iv { 4, 7 };
+};
+
+TEST_F(IsCloseTest, IntervalsAreTheSame)
+{
+    const Interval other { 4, 7 };
+    const uint32_t dist { 0 };
+
+    EXPECT_TRUE(iv.is_close(other, dist));
+}
+
+TEST_F(IsCloseTest, IntervalsHaveSameStart)
+{
+    const Interval other { 4, 9 };
+    const uint32_t dist { 0 };
+
+    EXPECT_TRUE(iv.is_close(other, dist));
+}
+
+TEST_F(IsCloseTest, IntervalsHaveSameEnd)
+{
+    const Interval other { 1, 7 };
+    const uint32_t dist { 0 };
+
+    EXPECT_TRUE(iv.is_close(other, dist));
+}
+
+TEST_F(IsCloseTest, IntervalsOverlap)
+{
+    const Interval other { 6, 9 };
+    const uint32_t dist { 0 };
+
+    EXPECT_TRUE(iv.is_close(other, dist));
+}
+
+TEST_F(IsCloseTest, OtherIntervalStartsAtEndAndDistIsZero)
+{
+    const Interval other { 7, 9 };
+    const uint32_t dist { 0 };
+
+    EXPECT_FALSE(iv.is_close(other, dist));
+}
+
+TEST_F(IsCloseTest, OtherIntervalStartsAtEndAndDistIsOne)
+{
+    const Interval other { 7, 9 };
+    const uint32_t dist { 1 };
+
+    EXPECT_TRUE(iv.is_close(other, dist));
+}
+
+TEST_F(IsCloseTest, OtherIntervalEndsAtStartOfThis)
+{
+    const Interval other { 2, 4 };
+    const uint32_t dist { 0 };
+
+    EXPECT_FALSE(iv.is_close(other, dist));
+}
+
+TEST_F(IsCloseTest, OtherIntervalEndsAtStartOfThisAndDistIsOne)
+{
+    const Interval other { 2, 4 };
+    const uint32_t dist { 1 };
+
+    EXPECT_TRUE(iv.is_close(other, dist));
+}
+
+TEST_F(IsCloseTest, OtherIntervalIsFarAway)
+{
+    const Interval other { 20, 40 };
+    const uint32_t dist { 1 };
+
+    EXPECT_FALSE(iv.is_close(other, dist));
+}
+
+TEST_F(IsCloseTest, OtherIntervalIsFarAwayButDistIsBig)
+{
+    const Interval other { 20, 40 };
+    const uint32_t dist { 100 };
+
+    EXPECT_TRUE(iv.is_close(other, dist));
 }
 
 class MergeIntervalsTest : public ::testing::Test {

--- a/test/minimizer_test.cpp
+++ b/test/minimizer_test.cpp
@@ -46,10 +46,11 @@ TEST(MinimizerTest, create)
     j = 10;
     EXPECT_EQ(m3.pos_of_kmer_in_read.get_end(), j);
 
-    EXPECT_DEATH(Minimizer(kh.first, 0, 2, 0), ""); // interval too short to be valid
-    // EXPECT_DEATH(Minimizer(kh.first, 0,8,0),""); // interval too long to be valid
-    EXPECT_DEATH(
-        Minimizer(kh.first, 2, 0, 0), ""); // doesn't generate an interval as 2>0
+    // interval too short to be valid
+    EXPECT_DEATH(Minimizer(kh.first, 0, 2, 0), "");
+    // doesn't generate an interval as 2>0
+    EXPECT_THROW(
+        Minimizer(kh.first, 2, 0, 0), std::logic_error);
 }
 
 TEST(MinimizerTest, less_than)

--- a/test/utils_test.cpp
+++ b/test/utils_test.cpp
@@ -1011,13 +1011,114 @@ TEST(UtilsTest, pangraphFromReadFile_Fq)
     index->clear();
 }
 
-/*
-TEST(UtilsTest, lognChoosek2)
+TEST(StrToGsTest, HandlesEmptyStr)
 {
-    EXPECT_EQ(0.0, lognchoosek2(0,0,0));
-    EXPECT_EQ(0.0, lognchoosek2(1,0,0));
-    EXPECT_EQ(0.0, lognchoosek2(1,1,0));
+    const char* str { "" };
+
+    const auto actual { strtogs(str) };
+    const auto expected { 0 };
+
+    EXPECT_EQ(actual, expected);
 }
 
-//update_covgs_from_hits
-*/
+TEST(StrToGsTest, DecimalConvertsToInt)
+{
+    const char* str { "3.3" };
+
+    const auto actual { strtogs(str) };
+    const auto expected { 3 };
+
+    EXPECT_EQ(actual, expected);
+}
+
+TEST(StrToGsTest, DecimalRoundsUpToInt)
+{
+    const char* str { "3.7" };
+
+    const auto actual { strtogs(str) };
+    const auto expected { 4 };
+
+    EXPECT_EQ(actual, expected);
+}
+
+TEST(StrToGsTest, IntReturnsSame)
+{
+    const char* str { "310" };
+
+    const auto actual { strtogs(str) };
+    const auto expected { 310 };
+
+    EXPECT_EQ(actual, expected);
+}
+
+TEST(StrToGsTest, NegativeFails)
+{
+    const char* str { "-4" };
+
+    EXPECT_THROW(strtogs(str), std::logic_error);
+}
+
+TEST(StrToGsTest, Kilo)
+{
+    const auto* str { "3.1k" };
+
+    auto actual { strtogs(str) };
+    const auto expected { 3100 };
+
+    EXPECT_EQ(actual, expected);
+
+    str = "3.1K";
+
+    actual = strtogs(str);
+
+    EXPECT_EQ(actual, expected);
+}
+
+TEST(StrToGsTest, Mega)
+{
+    const auto* str { "3m" };
+
+    auto actual { strtogs(str) };
+    const auto expected { 3e6 };
+
+    EXPECT_EQ(actual, expected);
+
+    str = "3M";
+
+    actual = strtogs(str);
+
+    EXPECT_EQ(actual, expected);
+}
+
+TEST(StrToGsTest, Giga)
+{
+    const auto* str { "3g" };
+
+    auto actual { strtogs(str) };
+    const auto expected { 3e9 };
+
+    EXPECT_EQ(actual, expected);
+
+    str = "3G";
+
+    actual = strtogs(str);
+
+    EXPECT_EQ(actual, expected);
+}
+
+TEST(StrToGsTest, TooLargeFails)
+{
+    const auto* str { "20g" };
+
+    EXPECT_THROW(strtogs(str), std::runtime_error);
+}
+
+TEST(TransformCliGsizeTest, GenomeSizeStringProducesIntToStr)
+{
+    const std::string str { "2k" };
+
+    const auto actual { transform_cli_gsize(str) };
+    const auto *const expected { "2000" };
+
+    EXPECT_EQ(actual, expected);
+}


### PR DESCRIPTION
I found myself needing to expose more and more *de novo* parameters at the CLI and realised it was all cluttering `map`. There could also a *slightly* misleading perception that using `--discover --genotype` in `map` would genotype with the discovered variants (which it doesn't). Anyway, I forsee - when we have self-container *de novo* variant integration - the need to have this subcommand output a new PRG with variants added, or even another subcommand `augment`.

## Added
- New subcommand `pandora discover`
```
$ pandora discover --help
Quasi-map reads to an indexed PRG, infer the sequence of present loci in the sample and discover novel variants.
Usage: ./pandora discover [OPTIONS] <TARGET> <QUERY>

Positionals:
  <TARGET> FILE [required]    An indexed PRG file (in fasta format)
  <QUERY> FILE [required]     Fast{a,q} file containing reads to quasi-map

Options:
  -h,--help                   Print this help message and exit
  --discover-k INT            K-mer size to use when discovering novel variants [default: 11]
  --max-ins INT               Max. insertion size for novel variants. Warning: setting too long may impair performance [default: 15]
  --covg-threshold INT        Positions with coverage less than this will be tagged for variant discovery [default: 3]
  -l INT                      Min. length of consecutive positions below coverage threshold to trigger variant discovery [default: 1]
  -L INT                      Max. length of consecutive positions below coverage threshold to trigger variant discovery [default: 50]
  -P,--pad INT                Padding either side of candidate variant intervals [default: 22]
  -d,--merge INT              Merge candidate variant intervals within distance [default: 22]
  --min-dbg-dp INT            Minimum node/kmer depth in the de Bruijn graph used for discovering variants [default: 2]
  -v                          Verbosity of logging. Repeat for increased verbosity

Indexing:
  -w INT                      Window size for (w,k)-minimizers (must be <=k) [default: 14]
  -k INT                      K-mer size for (w,k)-minimizers [default: 15]

Input/Output:
  -o,--outdir DIR             Directory to write output files to [default: pandora_discover]
  -t,--threads INT            Maximum number of threads to use [default: 1]
  --kg                        Save kmer graphs with forward and reverse coverage annotations for found loci
  -M,--mapped-reads           Save a fasta file for each loci containing read parts which overlapped it

Parameter Estimation:
  -e,--error-rate FLOAT       Estimated error rate for reads [default: 0.11]
  -g,--genome-size STR/INT    Estimated length of the genome - used for coverage estimation. Can pass string such as 4.4m, 100k etc. [default: 5000000]
  --bin                       Use binomial model for kmer coverages [default: negative binomial]

Mapping:
  -m,--max-diff INT           Maximum distance (bp) between consecutive hits within a cluster [default: 250]
  -c,--min-cluster-size INT   Minimum size of a cluster of hits between a read and a loci to consider the loci present [default: 10]

Preset:
  -I,--illumina               Reads are from Illumina. Alters error rate used and adjusts for shorter reads

Filtering:
  --clean                     Add a step to clean and detangle the pangraph
  --max-covg INT              Maximum coverage of reads to accept [default: 600]

Consensus/Variant Calling:
  --kmer-avg INT              Maximum number of kmers to average over when selecting the maximum likelihood path [default: 100]
```
- function to merge candidate regions within a certain distance [closes #228] and `-d,--merge` to specify the distance at CLI
- `Interval::is_close` method
- `--min-dbg-dp` to expose minimum adbundance in GATB graph
- `-l` and `-L` for min/max candidate region length
- `-P,--pad` to specify candidate region padding

## Changed
- allow `-g,--genome-size` to take a string such as `4.4m` [closes #233]
- some logging cleanup/level changes
 
## Removed
- `--coverages` option from `map` as it wasn't being used