### PR TITLE
Improve build process

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,20 @@ language: cpp
 compiler: gcc
 os: linux
 dist: bionic
+env:
+  - OMP_NUM_THREADS=4  # https://docs.travis-ci.com/user/languages/cpp/#openmp-projects
+
+git:
+  depth: 3  # https://docs.travis-ci.com/user/customizing-the-build/#git-clone-depth
+
+cache:
+  directories:
+    - ${TRAVIS_BUILD_DIR}/deps/boost-1.62.0
+
+branches:
+  only: # build all branches https://docs.travis-ci.com/user/customizing-the-build/#safelisting-or-blocklisting-branches
+    - gh-pages
+    - /.*/
 
 include:
   - os: linux
@@ -9,28 +23,27 @@ include:
       apt:
         packages:
           - clang-format-8
+          - zlib1g-dev
 
 jobs:
+  fast_finish: true
   include:
-    - stage: "Lint"                # naming the Tests stage
-      name: "Format"            # names the first Tests stage job
+    - stage: "Format"
       script:
         - find src/ include/ test/ -type f \( -iname \*.h -o -iname \*.cpp \) | xargs -I _ clang-format -style=file -output-replacements-xml _ | grep -c "<replacement " >/dev/null
         - if [ $? -ne 1 ]; then echo "Not all source and header files are formatted with clang-format"; exit 1; fi
-    - stage: "Build"
-      script: echo "This is where we build Pandora"
-    - stage: "Test"
-      name: "Unit tests"
-      script: echo "This is where we run the unit tests"
-    - stage: "Deploy"
-      name: "DockerHub"
-      script: echo "This is where we deploy a container to Docker Hub"
+    - stage: "Build and Test"
+      env:
+        - BOOST_VERSION="1.62.0"
+        - BOOST_LIBS="system,filesystem,iostreams,log,thread,date_time"
+        - BUILD_TYPE="Debug"
+        - DEPS_DIR="${TRAVIS_BUILD_DIR}/deps"
+      install: bash ci/install.sh
+      script: bash ci/script.sh
 
 stages:
-  - "Lint"
-  - "Build"
-  - "Test"
-  - "Deploy"
+  - "Format"
+  - "Build and Test"
 
 notifications:
   email: false

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,6 +46,7 @@ set(EXTERNAL_LIBS
         gatbcore
         hdf5
         hdf5_tools)
+link_directories(${gatb_binary_dir}/lib)
 
 include(${PROJECT_SOURCE_DIR}/ext/gtest.cmake)
 
@@ -53,6 +54,8 @@ include(${PROJECT_SOURCE_DIR}/ext/gtest.cmake)
 include_directories(SYSTEM
         ${CMAKE_BINARY_DIR}/include
         ${PROJECT_SOURCE_DIR}/cgranges/cpp
+        ${gatb_source_dir}/gatb-core/src
+        ${gatb_binary_dir}/include
         )
 
 #normal includes: warnings will be reported for these

--- a/README.md
+++ b/README.md
@@ -357,7 +357,7 @@ Options:
   -l INT                      Min. length of consecutive positions below coverage threshold to trigger variant discovery [default: 1]
   -L INT                      Max. length of consecutive positions below coverage threshold to trigger variant discovery [default: 50]
   -P,--pad INT                Padding either side of candidate variant intervals [default: 22]
-  -d,--merge INT              Merge candidate variant intervals within distance [default: 22]
+  -d,--merge INT              Merge candidate variant intervals within distance [default: 15]
   --min-dbg-dp INT            Minimum node/kmer depth in the de Bruijn graph used for discovering variants [default: 2]
   -v                          Verbosity of logging. Repeat for increased verbosity
 

--- a/README.md
+++ b/README.md
@@ -261,7 +261,7 @@ This will look for regions in the pangraph where the reads do not map and attemp
 ```
 $ pandora discover --help
 Quasi-map reads to an indexed PRG, infer the sequence of present loci in the sample and discover novel variants.
-Usage: ./pandora discover [OPTIONS] <TARGET> <QUERY>
+Usage: pandora discover [OPTIONS] <TARGET> <QUERY>
 
 Positionals:
   <TARGET> FILE [required]    An indexed PRG file (in fasta format)
@@ -269,7 +269,7 @@ Positionals:
 
 Options:
   -h,--help                   Print this help message and exit
-  --discover-k INT            K-mer size to use when discovering novel variants [default: 11]
+  --discover-k INT:[0-32)     K-mer size to use when discovering novel variants [default: 11]
   --max-ins INT               Max. insertion size for novel variants. Warning: setting too long may impair performance [default: 15]
   --covg-threshold INT        Positions with coverage less than this will be tagged for variant discovery [default: 3]
   -l INT                      Min. length of consecutive positions below coverage threshold to trigger variant discovery [default: 1]
@@ -303,6 +303,7 @@ Preset:
 
 Filtering:
   --clean                     Add a step to clean and detangle the pangraph
+  --clean-dbg                 Clean the local assembly de Bruijn graph
   --max-covg INT              Maximum coverage of reads to accept [default: 600]
 
 Consensus/Variant Calling:

--- a/README.md
+++ b/README.md
@@ -1,49 +1,89 @@
-[![Build Status](https://travis-ci.org/rmcolq/pandora.svg?branch=master)](https://travis-ci.org/rmcolq/pandora) master
+| Branch             | Status                                                                           |
+|:-------------------|:---------------------------------------------------------------------------------|
+| [`master`][master] | ![Travis (.com) branch](https://img.shields.io/travis/com/rmcolq/pandora/master) |
+| [`dev`][dev]       | ![Travis (.com) branch](https://img.shields.io/travis/com/rmcolq/pandora/dev)    |
 
-[![Build Status](https://travis-ci.com/rmcolq/pandora.svg?token=mxzxNwUzHrkcpsL2i7zU&branch=dev)](https://travis-ci.com/rmcolq/pandora) dev
+[master]: https://github.com/rmcolq/pandora/tree/master
+[dev]: https://github.com/rmcolq/pandora/tree/dev
 
-![Docker Cloud Build Status](https://img.shields.io/docker/cloud/build/rmcolq/pandora)
 
 # Pandora
 
-## Contents
-* [Introduction](#introduction)
-* [Quick Start](#quick-start)
-* [Installation](#installation)
-* [Usage](#usage)
+[TOC]: #
+
+# Table of Contents
+- [Introduction](#introduction)
+- [Quick Start](#quick-start)
+- [Installation](#installation)
+  - [Containers](#containers)
+  - [Installation from source](#installation-from-source)
+- [Usage](#usage)
+  - [Population Reference Graphs](#population-reference-graphs)
+  - [Build index](#build-index)
+  - [Map reads to index](#map-reads-to-index)
+  - [Compare reads from several samples](#compare-reads-from-several-samples)
+  - [Discover novel variants](#discover-novel-variants)
+
 
 ## Introduction
-Pandora is a tool for bacterial genome analysis using a pangenome reference graph (PanRG). It allows gene presence/absence detection and genotyping of SNPs, indels and longer variants in one or a number of samples. Pandora works with Illumina or Nanopore data. Core ideas behind the method are:
- - new genomes look like recombinants (plus mutations) of things seen before
- - we should be analysing nucleotide-level variation everywhere, not just in core genes
- - arbitrary single reference genomes are unnatural and limit comparisons of diverse sets of genomes
 
-The pangenome reference graph (PanRG) is a collection of 'floating' local graphs, each representing some orthologous region of interest (e.g. genes, mobile elements or intergenic regions). See https://github.com/rmcolq/make_prg for a pipeline which can construct these PRGs from a set of aligned sequence files.
+Pandora is a tool for bacterial genome analysis using a pangenome
+reference graph (PanRG). It allows gene presence/absence detection and
+genotyping of SNPs, indels and longer variants in one or a number of
+samples. Pandora works with Illumina or Nanopore data. Core ideas behind
+the method are:
+- new genomes look like recombinants (plus mutations) of things seen
+  before
+- we should be analysing nucleotide-level variation everywhere, not just
+  in core genes
+- arbitrary single reference genomes are unnatural and limit comparisons
+  of diverse sets of genomes
+
+The pangenome reference graph (PanRG) is a collection of 'floating'
+local graphs, each representing some orthologous region of interest
+(e.g. genes, mobile elements or intergenic regions). See
+https://github.com/rmcolq/make_prg for a pipeline which can construct
+these PRGs from a set of aligned sequence files.
 
 Pandora can do the following for a single sample (read dataset):
-- Output inferred mosaic of reference sequences for loci (eg genes) from the PanRG which are present
-- Output a VCF showing the variation found within these loci, with respect to any reference path in the PRG.
+- Output inferred mosaic of reference sequences for loci (eg genes) from
+  the PanRG which are present
+- Output a VCF showing the variation found within these loci, with
+  respect to any reference path in the PRG.
 
 Soon, in a galaxy not so far away, it will allow:
 - discovery of new variation not in the PRG
 
 For a collection of samples, it can:
-- Output a matrix showing inferred copy-number of each locus in each sample genome
-- Output a multisample pangenome VCF showing how including genotype calls for each sample in each of the loci
-- Output one VCF per orthologous-chunk, showing how samples which contained this chunk differed in their gene sequence. Variation is shown with respect to the most informative recombinant path in the PRG.
+- Output a matrix showing inferred copy-number of each locus in each
+  sample genome
+- Output a multisample pangenome VCF showing how including genotype
+  calls for each sample in each of the loci
+- Output one VCF per orthologous-chunk, showing how samples which
+  contained this chunk differed in their gene sequence. Variation is
+  shown with respect to the most informative recombinant path in the
+  PRG.
 
 Warning - this code is still in development.
 
 ## Quick Start
+
 Index PanRG file:
+
 ```
 pandora index -t 8 <panrg.fa>
 ```
-Compare first 30X of each Illumina sample to get pangenome matrix and VCF
+
+Compare first 30X of each Illumina sample to get pangenome matrix and
+VCF
+
 ```
 pandora compare --genotype --illumina --max-covg 30 <panrg.fa> <read_index.tab>
 ```
-Map Nanopore reads from a single sample to get approximate sequence for genes present
+
+Map Nanopore reads from a single sample to get approximate sequence for
+genes present
+
 ```
 pandora map <panrg.fa> <reads.fq>
 ```
@@ -51,21 +91,34 @@ pandora map <panrg.fa> <reads.fq>
 ## Installation
 
 ### Containers
-We highly recommend that you download a containerized image of Pandora. Pandora is hosted on Dockerhub and images can be downloaded with the command:
+
+![Docker Cloud Build Status](https://img.shields.io/docker/cloud/build/rmcolq/pandora)
+
+We highly recommend that you download a containerized image of Pandora.
+Pandora is hosted on Dockerhub and images can be downloaded with the
+command:
+
 ```
 docker pull rmcolq/pandora:latest
 ```
+
 Alternatively, using singularity:
+
 ```
 singularity pull docker://rmcolq/pandora:latest
 ```
+
 NB For consistency, we no longer maintain images on singularity hub.
 
 ### Installation from source
-This is not recommended because the required zlib and boost system installs do not always play nicely.
-If you want to take the risk:
+
+This is not recommended because the required zlib and boost system
+installs do not always play nicely. If you want to take the risk:
 - Requires a Unix or Mac OS.
-- Requires a system install of `zlib`. If this is not already installed, [this](https://geeksww.com/tutorials/libraries/zlib/installation/installing_zlib_on_ubuntu_linux.php) tutorial is helpful or try the following.
+- Requires a system install of `zlib`. If this is not already installed,
+  [this](https://geeksww.com/tutorials/libraries/zlib/installation/installing_zlib_on_ubuntu_linux.php)
+  tutorial is helpful or try the following.
+
 ```
 wget http://www.zlib.net/zlib-1.2.11.tar.gz -O - | tar xzf -
 cd zlib-1.2.11
