### PR TITLE
Add version flag and changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,40 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on
+[Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this
+project adheres to
+[Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+There is a significant amount of changes to the project between version
+0.6 and this release. Only major things are listed here. Future releases
+from this point will have their changes meticulously documented here.
+
+### Added
+
+- `discover` subcommand for de novo variant discovery [[#234][234]]
+- many more tests
+
+### Changed
+
+- FASTA/Q files are now parsed with `klib` [[#223][223]]
+- command-line interface is now overhauled with many breaking changes
+  [[#224][224]]
+- global genotyping has been made default [[#220][220]]
+- Various improvements to VCF-related functions
+
+### Fixed
+
+- k-mer coverage underflow bug in `LoacalPRG` [[#183][183]]
+
+[Unreleased]: https://github.com/olivierlacan/keep-a-changelog/compare/v0.6...HEAD
+
+[183]: https://github.com/rmcolq/pandora/issues/183
+[220]: https://github.com/rmcolq/pandora/pull/220
+[223]: https://github.com/rmcolq/pandora/pull/223
+[224]: https://github.com/rmcolq/pandora/pull/224
+[234]: https://github.com/rmcolq/pandora/pull/234
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,7 @@ from this point will have their changes meticulously documented here.
 
 ### Fixed
 
-- k-mer coverage underflow bug in `LoacalPRG` [[#183][183]]
+- k-mer coverage underflow bug in `LocalPRG` [[#183][183]]
 
 [Unreleased]: https://github.com/olivierlacan/keep-a-changelog/compare/v0.6...HEAD
 
@@ -37,4 +37,3 @@ from this point will have their changes meticulously documented here.
 [223]: https://github.com/rmcolq/pandora/pull/223
 [224]: https://github.com/rmcolq/pandora/pull/224
 [234]: https://github.com/rmcolq/pandora/pull/234
-

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,8 @@
-cmake_minimum_required(VERSION 2.8.7)
+cmake_minimum_required(VERSION 3.0)
 
 set(PROJECT_NAME_STR pandora)
-project(${PROJECT_NAME_STR} C CXX)
+project(${PROJECT_NAME_STR} VERSION "0.7.0" LANGUAGES C CXX)
+configure_file( include/version.h.in ${CMAKE_BINARY_DIR}/include/version.h )
 
 # add a RELEASE_WITH_ASSERTS build type
 set(CMAKE_CXX_FLAGS_RELEASE_WITH_ASSERTS "-O3")

--- a/README.md
+++ b/README.md
@@ -146,16 +146,18 @@ Usage: pandora [OPTIONS] SUBCOMMAND
 
 Options:
   -h,--help                   Print this help message and exit
+  -V,--version
 
 Subcommands:
   index                       Index population reference graph (PRG) sequences.
-  map                         Quasi-map reads to an indexed PRG, infer the sequence of present loci in the sample, and (optionally) genotype/discover variants.
+  map                         Quasi-map reads to an indexed PRG, infer the sequence of present loci in the sample, and optionally genotype variants.
   compare                     Quasi-map reads from multiple samples to an indexed PRG, infer the sequence of present loci in each sample, and call variants between the samples.
+  discover                    Quasi-map reads to an indexed PRG, infer the sequence of present loci in the sample and discover novel variants.
   walk                        Outputs a path through the nodes in a PRG corresponding to the either an input sequence (if it exists) or the top/bottom path
   seq2path                    For each sequence, return the path through the PRG
   get_vcf_ref                 Outputs a fasta suitable for use as the VCF reference using input sequences
   random                      Outputs a fasta of random paths through the PRGs
-  merge_index                 Allows multiple indices to be merged (no compatibility check
+  merge_index                 Allows multiple indices to be merged (no compatibility check)
 ```
 
 ### Population Reference Graphs

--- a/include/version.h.in
+++ b/include/version.h.in
@@ -1,0 +1,6 @@
+#ifndef VERSION_H
+#define VERSION_H
+
+#define PANDORA_VERSION "@PROJECT_VERSION@"
+
+#endif // VERSION_H

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,5 +1,6 @@
 #include <iostream>
 #include "CLI11.hpp"
+#include "version.h"
 #include "index_main.h"
 #include "map_main.h"
 #include "compare_main.h"
@@ -56,6 +57,10 @@ int main(int argc, char* argv[])
     CLI::App app { "Pandora: Pan-genome inference and genotyping with long noisy or "
                    "short accurate reads." };
     app.formatter(std::make_shared<MyFormatter>());
+    app.add_flag_callback("-V,--version", []() {
+        std::cout << "pandora version " << PANDORA_VERSION << std::endl;
+        throw(CLI::Success {});
+    });
     setup_index_subcommand(app);
     setup_map_subcommand(app);
     setup_compare_subcommand(app);


### PR DESCRIPTION
The additions in this PR are effectively the final steps before merging `dev` onto `master` and tagging a `v0.7.0` release. 

closes #245 