@@ -73,14 +126,23 @@ cd zlib-1.2.11
 make
 make install
 ```
-- Requires a system installation of `boost` containing the `system`, `filesystem`, `log` (which also depends on `thread` and `date_time`) and `iostreams` libraries. If not already installed use the following or look at [this](https://www.boost.org/doc/libs/1_62_0/more/getting_started/unix-variants.html) guide.
+
+- Requires a system installation of `boost` containing the `system`,
+  `filesystem`, `log` (which also depends on `thread` and `date_time`)
+  and `iostreams` libraries. If not already installed use the following
+  or look at
+  [this](https://www.boost.org/doc/libs/1_62_0/more/getting_started/unix-variants.html)
+  guide.
+
 ```
 wget https://sourceforge.net/projects/boost/files/boost/1.62.0/boost_1_62_0.tar.gz -O - | tar xzf -
 cd boost_1_62_0
 ./bootstrap.sh [--prefix=/prefix/path] --with-libraries=system,filesystem,iostreams,log,thread,date_time
 ./b2 install
 ```
+
 - Download and install `pandora` as follows:
+
 ```
 git clone --single-branch https://github.com/rmcolq/pandora.git --recursive
 cd pandora
@@ -113,11 +175,20 @@ Subcommands:
 ```
 
 ### Population Reference Graphs
-Pandora assumes you have already constructed a fasta-like file of graphs, one entry for each gene/ genome region of interest.
-If you haven't, you will need a multiple sequence alignment for each graph. Precompiled collections of MSA representing othologous gene clusters for a number of species can be downloaded from [here](http://pangenome.de/) and converted to graphs using the pipeline from [here](https://github.com/rmcolq/make_prg).
+
+Pandora assumes you have already constructed a fasta-like file of
+graphs, one entry for each gene/ genome region of interest. If you
+haven't, you will need a multiple sequence alignment for each graph.
+Precompiled collections of MSA representing othologous gene clusters for
+a number of species can be downloaded from [here](http://pangenome.de/)
+and converted to graphs using the pipeline from
+[here](https://github.com/rmcolq/make_prg).
 
 ### Build index
-Takes a fasta-like file of PanRG sequences and constructs an index, and a directory of gfa files to be used by `pandora map` or `pandora compare`. These are output in the same directory as the PanRG file.
+
+Takes a fasta-like file of PanRG sequences and constructs an index, and
+a directory of gfa files to be used by `pandora map` or `pandora
+compare`. These are output in the same directory as the PanRG file.
 
 ```
 $ pandora index --help
@@ -136,10 +207,15 @@ Options:
   -v                          Verbosity of logging. Repeat for increased verbosity
 ```
 
-The index stores (w,k)-minimizers for each PanRG path found. These parameters can be specified, but default to w=14, k=15.
+The index stores (w,k)-minimizers for each PanRG path found. These
+parameters can be specified, but default to w=14, k=15.
 
 ### Map reads to index
-This takes a fasta/q of Nanopore or Illumina reads and compares to the index. It infers which of the PanRG genes/elements is present, and for those that are present it outputs the inferred sequence and a genotyped VCF.
+
+This takes a fasta/q of Nanopore or Illumina reads and compares to the
+index. It infers which of the PanRG genes/elements is present, and for
+those that are present it outputs the inferred sequence and a genotyped
+VCF.
 
 ```
 $ pandora map --help
@@ -199,7 +275,12 @@ Genotyping:
 ```
 
 ### Compare reads from several samples
-This takes Nanopore or Illumina read fasta/q for a number of samples, mapping each to the index. It infers which of the PanRG genes/elements is present in each sample, and outputs a presence/absence pangenome matrix, the inferred sequences for each sample and a genotyped multisample pangenome VCF.
+
+This takes Nanopore or Illumina read fasta/q for a number of samples,
+mapping each to the index. It infers which of the PanRG genes/elements
+is present in each sample, and outputs a presence/absence pangenome
+matrix, the inferred sequences for each sample and a genotyped
+multisample pangenome VCF.
 
 ```
 $ pandora compare --help
@@ -256,7 +337,8 @@ Genotyping:
 
 ### Discover novel variants
 
-This will look for regions in the pangraph where the reads do not map and attempt to locally assemble these regions to find novel variants.
+This will look for regions in the pangraph where the reads do not map
+and attempt to locally assemble these regions to find novel variants.
 
 ```
 $ pandora discover --help
@@ -309,3 +391,4 @@ Filtering:
 Consensus/Variant Calling:
   --kmer-avg INT              Maximum number of kmers to average over when selecting the maximum likelihood path [default: 100]
 ```
+

--- a/ci/install.sh
+++ b/ci/install.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+set -evu
+
+BOOST_URL="http://sourceforge.net/projects/boost/files/boost/${BOOST_VERSION}/boost_${BOOST_VERSION//\./_}.tar.gz"
+BOOST_DIR="${DEPS_DIR}/boost-${BOOST_VERSION}"
+BOOST_ROOT="/usr"
+export BOOST_DIR
+export BOOST_ROOT
+
+# we cache this boost directory so we don't build it every time
+if [[ -z "$(ls -A "${BOOST_DIR}")" ]]; then
+  mkdir -p "${BOOST_DIR}"
+  { wget --quiet -O - "${BOOST_URL}" | tar --strip-components=1 -xz -C "${BOOST_DIR}"; } || exit 1
+fi
+
+cd "$BOOST_DIR" || exit 1
+{ sudo ./bootstrap.sh --with-libraries="$BOOST_LIBS" --prefix="$BOOST_ROOT" && sudo ./b2 install; } || exit 1

--- a/ci/script.sh
+++ b/ci/script.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+set -evu
+
+export CMAKE_OPTIONS="-DCMAKE_BUILD_TYPE=$BUILD_TYPE "
+
+echo "$CMAKE_OPTIONS"
+mkdir build
+cd build || exit 1
+{ cmake "$CMAKE_OPTIONS" ..  && make -j4; } || exit 1
+export PATH="${PWD}:${PATH}"
+./pandora --help
+ctest -V || exit 1

--- a/ext/gatb.cmake
+++ b/ext/gatb.cmake
@@ -9,7 +9,12 @@ ExternalProject_Add(gatb
         GIT_REPOSITORY https://github.com/GATB/gatb-core.git
         GIT_TAG "v1.4.1"
         PREFIX "${CMAKE_CURRENT_BINARY_DIR}/gatb"
-        SOURCE_DIR "${CMAKE_CURRENT_BINARY_DIR}/gatb/src/gatb/gatb-core/gatb-core"
+        SOURCE_SUBDIR gatb-core
         CMAKE_ARGS -DKSIZE_LIST=32
         INSTALL_COMMAND "")
+
+ExternalProject_Get_Property(gatb source_dir binary_dir)
+
+set(gatb_source_dir ${source_dir})
+set(gatb_binary_dir ${binary_dir})
 

--- a/ext/gatb.cmake
+++ b/ext/gatb.cmake
@@ -1,30 +1,15 @@
 include(ExternalProject)
 
-execute_process(COMMAND mkdir -p ${CMAKE_BINARY_DIR}/ext)
-execute_process(COMMAND mkdir -p ${CMAKE_BINARY_DIR}/bin)
-execute_process(COMMAND mkdir -p ${CMAKE_BINARY_DIR}/lib)
-execute_process(COMMAND mkdir -p ${CMAKE_BINARY_DIR}/include)
-
-set(GATB_DIR ${CMAKE_BINARY_DIR}/ext/gatb-core-1.4.1/gatb-core)
-set(GATB_BUILD_DIR ${GATB_DIR}/build)
-execute_process(COMMAND mkdir -p ${GATB_BUILD_DIR})
+# We don't want to install some GATB-CORE artifacts
+SET (GATB_CORE_EXCLUDE_TOOLS     1)
+SET (GATB_CORE_EXCLUDE_TESTS     1)
+SET (GATB_CORE_INCLUDE_EXAMPLES  1)
 
 ExternalProject_Add(gatb
-        DOWNLOAD_COMMAND  wget https://github.com/GATB/gatb-core/archive/v1.4.1.tar.gz --timestamping -O gatb.tar.gz
-        DOWNLOAD_DIR      "${CMAKE_BINARY_DIR}/ext"
-        CONFIGURE_COMMAND ""
-        BUILD_COMMAND     bash -c "cd ${GATB_BUILD_DIR} && cmake -D CMAKE_C_COMPILER=${CMAKE_C_COMPILER} -D CMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER} ${GATB_DIR} && make"
-        INSTALL_COMMAND   ""
-        TEST_COMMAND      "")
+        GIT_REPOSITORY https://github.com/GATB/gatb-core.git
+        GIT_TAG "v1.4.1"
+        PREFIX "${CMAKE_CURRENT_BINARY_DIR}/gatb"
+        SOURCE_DIR "${CMAKE_CURRENT_BINARY_DIR}/gatb/src/gatb/gatb-core/gatb-core"
+        CMAKE_ARGS -DKSIZE_LIST=32
+        INSTALL_COMMAND "")
 
-ExternalProject_Add_Step(gatb extract_tar
-        COMMAND tar -xvzf ${CMAKE_BINARY_DIR}/ext/gatb.tar.gz -C ${CMAKE_BINARY_DIR}/ext
-        DEPENDEES download
-        DEPENDERS configure)
-
-ExternalProject_Add_Step(gatb copy
-        COMMAND bash -c "cp -r ${GATB_BUILD_DIR}/bin/* ${CMAKE_BINARY_DIR}/bin/"
-        COMMAND bash -c "cp -r ${GATB_BUILD_DIR}/lib/* ${CMAKE_BINARY_DIR}/lib/"
-        COMMAND bash -c "cp -r ${GATB_BUILD_DIR}/include/* ${CMAKE_BINARY_DIR}/include/"
-        COMMAND bash -c "cp -r ${GATB_DIR}/src/gatb/* ${CMAKE_BINARY_DIR}/include/gatb/"
-        DEPENDEES build)

--- a/include/denovo_discovery/denovo_discovery.h
+++ b/include/denovo_discovery/denovo_discovery.h
@@ -20,7 +20,7 @@ private:
 public:
     const uint16_t max_insertion_size;
     const uint16_t min_covg_for_node_in_assembly_graph;
-    bool clean_assembly_graph;
+    const bool clean_assembly_graph;
 
     DenovoDiscovery(const uint16_t& kmer_size, const double& read_error_rate,
         uint16_t max_insertion_size = 15,

--- a/include/denovo_discovery/denovo_discovery.h
+++ b/include/denovo_discovery/denovo_discovery.h
@@ -13,23 +13,24 @@
 namespace fs = boost::filesystem;
 
 class DenovoDiscovery {
+private:
+    const uint16_t kmer_size;
+    const double read_error_rate;
+
 public:
-    const uint16_t min_covg_for_node_in_assembly_graph;
-    bool clean_assembly_graph { false };
     const uint16_t max_insertion_size;
+    const uint16_t min_covg_for_node_in_assembly_graph;
+    bool clean_assembly_graph;
 
     DenovoDiscovery(const uint16_t& kmer_size, const double& read_error_rate,
-        uint16_t max_insertion_size = 15, uint16_t min_covg_for_node_in_assembly_graph = 1);
+        uint16_t max_insertion_size = 15,
+        uint16_t min_covg_for_node_in_assembly_graph = 1, bool clean = false);
 
     void find_paths_through_candidate_region(
         CandidateRegion& candidate_region, const fs::path& denovo_output_directory);
 
     double calculate_kmer_coverage(
         const uint32_t& read_covg, const uint32_t& ref_length) const;
-
-private:
-    const uint16_t kmer_size;
-    const double read_error_rate;
 };
 
 #endif // PANDORA_DENOVO_DISCOVERY_H

--- a/include/denovo_discovery/denovo_discovery.h
+++ b/include/denovo_discovery/denovo_discovery.h
@@ -18,7 +18,7 @@ public:
     bool clean_assembly_graph { false };
     const uint16_t max_insertion_size;
 
-    DenovoDiscovery(const uint32_t& kmer_size, const double& read_error_rate,
+    DenovoDiscovery(const uint16_t& kmer_size, const double& read_error_rate,
         uint16_t max_insertion_size = 15, uint16_t min_covg_for_node_in_assembly_graph = 1);
 
     void find_paths_through_candidate_region(
@@ -28,7 +28,7 @@ public:
         const uint32_t& read_covg, const uint32_t& ref_length) const;
 
 private:
-    const uint32_t kmer_size;
+    const uint16_t kmer_size;
     const double read_error_rate;
 };
 

--- a/include/denovo_discovery/discover_main.h
+++ b/include/denovo_discovery/discover_main.h
@@ -13,6 +13,7 @@
 #include "denovo_discovery/candidate_region.h"
 #include "denovo_discovery/denovo_discovery.h"
 
+constexpr auto MAX_DENOVO_K { 32 };
 namespace fs = boost::filesystem;
 
 /// Collection of all options of discover subcommand.
@@ -33,7 +34,7 @@ struct DiscoverOptions {
     bool clean { false };
     bool binomial { false };
     uint32_t max_covg { 600 };
-    uint32_t denovo_kmer_size { 11 };
+    uint16_t denovo_kmer_size { 11 };
     uint16_t max_insertion_size { 15 };
     uint16_t min_covg_for_node_in_assembly_graph { 2 };
     uint32_t min_candidate_covg { 3 };

--- a/include/denovo_discovery/discover_main.h
+++ b/include/denovo_discovery/discover_main.h
@@ -44,6 +44,7 @@ struct DiscoverOptions {
     uint32_t merge_dist { 22 };
     uint32_t min_cluster_size { 10 };
     uint32_t max_num_kmers_to_avg { 100 };
+    bool clean_dbg { false };
 };
 
 void setup_discover_subcommand(CLI::App& app);

--- a/include/denovo_discovery/discover_main.h
+++ b/include/denovo_discovery/discover_main.h
@@ -41,7 +41,7 @@ struct DiscoverOptions {
     uint32_t min_candidate_len { 1 };
     uint32_t max_candidate_len { 50 };
     uint16_t candidate_padding { 22 };
-    uint32_t merge_dist { 22 };
+    uint32_t merge_dist { 15 };
     uint32_t min_cluster_size { 10 };
     uint32_t max_num_kmers_to_avg { 100 };
     bool clean_dbg { false };

--- a/include/denovo_discovery/local_assembly.h
+++ b/include/denovo_discovery/local_assembly.h
@@ -8,8 +8,8 @@
 #include <unordered_map>
 #include <unordered_set>
 
-#include <gatb/debruijn/impl/Simplifications.hpp>
-#include <gatb/gatb_core.hpp>
+#include "gatb/debruijn/impl/Simplifications.hpp"
+#include "gatb/gatb_core.hpp"
 #include <sys/stat.h>
 
 #include <boost/filesystem.hpp>

--- a/src/denovo_discovery/denovo_discovery.cpp
+++ b/src/denovo_discovery/denovo_discovery.cpp
@@ -38,8 +38,10 @@ void DenovoDiscovery::find_paths_through_candidate_region(
             new BankStrings(candidate_region.pileup),
             "-kmer-size %d -abundance-min %d -verbose 0 -nb-cores 1 -out %s", kmer_size,
             min_covg_for_node_in_assembly_graph, GATB_graph_filepath_as_string.c_str());
-        if (clean_assembly_graph) {
+        if (this->clean_assembly_graph) {
+            BOOST_LOG_TRIVIAL(debug) << "Cleaning local assembly graph...";
             clean(gatb_graph);
+            BOOST_LOG_TRIVIAL(debug) << "Local assembly graph cleaned";
         }
         graph = gatb_graph; // TODO: use move constructor
 
@@ -134,11 +136,12 @@ void DenovoDiscovery::find_paths_through_candidate_region(
 
 DenovoDiscovery::DenovoDiscovery(const uint16_t& kmer_size,
     const double& read_error_rate, const uint16_t max_insertion_size,
-    const uint16_t min_covg_for_node_in_assembly_graph)
-    : min_covg_for_node_in_assembly_graph { min_covg_for_node_in_assembly_graph }
-    , max_insertion_size { max_insertion_size }
-    , kmer_size { kmer_size }
+    const uint16_t min_covg_for_node_in_assembly_graph, const bool clean)
+    : kmer_size { kmer_size }
     , read_error_rate { read_error_rate }
+    , max_insertion_size { max_insertion_size }
+    , min_covg_for_node_in_assembly_graph { min_covg_for_node_in_assembly_graph }
+    , clean_assembly_graph { clean }
 {
 }
 

--- a/src/denovo_discovery/denovo_discovery.cpp
+++ b/src/denovo_discovery/denovo_discovery.cpp
@@ -132,7 +132,7 @@ void DenovoDiscovery::find_paths_through_candidate_region(
     remove_graph_file(GATB_graph_filepath);
 }
 
-DenovoDiscovery::DenovoDiscovery(const uint32_t& kmer_size,
+DenovoDiscovery::DenovoDiscovery(const uint16_t& kmer_size,
     const double& read_error_rate, const uint16_t max_insertion_size,
     const uint16_t min_covg_for_node_in_assembly_graph)
     : min_covg_for_node_in_assembly_graph { min_covg_for_node_in_assembly_graph }

--- a/src/denovo_discovery/discover_main.cpp
+++ b/src/denovo_discovery/discover_main.cpp
@@ -107,6 +107,7 @@ void setup_discover_subcommand(CLI::App& app)
         ->add_option("--discover-k", opt->denovo_kmer_size,
             "K-mer size to use when discovering novel variants")
         ->capture_default_str()
+        ->check(CLI::Range(0, MAX_DENOVO_K))
         ->type_name("INT");
 
     std::string description = "Max. insertion size for novel variants. Warning: "

--- a/src/denovo_discovery/discover_main.cpp
+++ b/src/denovo_discovery/discover_main.cpp
@@ -93,6 +93,11 @@ void setup_discover_subcommand(CLI::App& app)
         ->group("Filtering");
 
     discover_subcmd
+        ->add_flag(
+            "--clean-dbg", opt->clean_dbg, "Clean the local assembly de Bruijn graph")
+        ->group("Filtering");
+
+    discover_subcmd
         ->add_flag("--bin", opt->binomial,
             "Use binomial model for kmer coverages [default: negative binomial]")
         ->group("Parameter Estimation");
@@ -343,7 +348,8 @@ int pandora_discover(DiscoverOptions& opt)
     }
 
     DenovoDiscovery denovo { opt.denovo_kmer_size, opt.error_rate,
-        opt.max_insertion_size, opt.min_covg_for_node_in_assembly_graph };
+        opt.max_insertion_size, opt.min_covg_for_node_in_assembly_graph,
+        opt.clean_dbg };
     const fs::path denovo_output_directory { fs::path(opt.outdir) / "denovo_paths" };
     fs::create_directories(denovo_output_directory);
     BOOST_LOG_TRIVIAL(info)

--- a/src/denovo_discovery/discover_main.cpp
+++ b/src/denovo_discovery/discover_main.cpp
@@ -112,7 +112,8 @@ void setup_discover_subcommand(CLI::App& app)
         ->add_option("--discover-k", opt->denovo_kmer_size,
             "K-mer size to use when discovering novel variants")
         ->capture_default_str()
-        ->check(CLI::Range(0, MAX_DENOVO_K))
+        ->check(CLI::Range(0, MAX_DENOVO_K)
+                    .description("[0-" + std::to_string(MAX_DENOVO_K) + ")"))
         ->type_name("INT");
 
     std::string description = "Max. insertion size for novel variants. Warning: "

--- a/src/denovo_discovery/local_assembly.cpp
+++ b/src/denovo_discovery/local_assembly.cpp
@@ -180,6 +180,8 @@ std::pair<DenovoPaths, FoundPaths> LocalAssemblyGraph::get_paths_between(
             abandoned = true;
             break;
         }
+
+        BOOST_LOG_TRIVIAL(trace) << "Trying local assembly with " << std::to_string(required_percent_of_expected_covg) << " * <expected covg>";
         build_paths_between(start_kmer, end_kmer, path_accumulator, tree,
             node_to_distance_to_the_end_node, paths_between_queries, max_path_length,
             expected_coverage, required_percent_of_expected_covg);
@@ -224,7 +226,6 @@ void LocalAssemblyGraph::build_paths_between(const std::string& start_kmer,
             return;
         }
     }
-
     path_accumulator.push_back(start_kmer.back());
 
     if (string_ends_with(path_accumulator, end_kmer)

--- a/src/denovo_discovery/local_assembly.cpp
+++ b/src/denovo_discovery/local_assembly.cpp
@@ -259,15 +259,14 @@ void clean(Graph& graph, const uint16_t& num_cores)
     graph_simplifications._doBulgeRemoval = false;
     graph_simplifications._doECRemoval = false;
 
-    graph_simplifications._tipLen_Topo_kMult
-        = 2; // remove all tips of length <= k * X bp  [default '2.500000'] set to 0 to
-             // turn off
-    graph_simplifications._tipLen_RCTC_kMult
-        = 0; // remove tips that pass coverage criteria, of length <= k * X bp  [default
-             // '10.000000'] set to 0 to turn off
-    graph_simplifications._tipRCTCcutoff
-        = 2; // tip relative coverage coefficient: mean coverage of neighbors >  X * tip
-             // coverage default 2.0
+    // remove all tips of length <= k * X bp  [default '2.500000'] set to 0 to turn off
+    graph_simplifications._tipLen_Topo_kMult = 2;
+    // remove tips that pass coverage criteria, of length <= k * X bp  [default
+    // '10.000000'] set to 0 to turn off
+    graph_simplifications._tipLen_RCTC_kMult = 0;
+    // tip relative coverage coefficient: mean coverage of neighbors >  X * tip coverage
+    // default 2.0
+    graph_simplifications._tipRCTCcutoff = 2;
     graph_simplifications.simplify();
 }
 

--- a/src/estimate_parameters.cpp
+++ b/src/estimate_parameters.cpp
@@ -1,6 +1,5 @@
 #include <vector>
 #include <iostream>
-#include <fstream>
 #include <cmath>
 #include <cassert>
 #include <numeric>
@@ -250,14 +249,14 @@ uint32_t estimate_parameters(std::shared_ptr<pangenome::Graph> pangraph,
     // evaluate error rate
     auto mean = fit_mean_covg(kmer_covg_dist, covg / 10);
     auto var = fit_variance_covg(kmer_covg_dist, mean, covg / 10);
-    std::cout << "mean, var: " << mean << " " << var << std::endl;
+    BOOST_LOG_TRIVIAL(debug) << "mean, var: " << mean << ", " << var;
     if (mean > var) {
         auto zero_thresh = 2;
         mean = fit_mean_covg(kmer_covg_dist, zero_thresh);
         var = fit_variance_covg(kmer_covg_dist, mean, zero_thresh);
-        std::cout << "new mean, var: " << mean << " " << var << std::endl;
+        BOOST_LOG_TRIVIAL(debug) << "new mean, var: " << mean << ", " << var;
     }
-    std::cout << bin << " " << num_reads << " " << covg << std::endl;
+    BOOST_LOG_TRIVIAL(debug) << "nb reads, covg" << num_reads << ", " << covg;
     if ((bin and num_reads > 30 and covg > 30)
         or (not bin and abs(var - mean) < 2 and mean > 10 and num_reads > 30
             and covg > 2)) {

--- a/src/index.cpp
+++ b/src/index.cpp
@@ -22,8 +22,6 @@
 void Index::add_record(const uint64_t kmer, const uint32_t prg_id,
     const prg::Path& path, const uint32_t knode_id, const bool strand)
 {
-    // cout << "Add kmer " << kmer << " id, path, strand " << prg_id << ", " << path <<
-    // ", " << strand << endl;
     auto it = minhash.find(kmer); // checks if kmer is in minhash
     if (it == minhash.end()) { // no
         auto* newv = new std::vector<MiniRecord>; // get a new vector of MiniRecords -
@@ -32,7 +30,6 @@ void Index::add_record(const uint64_t kmer, const uint32_t prg_id,
         newv->emplace_back(MiniRecord(prg_id, path, knode_id, strand));
         minhash.insert(std::pair<uint64_t, std::vector<MiniRecord>*>(
             kmer, newv)); // add this record to minhash
-        // cout << "New minhash size: " << minhash.size() << endl;
     } else { // yes
         MiniRecord mr(prg_id, path, knode_id,
             strand); // create a new MiniRecord from this minimizer kmer
@@ -41,7 +38,6 @@ void Index::add_record(const uint64_t kmer, const uint32_t prg_id,
                                     // vector of this minimizer
             it->second->push_back(mr); // no, add it
         }
-        // cout << "New minhash entry for  kmer " << kmer << endl;
     }
 }
 

--- a/src/inthash.cpp
+++ b/src/inthash.cpp
@@ -1,6 +1,5 @@
 #include <iostream>
 #include <cassert>
-#include <cmath>
 #include <cstring>
 #include "inthash.h"
 
@@ -38,24 +37,16 @@
  * means hash_64(x, mask)==hash_64(y, mask) if and only if x==y.
  */
 
-unsigned char seq_nt4_table[256] = {
-    0, 1, 2, 3, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4,
-    4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4,
-    4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4,
-    4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4,
-    4, 0, 4, 1, 4, 4, 4, 2, 4, 4, 4, 4, 4, 4, 4, 4,
-    4, 4, 4, 4, 3, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4,
-    4, 0, 4, 1, 4, 4, 4, 2, 4, 4, 4, 4, 4, 4, 4, 4,
-    4, 4, 4, 4, 3, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4,
-    4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4,
-    4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4,
-    4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4,
-    4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4,
-    4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4,
-    4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4,
-    4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4,
-    4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4
-};
+unsigned char seq_nt4_table[256] = { 0, 1, 2, 3, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4,
+    4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4,
+    4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 0, 4, 1, 4, 4, 4, 2, 4,
+    4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 3, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 0, 4, 1, 4,
+    4, 4, 2, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 3, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4,
+    4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4,
+    4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4,
+    4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4,
+    4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4,
+    4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4 };
 
 uint32_t nt4(char c) { return seq_nt4_table[(uint8_t)c]; }
 
@@ -138,27 +129,17 @@ std::pair<uint64_t, uint64_t> KmerHash::kmerhash(const std::string& s, const uin
     assert(s.size() == k);
     int c;
     uint64_t shift1 = 2 * (k - 1), mask = (1ULL << 2 * k) - 1, kmer[2] = { 0, 0 };
-    // uint64_t mask1 = pow(4,k) - 1, kh = 0, rckh = 0;
     char myArray[s.size() + 1]; // as 1 char space for null is also required
     strcpy(myArray, s.c_str());
     for (char i : s) {
         c = seq_nt4_table[(uint8_t)i];
-        // cout << s[i] << " -> " << c;
         if (c < 4) { // not an ambiguous base
             kmer[0] = (kmer[0] << 2 | c) & mask; // forward k-mer
             kmer[1] = (kmer[1] >> 2) | (3ULL ^ c) << shift1; // reverse k-mer
-            // kh += c*pow(4,i);
-            // rckh += (3-c)*pow(4,k-i-1);
         }
-        // cout << "after adding " << s[i] << "=" << c << " kh is now " << kh << " and
-        // kmer[0] is now " << kmer[0] << ", rckh is now " << rckh << " and kmer[1] is
-        // now " << kmer[1] << endl;
     }
-    // cout << "s: " << s << " -> " << kh << endl;
     kmer[0] = hash64(kmer[0], mask);
     kmer[1] = hash64(kmer[1], mask);
-    // cout << "kmer " << s << " has kmer[0] " << kmer[0] << " and kmer[1] " << kmer[1]
-    // << endl;
 
     auto ret = std::make_pair(kmer[0], kmer[1]);
     lookup[s] = ret;

--- a/src/localPRG.cpp
+++ b/src/localPRG.cpp
@@ -1,9 +1,7 @@
 #include <fstream>
 #include <set>
 #include <cassert>
-#include <cmath>
 #include <algorithm>
-#include <numeric>
 #include <cstdlib>
 #include <utility>
 
@@ -47,7 +45,6 @@ bool LocalPRG::isalpha_string(const std::string& s) const
     // Returns if a string s is entirely alphabetic
     for (char j : s)
         if (isalpha(j) == 0) {
-            // std::cout << "Found non-alpha char: " << s[j] << std::endl;
             return false;
         }
     return true;
@@ -55,15 +52,12 @@ bool LocalPRG::isalpha_string(const std::string& s) const
 
 std::string LocalPRG::string_along_path(const prg::Path& p) const
 {
-    // std::cout << p << std::endl;
     assert(p.get_start() <= seq.length());
     assert(p.get_end() <= seq.length());
     std::string s;
     for (const auto& it : p) {
         s += seq.substr(it.start, it.length);
-        // std::cout << s << std::endl;
     }
-    // std::cout << "lengths: " << s.length() << ", " << p.length << std::endl;
     assert(s.length() == p.length()
         || assert_msg("sequence length "
             << s.length() << " is not equal to path length " << p.length()));
@@ -174,9 +168,6 @@ std::vector<LocalNodePtr> LocalPRG::nodes_along_path_core(const prg::Path& p) co
 std::vector<Interval> LocalPRG::split_by_site(const Interval& i) const
 {
     // Splits interval by next_site based on substring of seq in the interval
-    // std::cout << "splitting by site " << next_site << " in interval " << i <<
-    // std::endl;
-
     // Split first by var site
     std::vector<Interval> v; // contains the intervals split by the variant site
     v.reserve(4);
@@ -384,7 +375,6 @@ std::vector<PathPtr> LocalPRG::shift(prg::Path p) const
     std::deque<PathPtr> short_paths = { std::make_shared<prg::Path>(q) };
     std::vector<PathPtr> k_paths;
     bool non_terminus;
-    // uint exp_num_return_seqs = 0;
 
     // first find extensions of the path
     while (!short_paths.empty()) {
@@ -654,7 +644,6 @@ void LocalPRG::minimizer_sketch(const std::shared_ptr<Index>& index, const uint3
                     kmer = string_along_path(*(v[j]));
                     kh = hash.kmerhash(kmer, k);
                     smallest = std::min(smallest, std::min(kh.first, kh.second));
-                    // std::cout << min(kh.first, kh.second) << " ";
                 }
                 for (uint32_t j = 0; j != w; j++) {
                     kmer = string_along_path(*(v[j]));
@@ -850,18 +839,13 @@ std::vector<LocalNodePtr> LocalPRG::localnode_path_from_kmernode_path(
             }
         }
         if (localnode_path[0]->id != 0) {
-            // std::cout << "localnode path still does not start with 0" << std::endl;
             // add the first path to start
             LocalNodePtr next = nullptr;
             while (localnode_path[0]->id != 0 and next != localnode_path[0]) {
-                // std::cout << "look for a previous node to " << *localnode_path[0] <<
-                // std::endl;
                 next = prg.get_previous_node(localnode_path[0]);
                 if (next != nullptr) {
-                    // std::cout << "add " << *next << std::endl;
                     localnode_path.insert(localnode_path.begin(), next);
                 }
-                // std::cout << "new start node is " << *localnode_path[0] << std::endl;
             }
         }
     }
@@ -899,14 +883,10 @@ std::vector<LocalNodePtr> LocalPRG::localnode_path_from_kmernode_path(
             }
         }
         if (localnode_path.back()->id != prg.nodes.size() - 1) {
-            // std::cout << "localnode path still does not end with " <<
-            // prg.nodes.size()-1 << std::endl;
             // add the first path to end
             while (localnode_path.back()->id != prg.nodes.size() - 1
                 and !localnode_path.back()->outNodes.empty()) {
-                // std::cout << "extend " << *localnode_path.back();
                 localnode_path.push_back(localnode_path.back()->outNodes[0]);
-                // std::cout << " with " << *localnode_path.back() << std::endl;
             }
         }
     }
@@ -1188,17 +1168,6 @@ void LocalPRG::
         const std::string& sample_name) const
 {
     BOOST_LOG_TRIVIAL(debug) << "Update VCF with sample path";
-    /*for (uint i=0; i!=sample_path.size(); ++i)
-    {
-        std::cout << *sample_path[i] << " ";
-    }
-    std::cout << std::endl;
-    std::cout << now() << "Using ref path" << std::endl;
-    for (uint i=0; i!=rpath.size(); ++i)
-    {
-        std::cout << *rpath[i] << " ";
-    }
-    std::cout << std::endl;*/
     assert(!prg.nodes.empty()); // otherwise empty nodes -> segfault
 
     // if prg has only one node, simple case
@@ -1231,27 +1200,19 @@ void LocalPRG::
             found_new_site = true;
             sample_id++;
         } else if (found_new_site) {
-            // refpath back == samplepath back
             // add ref allele from previous site to this one
-            // std::cout << "update with ref alleles from " << pos << " to " << pos_to
-            // << std::endl;
             vcf.set_sample_gt_to_ref_allele_for_records_in_the_interval(
                 sample_name, name, pos, pos_to);
             pos = pos_to;
 
             // add new site to vcf
-            // std::cout << "find ref seq" << std::endl;
             for (uint32_t j = 1; j < refpath.size() - 1; ++j) {
                 ref += refpath[j]->seq;
-                // std::cout << ref << std::endl;
             }
-            // std::cout << "find alt seq" << std::endl;
             for (uint32_t j = 1; j < samplepath.size() - 1; ++j) {
                 alt += samplepath[j]->seq;
-                // std::cout << alt << std::endl;
             }
 
-            // std::cout << "add sample gt" << std::endl;
             vcf.add_a_new_record_discovered_in_a_sample_and_genotype_it(
                 sample_name, name, pos, ref, alt);
             found_new_site = false;
@@ -1276,7 +1237,6 @@ void LocalPRG::
             }
             pos_to = pos;
         } else {
-            // std::cout << pos_to << std::endl;
             refpath.erase(refpath.begin(), refpath.end() - 1);
             if (refpath.back()->id != prg.nodes.size() - 1) {
                 ref = "";
@@ -1293,10 +1253,8 @@ void LocalPRG::
             }
         }
     }
-    // std::cout << "add last ref alleles" << std::endl;
     vcf.set_sample_gt_to_ref_allele_for_records_in_the_interval(
         sample_name, name, pos, pos_to);
-    // std::cout << "done" << std::endl;
 }
 
 // Find the path through the PRG which deviates at pos from the ref path with alt
@@ -1305,8 +1263,6 @@ std::vector<LocalNodePtr> LocalPRG::find_alt_path(
     const std::vector<LocalNodePtr>& ref_path, const uint32_t pos,
     const std::string& ref, const std::string& alt) const
 {
-    // std::cout << now() << "Find alt path for PRG " << name << " variant " << pos << "
-    // " << ref << " " << alt << std::endl;
     std::vector<LocalNodePtr> alt_path, considered_path;
     std::deque<std::vector<LocalNodePtr>> paths_in_progress;
     uint32_t ref_added = 0, pos_along_ref_path = 0;
@@ -1327,8 +1283,6 @@ std::vector<LocalNodePtr> LocalPRG::find_alt_path(
             break;
         }
     }
-    // std::cout << "pos " << pos << " pos_along_ref_path " << pos_along_ref_path << "
-    // ref_path.size() " << ref_path.size() << std::endl;
 
     // find the localnodeptr we want to make our way back to
     while (pos_along_ref_path < ref_path.size() - 1
@@ -1339,7 +1293,6 @@ std::vector<LocalNodePtr> LocalPRG::find_alt_path(
     }
     assert(pos_along_ref_path < ref_path.size());
     auto ref_node_to_find = ref_path[pos_along_ref_path];
-    // std::cout << "trying to find " << *ref_node_to_find;
 
     // find an alt path with the required sequence
     if (alt_path.empty() and not ref_path.empty() and ref_path[0]->pos.length == 0)
@@ -1353,14 +1306,7 @@ std::vector<LocalNodePtr> LocalPRG::find_alt_path(
         considered_path = paths_in_progress.front();
         paths_in_progress.pop_front();
 
-        /*std::cout << "consider path ";
-        for (const auto &t : considered_path){
-            std::cout << t->pos << " ";
-        }
-        std::cout << std::endl;*/
-
         auto considered_seq = string_along_path(considered_path);
-        // std::cout << "considered_seq " << considered_seq << std::endl;
 
         if (considered_seq == working_alt) {
             // check if merge with ref path
@@ -1371,11 +1317,6 @@ std::vector<LocalNodePtr> LocalPRG::find_alt_path(
                     alt_path.end(), considered_path.begin(), considered_path.end());
                 alt_path.insert(alt_path.end(), ref_path.begin() + pos_along_ref_path,
                     ref_path.end());
-                /*std::cout << "found alt path ";
-                for (const auto &t : considered_path){
-                    std::cout << t->pos << " ";
-                }
-                std::cout << std::endl;*/
                 return alt_path;
             } else {
                 for (const auto& m : considered_path.back()->outNodes) {
@@ -1544,7 +1485,6 @@ void LocalPRG::add_sample_covgs_to_vcf(VCF& vcf, const KmerGraphWithCoverage& kg
 
     for (auto& recordPointer : vcf.get_records()) {
         auto& record = *recordPointer;
-        // std::cout << record << std::endl;
         // find corresponding ref kmers
         auto end_pos = record.get_ref_end_pos();
 

--- a/src/localnode.cpp
+++ b/src/localnode.cpp
@@ -22,23 +22,18 @@ std::ostream& operator<<(std::ostream& out, LocalNode const& n)
 
 bool LocalNode::operator==(const LocalNode& y) const
 {
-    if (seq != y.seq) { // cout << "different seq" << endl;
+    if (seq != y.seq) {
         return false;
     }
-    // if (!(pos == y.pos)) {//cout << "different interval" << endl;
-    // return false;}
-    if (id != y.id) { // cout << "different id" << endl;
+    if (id != y.id) {
         return false;
     }
-    if (outNodes.size()
-        != y.outNodes.size()) { // cout << "differnet numbers of out edges" << endl;
+    if (outNodes.size() != y.outNodes.size()) {
         return false;
     }
     for (uint32_t i = 0; i != outNodes.size(); ++i) {
         spointer_values_equal<LocalNode> eq = { outNodes[i] };
-        if (find_if(y.outNodes.begin(), y.outNodes.end(), eq)
-            == y.outNodes.end()) { // cout << "the out edge points to a different node"
-                                   // << endl;
+        if (find_if(y.outNodes.begin(), y.outNodes.end(), eq) == y.outNodes.end()) {
             return false;
         }
     }

--- a/src/minirecord.cpp
+++ b/src/minirecord.cpp
@@ -1,4 +1,3 @@
-#include <cassert>
 #include <functional>
 #include <iostream>
 #include "minirecord.h"
@@ -16,8 +15,6 @@ MiniRecord::~MiniRecord() {};
 
 bool MiniRecord::operator==(const MiniRecord& y) const
 {
-    // cout << prg_id << "," << y.prg_id << endl;
-    // cout << path << "," << y.path << endl;
     if (prg_id != y.prg_id) {
         return false;
     }

--- a/src/pangenome/panread.cpp
+++ b/src/pangenome/panread.cpp
@@ -1,7 +1,5 @@
 #include <iostream>
-#include <fstream>
 #include <cassert>
-#include <climits>
 #include <unordered_set>
 #include <set>
 #include <memory>
@@ -110,42 +108,21 @@ std::pair<uint32_t, uint32_t> Read::find_position(
     const std::vector<uint_least32_t>& node_ids, const std::vector<bool>& node_orients,
     const uint16_t min_overlap)
 {
-    /*cout << "searching for ";
-    for (const auto &n : node_ids)
-    {
-        cout << n << " ";
-    }
-    cout << " in ";
-    for (const auto &n : nodes)
-    {
-        cout << n->node_id << " ";
-    }
-    cout << endl;*/
-
     assert(node_ids.size() == node_orients.size());
     assert(not node_ids.empty());
     uint32_t search_pos = 0;
     uint32_t found_pos = 0;
 
-    // cout << "searching forwards for " << node_ids[0] << " " << node_orients[0];
-    // cout << " and backwards for " << node_ids.back() << " " << !node_orients.back()
-    // << endl;
-
     for (uint32_t i = 0; i < nodes.size(); ++i) {
-        // cout << "compare nodes pos " << i << " with node_ids 0" << endl;
         // if first node matches at position i going forwards...
         if (nodes[i].lock()->node_id == node_ids[0]
             and node_orientations[i] == node_orients[0]) {
-            // cout << "start node " << i << " fwd " << nodes[i]->node_id << " " <<
-            // node_orientations[i]; cout << " matches " << node_ids[0] << " and " <<
-            // node_orients[0] << endl;
 
             search_pos = 0;
             found_pos = 0;
             while (i + found_pos < nodes.size()
                 and nodes[i + found_pos].lock()->node_id == node_ids[search_pos]
                 and node_orientations[i + found_pos] == node_orients[search_pos]) {
-                // cout << "fwd " << search_pos << " " << i + found_pos << endl;
                 if (search_pos == node_ids.size() - 1
                     or i + found_pos == nodes.size() - 1) {
                     if (found_pos + 1 >= min_overlap) {
@@ -157,30 +134,20 @@ std::pair<uint32_t, uint32_t> Read::find_position(
                 search_pos++;
                 found_pos++;
             }
-            // cout << "end fwd" << endl;
         }
 
         // if i+node_ids.size() is over the end of nodes, consider partial matches which
         // skip the first <size_overhang> nodes
-        // cout << "compare nodes pos " << 0 << " with node_ids " << i + node_ids.size()
-        // - nodes.size() << endl;
         if (i + node_ids.size() > nodes.size()
             and nodes[0].lock()->node_id == node_ids[i + node_ids.size() - nodes.size()]
             and node_orientations[0]
                 == node_orients[i + node_orients.size() - nodes.size()]) {
-
-            // cout << "start node " << i << " truncated fwd " << nodes[0]->node_id;
-            // cout << " " << node_orientations[0];
-            // cout << " matches " << node_ids[i + node_ids.size() - nodes.size()];
-            // cout << " and " << node_orients[i + node_ids.size() - nodes.size()] <<
-            // endl;
 
             search_pos = i + node_ids.size() - nodes.size();
             found_pos = 0;
             while (found_pos < nodes.size()
                 and nodes[found_pos].lock()->node_id == node_ids[search_pos]
                 and node_orientations[found_pos] == node_orients[search_pos]) {
-                // cout << "fwd " << search_pos << " " << found_pos << endl;
                 if (search_pos == node_ids.size() - 1
                     or found_pos == nodes.size() - 1) {
                     if (found_pos + 1 >= min_overlap) {
@@ -194,14 +161,9 @@ std::pair<uint32_t, uint32_t> Read::find_position(
             }
         }
 
-        // cout << "compare nodes pos " << nodes.size() -1 -i << " with node_ids " << 0
-        // << endl;
         if (nodes[nodes.size() - 1 - i].lock()->node_id == node_ids[0]
             and node_orientations[node_orientations.size() - 1 - i]
                 == !node_orients[0]) {
-            // cout << "start node " << i << " bwd " << nodes[nodes.size() -1
-            // -i]->node_id; cout << " " << node_orientations[nodes.size() -1 -i]; cout
-            // << " matches " << node_ids[0] << " and " << !node_orients[0] << endl;
 
             search_pos = 0;
             found_pos = 0;
@@ -210,8 +172,6 @@ std::pair<uint32_t, uint32_t> Read::find_position(
                     == node_ids[search_pos]
                 and node_orientations[nodes.size() - 1 - i - found_pos]
                     == !node_orients[search_pos]) {
-                // cout << "bwd " << search_pos << " " << nodes.size() -1 -i -found_pos
-                // << endl;
                 if (search_pos == node_ids.size() - 1
                     or i + 1 + found_pos == nodes.size()) {
                     if (found_pos + 1 >= min_overlap) {
@@ -224,29 +184,15 @@ std::pair<uint32_t, uint32_t> Read::find_position(
                 search_pos++;
                 found_pos++;
             }
-            // cout << "end bwd" << endl;
         }
 
         // if we are considering matches which overlap the start backwards, also
         // consider ones which overlap the end backwards by the same amount
-        // cout << "compare nodes pos " << nodes.size() -1 << " with node_ids " <<
-        // nodes.size() -1 - i << endl;
         if (i + node_ids.size() > nodes.size()
-            // and nodes[nodes.size() -1 -i]->node_id == node_ids[i + node_ids.size() -
-            // nodes.size()] and node_orientations[node_orientations.size() -1  -i] ==
-            // !node_orients[i + node_orients.size() - nodes.size()])
             and nodes.back().lock()->node_id
                 == node_ids[i + node_ids.size() - nodes.size()]
             and node_orientations.back()
                 == !node_orients[i + node_orients.size() - nodes.size()]) {
-            // cout << "start node " << i << " truncated bwd " << nodes.back()->node_id;
-            // cout << " " << node_orientations.back();
-            // //cout << " matches " << node_ids[node_ids.size() - nodes.size()-1 - i];
-            // //cout << " and " << !node_orients[node_ids.size() - nodes.size()-1 - i]
-            // << endl;
-            // cout << " matches " << node_ids[i + node_ids.size() - nodes.size()];
-            // cout << " and " << !node_orients[i + node_ids.size() - nodes.size()] <<
-            // endl;
 
             search_pos = i + node_ids.size() - nodes.size();
             found_pos = 0;
@@ -255,7 +201,6 @@ std::pair<uint32_t, uint32_t> Read::find_position(
                     == node_ids[search_pos]
                 and node_orientations[nodes.size() - 1 - found_pos]
                     == !node_orients[search_pos]) {
-                // cout << "bwd " << search_pos << " " << found_pos << endl;
                 if (search_pos == node_ids.size() - 1
                     or i + 1 + found_pos == nodes.size()) {
                     if (found_pos + 1 >= min_overlap) {
@@ -289,7 +234,6 @@ void Read::remove_all_nodes_with_this_id(const uint32_t node_id)
 std::vector<WeakNodePtr>::iterator Read::remove_node_with_iterator(
     std::vector<WeakNodePtr>::iterator nit)
 {
-    //(*nit)->covg -= 1;
     uint32_t d = distance(nodes.begin(), nit);
     node_orientations.erase(node_orientations.begin() + d);
     nit = nodes.erase(nit);
@@ -299,11 +243,8 @@ std::vector<WeakNodePtr>::iterator Read::remove_node_with_iterator(
 void Read::replace_node_with_iterator(
     std::vector<WeakNodePtr>::iterator n_original, NodePtr n)
 {
-    // hits[n->node_id].insert(hits[(*n_original)->node_id].begin(),hits[(*n_original)->node_id].end()
-    // );
     auto it = nodes.erase(n_original);
     nodes.insert(it, n);
-    // hits.erase((*n_original)->node_id);
 }
 
 bool Read::operator==(const Read& y) const

--- a/src/prg/path.cpp
+++ b/src/prg/path.cpp
@@ -69,8 +69,7 @@ std::vector<LocalNodePtr> prg::Path::nodes_along_path(const LocalPRG& localPrg)
 prg::Path prg::Path::subpath(const uint32_t start, const uint32_t len) const
 {
     // function now returns the path starting at position start along the path, rather
-    // than at position start on linear PRG, and for length len cout << "find subpath of
-    // " << *this << " from " << start << " for length " << len << endl;
+    // than at position start on linear PRG, and for length len
     assert(start + len <= length());
     prg::Path p;
     std::deque<Interval> d;
@@ -87,17 +86,12 @@ prg::Path prg::Path::subpath(const uint32_t start, const uint32_t len) const
             p.initialize(d);
             added_len
                 += std::min(len - added_len, interval.length - start + covered_length);
-            /// cout << "added first interval " << p.path.back() << " and added length
-            /// is now " << added_len << endl;
         } else if (covered_length >= start and added_len <= len) {
             p.add_end_interval(Interval(interval.start,
                 std::min(interval.get_end(), interval.start + len - added_len)));
             added_len += std::min(len - added_len, interval.length);
-            // cout << "added interval " << p.path.back() << " and added length is now "
-            // << added_len << endl;
         }
         covered_length += interval.length;
-        // cout << "covered length is now " << covered_length << endl;
         if (added_len >= len) {
             break;
         }
@@ -121,7 +115,6 @@ bool prg::Path::is_branching(const prg::Path& y)
         if (overlap) {
             if (it->start != it2->start) {
                 // had paths which overlapped and now don't
-                // cout << "branch" << endl;
                 return true; // represent branching paths at this point
             }
             ++it2;
@@ -131,17 +124,14 @@ bool prg::Path::is_branching(const prg::Path& y)
             }
         } else {
             for (it2 = y.path.begin(); it2 != y.path.end(); ++it2) {
-                // cout << *it << " " << *it2 << endl;
                 if ((it->get_end() > it2->start and it->start < it2->get_end())
                     or (*it == *it2)) {
                     // then the paths overlap
                     overlap = true;
-                    // cout << "overlap" << endl;
                     // first query the previous intervals if they exist, to see if they
                     // overlap
                     if (it != path.begin() && it2 != y.path.begin()
                         && (--it)->get_end() != (--it2)->get_end()) {
-                        // cout << "coal" << endl;
                         return true; // represent coalescent paths at this point
                     } else {
                         ++it2;
@@ -163,9 +153,6 @@ bool prg::Path::is_subpath(const prg::Path& big_path) const
 {
     if (big_path.length() < length() or big_path.get_start() > get_start()
         or big_path.get_end() < get_end() or is_branching(big_path)) {
-        // cout << "fell at first hurdle " << (big_path.length() < length());
-        // cout << (big_path.start > start) << (big_path.end < end);
-        // cout << (is_branching(big_path)) << endl;
         return false;
     }
 

--- a/src/seq.cpp
+++ b/src/seq.cpp
@@ -75,7 +75,6 @@ void Seq::add_minimizing_kmers_to_sketch(
     for (const auto& minimizer : window) {
         if (minimizer.canonical_kmer_hash == smallest) {
             sketch.insert(minimizer);
-            // num_minis_found += 1;
         }
     }
 }
@@ -138,7 +137,6 @@ void Seq::minimizer_sketch(const uint32_t w, const uint32_t k)
                           "still has size "
                 << window.size()));
     }
-    // cout << now() << "Sketch size " << sketch.size() << " for read " << name << endl;
 }
 
 std::ostream& operator<<(std::ostream& out, Seq const& data)

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -1,13 +1,10 @@
 #include <cstring>
-#include <sstream>
 #include <iomanip>
 #include <unordered_map>
 #include <vector>
 #include <iostream>
-#include <fstream>
 #include <cmath>
 #include <cassert>
-#include <cctype>
 #include <set>
 #include <memory>
 #include <ctime>
@@ -18,7 +15,6 @@
 #include "seq.h"
 #include "localPRG.h"
 #include "pangenome/pangraph.h"
-#include "pangenome/panread.h"
 #include "noise_filtering.h"
 #include "minihit.h"
 #include "fastaq_handler.h"
@@ -76,7 +72,6 @@ char complement(char n)
     case 'c':
         return 'G';
     }
-    // assert(false);
     return 'N';
 }
 
@@ -134,7 +129,7 @@ void read_prg_file(std::vector<std::shared_ptr<LocalPRG>>& prgs,
             prgs.push_back(s);
             id++;
         } else {
-            std::cerr << "Failed to make LocalPRG for " << fh.name << std::endl;
+            BOOST_LOG_TRIVIAL(error) << "Failed to make LocalPRG for " << fh.name;
             exit(1);
         }
     }
@@ -151,12 +146,10 @@ void load_PRG_kmergraphs(std::vector<std::shared_ptr<LocalPRG>>& prgs,
         prefix += prgfile.substr(0, pos);
         prefix += "/";
     }
-    // cout << "prefix for kmerprgs dir is " << prefix << endl;
 
     auto dir_num = 0;
     std::string dir;
     for (const auto& prg : prgs) {
-        // cout << "Load kmergraph for " << prg->name << endl;
         if (prg->id % 4000 == 0) {
             dir = prefix + "kmer_prgs/" + int_to_string(dir_num + 1);
             dir_num++;
@@ -189,9 +182,6 @@ void load_vcf_refs_file(const std::string& filepath, VCFRefs& vcf_refs)
 void add_read_hits(const Seq& sequence,
     const std::shared_ptr<MinimizerHits>& minimizer_hits, const Index& index)
 {
-    // cout << now() << "Search for hits for read " << s->name << " which has sketch
-    // size " << s->sketch.size() << " against index of size " << idx->minhash.size() <<
-    // endl; uint32_t hit_count = 0;
     // creates Seq object for the read, then looks up minimizers in the Seq sketch and
     // adds hits to a global MinimizerHits object
     // Seq s(id, name, seq, w, k);
@@ -202,14 +192,9 @@ void add_read_hits(const Seq& sequence,
             // yes, add all hits of this minimizer hit to this kmer
             for (const MiniRecord& miniRecord : *(minhashIt->second)) {
                 minimizer_hits->add_hit(sequence.id, *sequenceSketchIt, miniRecord);
-                //++hit_count;
             }
         }
     }
-    // hits->sort();
-    // cout << now() << "Found " << hit_count << " hits found for read " << s->name << "
-    // so size of MinimizerHits is now "
-    //     << hits->hits.size() + hits->uhits.size() << endl;
 }
 
 void define_clusters(std::set<MinimizerHitCluster, clusterComp>& clusters_of_hits,
@@ -218,7 +203,7 @@ void define_clusters(std::set<MinimizerHitCluster, clusterComp>& clusters_of_hit
     const float& fraction_kmers_required_for_cluster, const uint32_t min_cluster_size,
     const uint32_t expected_number_kmers_in_short_read_sketch)
 {
-    BOOST_LOG_TRIVIAL(debug) << "Define clusters of hits from the "
+    BOOST_LOG_TRIVIAL(trace) << "Define clusters of hits from the "
                              << minimizer_hits->hits.size() << " hits";
 
     if (minimizer_hits->hits.empty()) {
@@ -245,7 +230,7 @@ void define_clusters(std::set<MinimizerHitCluster, clusterComp>& clusters_of_hit
                       prgs[(*mh_previous)->get_prg_id()]->kmer_prg.min_path_length(),
                       expected_number_kmers_in_short_read_sketch)
                 * fraction_kmers_required_for_cluster;
-            BOOST_LOG_TRIVIAL(debug)
+            BOOST_LOG_TRIVIAL(trace)
                 << "Length based cluster threshold min("
                 << prgs[(*mh_previous)->get_prg_id()]->kmer_prg.min_path_length()
                 << ", " << expected_number_kmers_in_short_read_sketch << ") * "
@@ -255,9 +240,8 @@ void define_clusters(std::set<MinimizerHitCluster, clusterComp>& clusters_of_hit
             if (current_cluster.size()
                 > std::max(length_based_threshold, min_cluster_size)) {
                 clusters_of_hits.insert(current_cluster);
-                // cout << "Found cluster of size " << current_cluster.size() << endl;
             } else {
-                BOOST_LOG_TRIVIAL(debug)
+                BOOST_LOG_TRIVIAL(trace)
                     << "Rejected cluster of size " << current_cluster.size()
                     << " < max(" << length_based_threshold << ", " << min_cluster_size
                     << ")";
@@ -271,7 +255,7 @@ void define_clusters(std::set<MinimizerHitCluster, clusterComp>& clusters_of_hit
         = std::min(prgs[(*mh_previous)->get_prg_id()]->kmer_prg.min_path_length(),
               expected_number_kmers_in_short_read_sketch)
         * fraction_kmers_required_for_cluster;
-    BOOST_LOG_TRIVIAL(debug)
+    BOOST_LOG_TRIVIAL(trace)
         << "Length based cluster threshold min("
         << prgs[(*mh_previous)->get_prg_id()]->kmer_prg.min_path_length() << ", "
         << expected_number_kmers_in_short_read_sketch << ") * "
@@ -279,39 +263,27 @@ void define_clusters(std::set<MinimizerHitCluster, clusterComp>& clusters_of_hit
     if (current_cluster.size() > std::max(length_based_threshold, min_cluster_size)) {
         clusters_of_hits.insert(current_cluster);
     } else {
-        BOOST_LOG_TRIVIAL(debug)
+        BOOST_LOG_TRIVIAL(trace)
             << "Rejected cluster of size " << current_cluster.size() << " < max("
             << length_based_threshold << ", " << min_cluster_size << ")";
     }
 
-    BOOST_LOG_TRIVIAL(debug) << "Found " << clusters_of_hits.size()
+    BOOST_LOG_TRIVIAL(trace) << "Found " << clusters_of_hits.size()
                              << " clusters of hits";
 }
 
 void filter_clusters(std::set<MinimizerHitCluster, clusterComp>& clusters_of_hits)
 {
     // Next order clusters, choose between those that overlap by too much
-    BOOST_LOG_TRIVIAL(debug) << "Filter the " << clusters_of_hits.size()
+    BOOST_LOG_TRIVIAL(trace) << "Filter the " << clusters_of_hits.size()
                              << " clusters of hits";
     if (clusters_of_hits.empty()) {
         return;
     }
     // to do this consider pairs of clusters in turn
     auto c_previous = clusters_of_hits.begin();
-    /*cout << "first cluster" << endl;
-    for (set<MinimizerHit*, pComp>::iterator p=c_previous->begin();
-    p!=c_previous->end(); ++p)
-    {
-        cout << **p << endl;
-    }*/
     for (auto c_current = ++clusters_of_hits.begin();
          c_current != clusters_of_hits.end(); ++c_current) {
-        /*cout << "current cluster" << endl;
-        for (set<MinimizerHit*, pComp>::iterator p=c_current->begin();
-        p!=c_current->end(); ++p)
-        {
-            cout << **p << endl;
-        }*/
         if (((*(*c_current).begin())->get_read_id()
                 == (*(*c_previous).begin())->get_read_id())
             && // if on same read and either
@@ -330,16 +302,14 @@ void filter_clusters(std::set<MinimizerHitCluster, clusterComp>& clusters_of_hit
         {
             if (c_previous->size() >= c_current->size()) {
                 clusters_of_hits.erase(c_current);
-                // cout << "erase current" << endl;
                 c_current = c_previous;
             } else {
                 clusters_of_hits.erase(c_previous);
-                // cout << "erase previous" << endl;
             }
         }
         c_previous = c_current;
     }
-    BOOST_LOG_TRIVIAL(debug) << "Now have " << clusters_of_hits.size()
+    BOOST_LOG_TRIVIAL(trace) << "Now have " << clusters_of_hits.size()
                              << " clusters of hits";
 }
 
@@ -348,7 +318,7 @@ void filter_clusters2(std::set<MinimizerHitCluster, clusterComp>& clusters_of_hi
 {
     // Sort clusters by size, and filter out those small clusters which are entirely
     // contained in bigger clusters on reads
-    BOOST_LOG_TRIVIAL(debug) << "Filter2 the " << clusters_of_hits.size()
+    BOOST_LOG_TRIVIAL(trace) << "Filter2 the " << clusters_of_hits.size()
                              << " clusters of hits";
     if (clusters_of_hits.empty()) {
         return;
@@ -359,25 +329,18 @@ void filter_clusters2(std::set<MinimizerHitCluster, clusterComp>& clusters_of_hi
 
     auto it = clusters_by_size.begin();
     std::vector<int> read_v(genome_size, 0);
-    // cout << "fill from " << (*(it->begin()))->read_start_position() << " to " <<
-    // (*--(it->end()))->read_start_position() << endl;
     fill(read_v.begin() + (*(it->begin()))->get_read_start_position(),
         read_v.begin() + (*--(it->end()))->get_read_start_position(), 1);
     bool contained;
     for (auto it_next = ++clusters_by_size.begin(); it_next != clusters_by_size.end();
          ++it_next) {
-        // cout << "read id " << (*(it_next->begin()))->get_prg_id() << endl;
         if ((*(it_next->begin()))->get_read_id() == (*(it->begin()))->get_read_id()) {
             // check if have any 0s in interval of read_v between first and last
             contained = true;
             for (uint32_t i = (*(it_next->begin()))->get_read_start_position();
                  i < (*--(it_next->end()))->get_read_start_position(); ++i) {
-                // cout << i << ":" << read_v[i] << "\t";
                 if (read_v[i] == 0) {
                     contained = false;
-                    // cout << "found unique element at read position " << i << endl;
-                    // cout << "fill from " << i << " to " <<
-                    // (*--(it_next->end()))->get_read_start_position() << endl;
                     fill(read_v.begin() + i,
                         read_v.begin()
                             + (*--(it_next->end()))->get_read_start_position(),
@@ -385,20 +348,16 @@ void filter_clusters2(std::set<MinimizerHitCluster, clusterComp>& clusters_of_hi
                     break;
                 }
             }
-            // cout << endl;
             if (contained) {
-                // cout << "erase cluster so clusters_of_hits has size decrease from "
-                // << clusters_of_hits.size();
                 clusters_of_hits.erase(*it_next);
-                // cout << " to " << clusters_of_hits.size() << endl;
             }
         } else {
-            // cout << "consider new read" << endl;
+            // consider new read
             fill(read_v.begin(), read_v.end(), 0);
         }
         ++it;
     }
-    BOOST_LOG_TRIVIAL(debug) << "Now have " << clusters_of_hits.size()
+    BOOST_LOG_TRIVIAL(trace) << "Now have " << clusters_of_hits.size()
                              << " clusters of hits";
 }
 
@@ -407,7 +366,7 @@ void add_clusters_to_pangraph(
     std::shared_ptr<pangenome::Graph> pangraph,
     const std::vector<std::shared_ptr<LocalPRG>>& prgs)
 {
-    BOOST_LOG_TRIVIAL(debug) << "Add inferred order to PanGraph";
+    BOOST_LOG_TRIVIAL(trace) << "Add inferred order to PanGraph";
     if (clusters_of_hits.empty()) {
         return;
     }
@@ -645,6 +604,7 @@ uint32_t strtogs(const char* str)
     return (uint32_t)(x + .499);
 }
 
-std::string transform_cli_gsize(std::string str) {
+std::string transform_cli_gsize(std::string str)
+{
     return int_to_string(strtogs(str.c_str()));
 }

--- a/src/vcf.cpp
+++ b/src/vcf.cpp
@@ -78,7 +78,6 @@ ptrdiff_t VCF::get_sample_index(const std::string& name)
     // if this sample has not been added before, add a column for it
     auto sample_it = find(samples.begin(), samples.end(), name);
     if (sample_it == samples.end()) {
-        // cout << "this is the first time this sample has been added" << endl;
         samples.push_back(name);
         for (auto& record_ptr : records) {
             record_ptr->add_new_samples(1);
@@ -95,13 +94,9 @@ void VCF::add_a_new_record_discovered_in_a_sample_and_genotype_it(
     const std::string& sample_name, const std::string& chrom, const uint32_t pos,
     const std::string& ref, const std::string& alt)
 {
-    // cout << "adding gt " << chrom << " " << pos << " " << ref << " vs " <<
-    // sample_name << " " << alt << endl;
     if (ref == "" and alt == "") {
         return;
     }
-
-    // cout << "adding gt " << ref << " vs " << alt << endl;
 
     ptrdiff_t sample_index = get_sample_index(sample_name);
 
@@ -112,14 +107,11 @@ void VCF::add_a_new_record_discovered_in_a_sample_and_genotype_it(
         vcf_record); // TODO: improve this search to log(n) using alt map or sth
     bool vcf_record_was_found = vcf_record_iterator != records.end();
     if (vcf_record_was_found) {
-        // cout << "found record with this ref and alt" << endl;
         (*vcf_record_iterator)
             ->sampleIndex_to_sampleInfo[sample_index]
             .set_gt_from_max_likelihood_path(1);
         vcf_record_pointer = vcf_record_iterator->get();
     } else {
-        // cout << "didn't find alt record for pos " << pos << " ref " << ref << " and
-        // alt " << alt << endl;
         // either we have the ref allele, an alternative allele for alt too nested site,
         // or alt mistake
         bool vcf_record_was_processed = false;
@@ -137,7 +129,6 @@ void VCF::add_a_new_record_discovered_in_a_sample_and_genotype_it(
                 }
             }
         } else {
-            // cout << "have new allele not in graph" << endl;
             add_record(
                 chrom, pos, ref, alt, "SVTYPE=COMPLEX", "GRAPHTYPE=TOO_MANY_ALTS");
             records.back()
@@ -174,8 +165,6 @@ void VCF::update_other_samples_of_this_record(VCFRecord* reference_record)
                     and other_record->sampleIndex_to_sampleInfo[sample_index]
                             .get_gt_from_max_likelihood_path()
                         == 0) {
-                    // cout << "update my record to have ref allele also for sample " <<
-                    // sample_index << endl; cout << records[record_index] << endl;
                     reference_record->sampleIndex_to_sampleInfo[sample_index]
                         .set_gt_from_max_likelihood_path(0);
                 }
@@ -195,7 +184,6 @@ void VCF::set_sample_gt_to_ref_allele_for_records_in_the_interval(
         if (record->ref_allele_is_inside_given_interval(chrom, pos_from, pos_to)) {
             record->sampleIndex_to_sampleInfo[sample_index]
                 .set_gt_from_max_likelihood_path(0);
-            // cout << "update record " << records[i] << endl;
         }
     }
 }
@@ -316,13 +304,6 @@ void VCF::merge_multi_allelic_core(VCF& merged_VCF, uint32_t max_allele_length) 
                         .empty()) {
                     assert_msg("VCF::merge_multi_allelic: vcf_record_to_be_merged_in "
                                "has no samples");
-                    /*
-                    records.at(current_vcf_record_position)->clear();
-                    records.at(previous_vcf_record_position)->clear();
-                    merged_VCF.add_record_core(vcf_record_merged);
-                    previous_vcf_record_position = records.size() - 1;
-                    vcf_record_merged = *(records.at(previous_vcf_record_position));
-                     */
                 }
                 vcf_record_merged->merge_record_into_this(
                     *vcf_record_to_be_merged_in_pointer);

--- a/test/denovo_discovery/denovo_discovery_test.cpp
+++ b/test/denovo_discovery/denovo_discovery_test.cpp
@@ -211,10 +211,10 @@ TEST(FindPathsThroughCandidateRegionTest, endKmerExistsInStartKmersFindPathAndCy
 TEST(FindPathsThroughCandidateRegionTest,
     doGraphCleaningtwoIdenticalReadsPlusNoiseReturnOnePath)
 {
+    const auto clean { true };
     const int k { 9 };
     const double error_rate { 0.11 };
-    DenovoDiscovery denovo { k, error_rate };
-    denovo.clean_assembly_graph = true;
+    DenovoDiscovery denovo { k, error_rate, 15, 1, clean };
     CandidateRegion candidate_region { Interval(0, 1), "test" };
     candidate_region.max_likelihood_sequence = "ATGCGCTGAGAGTCGGACT";
     candidate_region.pileup


### PR DESCRIPTION
_**DISCLAIMER**: don't let the number of file changes put you off - I just deleted a lot of comments..._

## Added

- Build and test on travis-ci [closes #158]. You can see an example for commit abc2508 [here](https://travis-ci.com/github/mbhall88/pandora/builds/196284489)
- `--clean-dbg` flag in `pandora discover`. This exposes the option for cleaning the GATB de Bruijn graph before doing local assembly.

## Removed

- a lot of commented-out code - basically any comments that mention `cout` or `cerr`

## Changed

- GATB build process. This is now considerably faster as we now only build GATB for a maximum k-mer size of 32. I changed the `--discover-k` parameter to only accept integers in the range [0-32) as a guard for this. I also streamlined the cmake build process for GATB to build from a git commit rather than downloading a tar ball. This is so that we can easily transition to a fork of GATB if we need to to support multithreading.
- (Almost) all usage of `std::cout` and `std::cerr` has been replaced with writes to the log instead [closes #221]
- default value for `--merge-dist` is now 15 [#74 and mbhall88/head_to_head_pipeline/issues/48 will have evidence to support this change soon]