### PR TITLE
0.9.0-rc2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ project adheres to
 
 ## [Unreleased]
 
+## [0.9.0-rc2]
+
+### Changed
+- `pandora discover` now processes one sample at a time, but runs with several threads on the heavy tasks, i.e. when
+mapping reads, finding candidate regions, and finding denovo variants. The result is that it now takes a lot less RAM to
+run on multiple samples at the cost of a small increase of runtime.
+
 ## [0.9.0-rc1]
 
 ### Changed
@@ -85,7 +92,8 @@ from this point will have their changes meticulously documented here.
 
 - k-mer coverage underflow bug in `LocalPRG` [[#183][183]]
 
-[Unreleased]: https://github.com/rmcolq/pandora/compare/0.9.0-rc1...HEAD
+[Unreleased]: https://github.com/rmcolq/pandora/compare/0.9.0-rc2...HEAD
+[0.9.0-rc2]: https://github.com/rmcolq/pandora/releases/tag/0.9.0-rc2
 [0.9.0-rc1]: https://github.com/rmcolq/pandora/releases/tag/0.9.0-rc1
 [0.8.0]: https://github.com/rmcolq/pandora/releases/tag/0.8.0
 [v0.7.0]: https://github.com/rmcolq/pandora/releases/tag/v0.7.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ project adheres to
 ### Changed
 - `pandora discover` now processes one sample at a time, but runs with several threads on the heavy tasks, i.e. when
 mapping reads, finding candidate regions, and finding denovo variants. The result is that it now takes a lot less RAM to
-run on multiple samples at the cost of a small increase of runtime.
+run on multiple samples.
 
 ## [0.9.0-rc1]
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -92,9 +92,9 @@ set(Gtest_LIBRARIES GTest::gtest GTest::gmock_main)
 
 ########################################################################################################################
 # INSTALL BOOST
-hunter_add_package(Boost COMPONENTS filesystem iostreams log system thread)
-find_package(Boost CONFIG REQUIRED filesystem iostreams log system thread)
-set(BOOST_LIBRARIES Boost::filesystem Boost::iostreams Boost::log Boost::system Boost::thread)
+hunter_add_package(Boost COMPONENTS filesystem iostreams log serialization system thread)
+find_package(Boost CONFIG REQUIRED filesystem iostreams log serialization system thread)
+set(BOOST_LIBRARIES Boost::filesystem Boost::iostreams Boost::log Boost::serialization Boost::system Boost::thread)
 set(Boost_USE_STATIC_LIBS ON)
 ########################################################################################################################
 ########################################################################################################################

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,7 +12,7 @@ HunterGate(
 # project configuration
 set(PROJECT_NAME_STR pandora)
 project(${PROJECT_NAME_STR} VERSION "0.9.0" LANGUAGES C CXX)
-set(ADDITIONAL_VERSION_LABELS "-rc1")
+set(ADDITIONAL_VERSION_LABELS "-rc2")
 configure_file( include/version.h.in ${CMAKE_BINARY_DIR}/include/version.h )
 
 # add or not feature to print the stack trace

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,7 @@ ENV PANDORA_DIR "/pandora/"
 
 COPY . $PANDORA_DIR
 WORKDIR ${PANDORA_DIR}/build
-RUN cmake -DCMAKE_BUILD_TYPE="$PANDORA_BUILD_TYPE" -j4 .. \
+RUN cmake -DCMAKE_BUILD_TYPE="$PANDORA_BUILD_TYPE" -DHUNTER_JOBS_NUMBER=4 .. \
     && make -j4 \
     && ctest -V \
     && apt-get remove -y cmake git \

--- a/README.md
+++ b/README.md
@@ -115,14 +115,14 @@ This is the hardest way to install `pandora`, but that yields the most optimised
 Requirements:
 - A Unix or Mac OS, with a C++11 compiler toolset (e.g. `g++`, `ld`, `make`, `ctest`, etc), `cmake`, `git` and `wget`.
 
-- Download and install `pandora` as follows:
+- Download and install `pandora` as follows (this example is using `4` threads, change `4` to how many threads you want):
 
 ```
 git clone --single-branch https://github.com/rmcolq/pandora.git --recursive
 cd pandora
 mkdir -p build
 cd build
-cmake -DCMAKE_BUILD_TYPE=Release .. 
+cmake -DHUNTER_JOBS_NUMBER=4 -DCMAKE_BUILD_TYPE=Release ..
 make -j4
 ctest -VV
 ```

--- a/README.md
+++ b/README.md
@@ -78,13 +78,13 @@ In this binary, all libraries are linked statically.
 
 * **Download**:
   ```
-  wget https://github.com/rmcolq/pandora/releases/download/0.9.0-rc1/pandora-linux-precompiled-v0.9.0-rc1
+  wget https://github.com/rmcolq/pandora/releases/download/0.9.0-rc2/pandora-linux-precompiled-v0.9.0-rc2
   ```
 
 * **Running**:
 ```
-chmod +x pandora-linux-precompiled-v0.9.0-rc1
-./pandora-linux-precompiled-v0.9.0-rc1 -h
+chmod +x pandora-linux-precompiled-v0.9.0-rc2
+./pandora-linux-precompiled-v0.9.0-rc2 -h
 ```
 
 * **Notes**:

--- a/ci/script.sh
+++ b/ci/script.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -evu
 
-export CMAKE_OPTIONS="-DCMAKE_BUILD_TYPE=$BUILD_TYPE "
+export CMAKE_OPTIONS="-DCMAKE_BUILD_TYPE=$BUILD_TYPE -DHUNTER_JOBS_NUMBER=4"
 
 echo "$CMAKE_OPTIONS"
 mkdir build

--- a/example/run_pandora.sh
+++ b/example/run_pandora.sh
@@ -2,7 +2,7 @@
 set -eu
 
 # configs
-pandora_URL="https://github.com/leoisl/pandora/releases/download/0.9.0-rc1_RAM/pandora-linux-precompiled-v0.9.0-rc1_RAM"
+pandora_URL="https://github.com/rmcolq/pandora/releases/download/0.9.0-rc1/pandora-linux-precompiled-v0.9.0-rc1"
 pandora_executable="./pandora-linux-precompiled-v0.9.0-rc1"
 make_prg_URL="https://github.com/leoisl/make_prg/releases/download/v0.2.0_prototype/make_prg_0.2.0_prototype"
 make_prg_executable="./make_prg_0.2.0_prototype"

--- a/example/run_pandora.sh
+++ b/example/run_pandora.sh
@@ -2,7 +2,7 @@
 set -eu
 
 # configs
-pandora_URL="https://github.com/rmcolq/pandora/releases/download/0.9.0-rc1/pandora-linux-precompiled-v0.9.0-rc1"
+pandora_URL="https://github.com/leoisl/pandora/releases/download/0.9.0-rc1_RAM/pandora-linux-precompiled-v0.9.0-rc1_RAM"
 pandora_executable="./pandora-linux-precompiled-v0.9.0-rc1"
 make_prg_URL="https://github.com/leoisl/make_prg/releases/download/v0.2.0_prototype/make_prg_0.2.0_prototype"
 make_prg_executable="./make_prg_0.2.0_prototype"

--- a/example/run_pandora.sh
+++ b/example/run_pandora.sh
@@ -2,8 +2,8 @@
 set -eu
 
 # configs
-pandora_URL="https://github.com/rmcolq/pandora/releases/download/0.9.0-rc1/pandora-linux-precompiled-v0.9.0-rc1"
-pandora_executable="./pandora-linux-precompiled-v0.9.0-rc1"
+pandora_URL="https://github.com/rmcolq/pandora/releases/download/0.9.0-rc2/pandora-linux-precompiled-v0.9.0-rc2"
+pandora_executable="./pandora-linux-precompiled-v0.9.0-rc2"
 make_prg_URL="https://github.com/leoisl/make_prg/releases/download/v0.2.0_prototype/make_prg_0.2.0_prototype"
 make_prg_executable="./make_prg_0.2.0_prototype"
 

--- a/include/denovo_discovery/candidate_region.h
+++ b/include/denovo_discovery/candidate_region.h
@@ -192,7 +192,20 @@ public:
 
     CandidateRegionWriteBuffer(const std::string& sample_name)
         : sample_name(sample_name)
-    {
+    {}
+
+    virtual ~CandidateRegionWriteBuffer() = default;
+    CandidateRegionWriteBuffer(const CandidateRegionWriteBuffer& other) = default;
+    CandidateRegionWriteBuffer(CandidateRegionWriteBuffer&& other) = default;
+    CandidateRegionWriteBuffer& operator=(const CandidateRegionWriteBuffer& other) = default;
+    CandidateRegionWriteBuffer& operator=(CandidateRegionWriteBuffer&& other) = default;
+    bool operator==(const CandidateRegionWriteBuffer& other) const {
+        return this->sample_name == other.sample_name &&
+               this->locus_name_to_ML_path == other.locus_name_to_ML_path &&
+               this->locus_name_to_variants == other.locus_name_to_variants;
+    }
+    bool operator!=(const CandidateRegionWriteBuffer& other) const {
+        return !(*this == other);
     }
 
     virtual void add_new_variant(const std::string& locus_name,

--- a/include/denovo_discovery/candidate_region.h
+++ b/include/denovo_discovery/candidate_region.h
@@ -10,6 +10,10 @@
 #include <set>
 #include <vector>
 #include <sstream>
+#include <boost/archive/text_oarchive.hpp>
+#include <boost/archive/text_iarchive.hpp>
+#include <boost/serialization/map.hpp>
+#include <boost/serialization/vector.hpp>
 
 #ifndef NO_OPENMP
 #include <omp.h>
@@ -173,7 +177,19 @@ protected:
         }
     }
 
+    friend class boost::serialization::access;
+    // Note: trivial method, not tested
+    template<class Archive>
+    void serialize(Archive & ar, const unsigned int version)
+    {
+        ar & sample_name;
+        ar & locus_name_to_ML_path;
+        ar & locus_name_to_variants;
+    }
+
 public:
+    CandidateRegionWriteBuffer(){}  // required by Boost serialization
+
     CandidateRegionWriteBuffer(const std::string& sample_name)
         : sample_name(sample_name)
     {
@@ -196,6 +212,8 @@ public:
     {
         return locus_name_to_variants;
     }
+
+    void merge (const CandidateRegionWriteBuffer &other);
 };
 
 #endif // PANDORA_CANDIDATE_REGION_H

--- a/include/denovo_discovery/candidate_region.h
+++ b/include/denovo_discovery/candidate_region.h
@@ -179,32 +179,35 @@ protected:
 
     friend class boost::serialization::access;
     // Note: trivial method, not tested
-    template<class Archive>
-    void serialize(Archive & ar, const unsigned int version)
+    template <class Archive> void serialize(Archive& ar, const unsigned int version)
     {
-        ar & sample_name;
-        ar & locus_name_to_ML_path;
-        ar & locus_name_to_variants;
+        ar& sample_name;
+        ar& locus_name_to_ML_path;
+        ar& locus_name_to_variants;
     }
 
 public:
-    CandidateRegionWriteBuffer(){}  // required by Boost serialization
+    CandidateRegionWriteBuffer() { } // required by Boost serialization
 
     CandidateRegionWriteBuffer(const std::string& sample_name)
         : sample_name(sample_name)
-    {}
+    {
+    }
 
     virtual ~CandidateRegionWriteBuffer() = default;
     CandidateRegionWriteBuffer(const CandidateRegionWriteBuffer& other) = default;
     CandidateRegionWriteBuffer(CandidateRegionWriteBuffer&& other) = default;
-    CandidateRegionWriteBuffer& operator=(const CandidateRegionWriteBuffer& other) = default;
+    CandidateRegionWriteBuffer& operator=(const CandidateRegionWriteBuffer& other)
+        = default;
     CandidateRegionWriteBuffer& operator=(CandidateRegionWriteBuffer&& other) = default;
-    bool operator==(const CandidateRegionWriteBuffer& other) const {
-        return this->sample_name == other.sample_name &&
-               this->locus_name_to_ML_path == other.locus_name_to_ML_path &&
-               this->locus_name_to_variants == other.locus_name_to_variants;
+    bool operator==(const CandidateRegionWriteBuffer& other) const
+    {
+        return this->sample_name == other.sample_name
+            && this->locus_name_to_ML_path == other.locus_name_to_ML_path
+            && this->locus_name_to_variants == other.locus_name_to_variants;
     }
-    bool operator!=(const CandidateRegionWriteBuffer& other) const {
+    bool operator!=(const CandidateRegionWriteBuffer& other) const
+    {
         return !(*this == other);
     }
 
@@ -226,7 +229,7 @@ public:
         return locus_name_to_variants;
     }
 
-    void merge (const CandidateRegionWriteBuffer &other);
+    void merge(const CandidateRegionWriteBuffer& other);
 };
 
 #endif // PANDORA_CANDIDATE_REGION_H

--- a/include/denovo_discovery/discover_main.h
+++ b/include/denovo_discovery/discover_main.h
@@ -14,10 +14,6 @@
 #include "denovo_discovery/candidate_region.h"
 #include "denovo_discovery/denovo_discovery.h"
 
-// set to 0 to disallow multiprocessing and 1 to allow multiprocessing
-// should always be 1 except if you want to trigger breakpoints, which does not
-// work on forked processes
-#define ALLOW_FORK 1
 constexpr auto MAX_DENOVO_K { 32 };
 namespace fs = boost::filesystem;
 

--- a/include/version.h.in
+++ b/include/version.h.in
@@ -1,6 +1,8 @@
 #ifndef VERSION_H
 #define VERSION_H
 
-#define PANDORA_VERSION "@PROJECT_VERSION@""@ADDITIONAL_VERSION_LABELS@"
+#define PANDORA_VERSION                                                                \
+    "@PROJECT_VERSION@"                                                                \
+    "@ADDITIONAL_VERSION_LABELS@"
 
 #endif // VERSION_H

--- a/scripts/portable_binary_builder/build_portable_binary_core.sh
+++ b/scripts/portable_binary_builder/build_portable_binary_core.sh
@@ -6,7 +6,7 @@ set -eux
 cd /pandora
 mkdir build_portable_executable
 cd build_portable_executable
-cmake -DCMAKE_EXE_LINKER_FLAGS="-static" -DCMAKE_BUILD_TYPE=Release ..
+cmake -DHUNTER_JOBS_NUMBER=4 -DCMAKE_EXE_LINKER_FLAGS="-static" -DCMAKE_BUILD_TYPE=Release ..
 make VERBOSE=1 -j 4
 ctest -VV
 

--- a/src/denovo_discovery/candidate_region.cpp
+++ b/src/denovo_discovery/candidate_region.cpp
@@ -411,9 +411,9 @@ Discover::Discover(uint32_t min_required_covg, uint32_t min_candidate_len,
 void CandidateRegionWriteBuffer::add_new_variant(const std::string& locus_name,
     const std::string& ML_path, const std::string& variant)
 {
-    std::vector<std::string> &variants = locus_name_to_variants[locus_name];
-    const bool variant_already_exists =
-        std::find(variants.begin(), variants.end(), variant) != variants.end();
+    std::vector<std::string>& variants = locus_name_to_variants[locus_name];
+    const bool variant_already_exists
+        = std::find(variants.begin(), variants.end(), variant) != variants.end();
     if (variant_already_exists) {
         return;
     }
@@ -430,28 +430,33 @@ void CandidateRegionWriteBuffer::write_to_file(const fs::path& output_file) cons
     output_filehandler.close();
 }
 
-void CandidateRegionWriteBuffer::merge (const CandidateRegionWriteBuffer &other) {
+void CandidateRegionWriteBuffer::merge(const CandidateRegionWriteBuffer& other)
+{
     const bool same_samples = this->sample_name == other.sample_name;
     if (!same_samples) {
-        fatal_error("Tried to merge two candidate regions buffers of different samples.");
+        fatal_error(
+            "Tried to merge two candidate regions buffers of different samples.");
     }
 
-    for (const auto &locus_name_to_ML_path_entry : other.locus_name_to_ML_path) {
-        const auto &locus_name = locus_name_to_ML_path_entry.first;
-        const auto &ML_path = locus_name_to_ML_path_entry.second;
+    for (const auto& locus_name_to_ML_path_entry : other.locus_name_to_ML_path) {
+        const auto& locus_name = locus_name_to_ML_path_entry.first;
+        const auto& ML_path = locus_name_to_ML_path_entry.second;
 
-        const bool locus_already_exists_in_this_buffer =
-            this->locus_name_to_ML_path.find(locus_name) != this->locus_name_to_ML_path.end();
+        const bool locus_already_exists_in_this_buffer
+            = this->locus_name_to_ML_path.find(locus_name)
+            != this->locus_name_to_ML_path.end();
         if (locus_already_exists_in_this_buffer) {
-            const bool locus_has_same_ML_path =
-                this->locus_name_to_ML_path.at(locus_name) == other.locus_name_to_ML_path.at(locus_name);
+            const bool locus_has_same_ML_path
+                = this->locus_name_to_ML_path.at(locus_name)
+                == other.locus_name_to_ML_path.at(locus_name);
             if (!locus_has_same_ML_path) {
-                fatal_error("Tried to merge two candidate regions buffers, but they have "
-                            "different ML paths for a same locus.");
+                fatal_error(
+                    "Tried to merge two candidate regions buffers, but they have "
+                    "different ML paths for a same locus.");
             }
         }
 
-        for (const std::string &variant : other.locus_name_to_variants.at(locus_name)) {
+        for (const std::string& variant : other.locus_name_to_variants.at(locus_name)) {
             this->add_new_variant(locus_name, ML_path, variant);
         }
     }

--- a/src/denovo_discovery/candidate_region.cpp
+++ b/src/denovo_discovery/candidate_region.cpp
@@ -411,8 +411,15 @@ Discover::Discover(uint32_t min_required_covg, uint32_t min_candidate_len,
 void CandidateRegionWriteBuffer::add_new_variant(const std::string& locus_name,
     const std::string& ML_path, const std::string& variant)
 {
+    std::vector<std::string> &variants = locus_name_to_variants[locus_name];
+    const bool variant_already_exists =
+        std::find(variants.begin(), variants.end(), variant) != variants.end();
+    if (variant_already_exists) {
+        return;
+    }
+
     locus_name_to_ML_path[locus_name] = ML_path;
-    locus_name_to_variants[locus_name].push_back(variant);
+    variants.push_back(variant);
 }
 
 void CandidateRegionWriteBuffer::write_to_file(const fs::path& output_file) const
@@ -423,7 +430,6 @@ void CandidateRegionWriteBuffer::write_to_file(const fs::path& output_file) cons
     output_filehandler.close();
 }
 
-// TODO: test
 void CandidateRegionWriteBuffer::merge (const CandidateRegionWriteBuffer &other) {
     const bool same_samples = this->sample_name == other.sample_name;
     if (!same_samples) {

--- a/src/denovo_discovery/discover_main.cpp
+++ b/src/denovo_discovery/discover_main.cpp
@@ -186,179 +186,6 @@ void setup_discover_subcommand(CLI::App& app)
     discover_subcmd->callback([opt]() { pandora_discover(*opt); });
 }
 
-void pandora_discover_core(
-    const std::vector<std::pair<SampleIdText, SampleFpath>>& samples,
-    const std::shared_ptr<Index>& index,
-    const std::vector<std::shared_ptr<LocalPRG>>& prgs, const DiscoverOptions& opt,
-    uint32_t first_index)
-{
-    for (uint32_t sample_id = first_index; sample_id < samples.size();
-         sample_id += opt.threads) {
-        const auto& sample = samples[sample_id];
-        const auto& sample_name = sample.first;
-        const auto& sample_fpath = sample.second;
-
-        // make output dir for this sample
-        const auto sample_outdir { opt.outdir / sample_name };
-        fs::create_directories(sample_outdir);
-
-        // create temp dir
-        const auto temp_dir { sample_outdir / "temp" };
-        fs::create_directories(temp_dir);
-
-        // create kmer graph dir
-        const auto kmer_graph_dir { sample_outdir / "kmer_graphs" };
-        if (opt.output_kg) {
-            fs::create_directories(kmer_graph_dir);
-        }
-
-        BOOST_LOG_TRIVIAL(info) << "[Sample " << sample_name << "] "
-                                << "Constructing pangenome::Graph from read file "
-                                << sample_fpath << " (this will take a while)";
-        auto pangraph = std::make_shared<pangenome::Graph>();
-        uint32_t covg = pangraph_from_read_file(sample_fpath, pangraph, index, prgs,
-            opt.window_size, opt.kmer_size, opt.max_diff, opt.error_rate,
-            opt.min_cluster_size, opt.genome_size, opt.illumina, opt.clean,
-            opt.max_covg, 1);
-
-        const auto pangraph_gfa { sample_outdir / "pandora.pangraph.gfa" };
-        BOOST_LOG_TRIVIAL(info) << "[Sample " << sample_name << "] "
-                                << "Writing pangenome::Graph to file " << pangraph_gfa;
-        write_pangraph_gfa(pangraph_gfa, pangraph);
-
-        if (pangraph->nodes.empty()) {
-            BOOST_LOG_TRIVIAL(warning)
-                << "[Sample " << sample_name << "] "
-                << "Found no LocalPRGs in the reads for sample " << sample_name;
-        }
-
-        BOOST_LOG_TRIVIAL(info) << "[Sample " << sample_name << "] "
-                                << "Updating local PRGs with hits...";
-        pangraph->add_hits_to_kmergraphs();
-
-        BOOST_LOG_TRIVIAL(info) << "[Sample " << sample_name << "] "
-                                << "Find PRG paths and write to files...";
-
-        Fastaq consensus_fq(true, true);
-        CandidateRegions candidate_regions;
-
-        // will denote which nodes we have to remove after the loop
-        std::vector<pangenome::NodePtr> nodes_to_remove;
-        nodes_to_remove.reserve(pangraph->nodes.size());
-
-        const uint16_t candidate_padding { static_cast<uint16_t>(
-            2 * opt.denovo_kmer_size) };
-        Discover discover { opt.min_candidate_covg, opt.min_candidate_len,
-            opt.max_candidate_len, candidate_padding, opt.merge_dist };
-
-        // transforms the pangraph->nodes from map to vector so that we can run it in
-        std::vector<pangenome::NodePtr> pangraphNodesAsVector;
-        pangraphNodesAsVector.reserve(pangraph->nodes.size());
-        for (auto pan_id_to_node_mapping = pangraph->nodes.begin();
-             pan_id_to_node_mapping != pangraph->nodes.end();
-             ++pan_id_to_node_mapping) {
-            pangraphNodesAsVector.push_back(pan_id_to_node_mapping->second);
-        }
-
-        for (uint32_t i = 0; i < pangraphNodesAsVector.size(); ++i) {
-            // add some progress
-            if (i && i % 100 == 0) {
-                BOOST_LOG_TRIVIAL(info)
-                    << "[Sample " << sample_name << "] "
-                    << ((double)i) / pangraphNodesAsVector.size() * 100 << "% done";
-            }
-
-            // get the node
-            const auto& pangraph_node = pangraphNodesAsVector[i];
-
-            // add consensus path to fastaq
-            std::vector<KmerNodePtr> kmp;
-            std::vector<LocalNodePtr> lmp;
-            prgs[pangraph_node->prg_id]->add_consensus_path_to_fastaq(consensus_fq,
-                pangraph_node, kmp, lmp, opt.window_size, opt.binomial, covg,
-                opt.max_num_kmers_to_avg, 0);
-
-            if (kmp.empty()) {
-                // mark the node as to remove
-                nodes_to_remove.push_back(pangraph_node);
-                continue;
-            }
-
-            if (opt.output_kg) {
-                pangraph_node->kmer_prg_with_coverage.save(
-                    kmer_graph_dir / (pangraph_node->get_name() + ".kg.gfa"),
-                    prgs[pangraph_node->prg_id]);
-            }
-
-            BOOST_LOG_TRIVIAL(info) << "[Sample " << sample_name << "] "
-                                    << "Searching for regions with evidence of novel "
-                                       "variants...";
-            const string lmp_seq = prgs[pangraph_node->prg_id]->string_along_path(lmp);
-            const TmpPanNode pangraph_node_components { pangraph_node,
-                prgs[pangraph_node->prg_id], kmp, lmp, lmp_seq };
-            auto candidate_regions_for_pan_node {
-                discover.find_candidate_regions_for_pan_node(pangraph_node_components)
-            };
-
-            candidate_regions.insert(candidate_regions_for_pan_node.begin(),
-                candidate_regions_for_pan_node.end());
-        }
-
-        BOOST_LOG_TRIVIAL(info)
-            << "[Sample " << sample_name << "] "
-            << "Building read pileups for " << candidate_regions.size()
-            << " candidate de novo regions...";
-        const auto pileup_construction_map
-            = discover.pileup_construction_map(candidate_regions);
-
-        discover.load_candidate_region_pileups(
-            sample_fpath, candidate_regions, pileup_construction_map, 1);
-
-        // remove the nodes marked as to be removed
-        for (const auto& node_to_remove : nodes_to_remove) {
-            pangraph->remove_node(node_to_remove);
-        }
-
-        consensus_fq.save(sample_outdir / "pandora.consensus.fq.gz");
-
-        if (pangraph->nodes.empty()) {
-            BOOST_LOG_TRIVIAL(error)
-                << "[Sample " << sample_name << "] "
-                << "All nodes which were found have been removed during cleaning. Is "
-                   "your genome_size accurate?"
-                << " Genome size is assumed to be " << opt.genome_size
-                << " and can be updated with --genome_size";
-        }
-
-        DenovoDiscovery denovo { opt.denovo_kmer_size, opt.error_rate,
-            opt.max_num_candidate_paths, opt.max_insertion_size,
-            opt.min_covg_for_node_in_assembly_graph, opt.clean_dbg };
-
-        BOOST_LOG_TRIVIAL(info)
-            << "[Sample " << sample_name << "] "
-            << "Generating de novo variants as paths through their local graph...";
-
-        CandidateRegionWriteBuffer buffer(sample_name);
-        for (auto& element : candidate_regions) {
-            auto& candidate_region { element.second };
-            denovo.find_paths_through_candidate_region(candidate_region, temp_dir);
-            candidate_region.write_denovo_paths_to_buffer(buffer);
-        }
-        auto denovo_output_file = sample_outdir / "denovo_paths.txt";
-        buffer.write_to_file(denovo_output_file);
-        BOOST_LOG_TRIVIAL(info)
-            << "[Sample " << sample_name << "] "
-            << "De novo variant paths written to " << denovo_output_file.string();
-
-        if (opt.output_mapped_read_fa) {
-            pangraph->save_mapped_read_strings(sample_fpath, sample_outdir);
-        }
-
-        BOOST_LOG_TRIVIAL(info) << "[Sample " << sample_name << "] "
-                                << "Done discovering!";
-    }
-}
-
 void concatenate_denovo_files(
     const fs::path& output_filename, const std::vector<fs::path>& input_filenames)
 {
@@ -375,6 +202,286 @@ void concatenate_denovo_files(
     }
 
     output_filehandler.close();
+}
+
+void find_denovo_variants_core(
+    std::vector<CandidateRegion*> &candidate_regions,
+    const SampleIdText &sample_name,
+    const fs::path &sample_outdir,
+    const DenovoDiscovery &denovo,
+    uint32_t child_id,
+    uint32_t threads) {
+    // create temp dir
+    const auto temp_dir { sample_outdir / ("temp_child_" + int_to_string(child_id))};
+    fs::create_directories(temp_dir);
+
+    CandidateRegionWriteBuffer buffer(sample_name);
+    for (uint32_t candidate_region_index=child_id;
+                  candidate_region_index < candidate_regions.size();
+                  candidate_region_index+=threads) {
+        CandidateRegion& candidate_region { *(candidate_regions[candidate_region_index]) };
+        denovo.find_paths_through_candidate_region(candidate_region, temp_dir);
+        candidate_region.write_denovo_paths_to_buffer(buffer);
+    }
+
+    // serialise the buffer
+    {
+        const auto buffer_binary_filename = temp_dir / "candidate_regions_write_buffer.bin";
+        std::ofstream buffer_binary_filehandler(buffer_binary_filename.string());
+        boost::archive::text_oarchive buffer_binary_archive(buffer_binary_filehandler);
+        // write class instance to archive
+        buffer_binary_archive << buffer;
+        // archive and stream closed when destructors are called
+    }
+}
+
+void find_denovo_variants_multiprocess(
+    CandidateRegions &candidate_regions,
+    const SampleIdText &sample_name,
+    const fs::path &sample_outdir,
+    const DenovoDiscovery &denovo,
+    uint32_t threads) {
+    // transforms CandidateRegions into a vector of pointer to CandidateRegion so that
+    // it is easier to multithread/multiprocess on it
+    std::vector<CandidateRegion*> candidate_regions_as_vector;
+    candidate_regions_as_vector.reserve(candidate_regions.size());
+    for (auto& element : candidate_regions) {
+        CandidateRegion* candidate_region_pointer = &(element.second);
+        candidate_regions_as_vector.push_back(candidate_region_pointer);
+    }
+
+    // forking due to GATB
+    size_t child_id;
+    bool on_child;
+    for (child_id = 0; child_id < threads; ++child_id) {
+        int child_process_id = fork();
+        bool error_creating_child_process = child_process_id == -1;
+        on_child = child_process_id == 0;
+
+        if (error_creating_child_process) {
+            fatal_error("Error creating child process.");
+        } else if (on_child) {
+            break;
+        } else {
+            BOOST_LOG_TRIVIAL(info) << "Child process id " << child_process_id
+                                    << " (child #" << child_id << ") created...";
+        }
+    }
+
+    if (on_child) {
+        find_denovo_variants_core(candidate_regions_as_vector, sample_name,
+            sample_outdir, denovo, child_id, threads);
+        std::exit(0);
+    } else {
+        // wait for all children to finish
+        for (child_id = 0; child_id < threads; ++child_id) {
+            int child_pid = wait(NULL);
+            bool error_on_waiting_for_child = child_pid == -1;
+            if (error_on_waiting_for_child) {
+                fatal_error("Error waiting for child process.");
+            } else {
+                BOOST_LOG_TRIVIAL(info)
+                    << "Child process " << child_pid << " finished!";
+            }
+        }
+    }
+
+    // add all candidate region write buffers to a central one
+    CandidateRegionWriteBuffer buffer(sample_name);
+    std::vector<fs::path> buffer_binary_filenames;
+    for (child_id = 0; child_id < threads; child_id++) {
+        CandidateRegionWriteBuffer child_buffer;
+        {
+            const auto child_temp_dir { sample_outdir / ("temp_child_" + int_to_string(child_id))};
+            const auto child_buffer_binary_filename = child_temp_dir / "candidate_regions_write_buffer.bin";
+            // create and open an archive for input
+            std::ifstream child_buffer_binary_filehandler(child_buffer_binary_filename.string());
+            boost::archive::text_iarchive child_buffer_binary_archive(
+                child_buffer_binary_filehandler
+                );
+            // read class state from archive
+            child_buffer_binary_archive >> child_buffer;
+            // archive and stream closed when destructors are called
+        }
+        buffer.merge(child_buffer);
+    }
+
+
+    auto denovo_output_file = sample_outdir / "denovo_paths.txt";
+    buffer.write_to_file(denovo_output_file);
+    BOOST_LOG_TRIVIAL(info)
+        << "[Sample " << sample_name << "] "
+        << "De novo variant paths written to " << denovo_output_file.string();
+}
+
+void pandora_discover_core(
+    const std::pair<SampleIdText, SampleFpath> &sample,
+    const std::shared_ptr<Index>& index,
+    const std::vector<std::shared_ptr<LocalPRG>>& prgs, const DiscoverOptions& opt)
+{
+    const auto& sample_name = sample.first;
+    const auto& sample_fpath = sample.second;
+
+    // make output dir for this sample
+    const auto sample_outdir { opt.outdir / sample_name };
+    fs::create_directories(sample_outdir);
+
+    // create kmer graph dir
+    const auto kmer_graph_dir { sample_outdir / "kmer_graphs" };
+    if (opt.output_kg) {
+        fs::create_directories(kmer_graph_dir);
+    }
+
+    BOOST_LOG_TRIVIAL(info) << "[Sample " << sample_name << "] "
+                            << "Constructing pangenome::Graph from read file "
+                            << sample_fpath << " (this will take a while)";
+    auto pangraph = std::make_shared<pangenome::Graph>();
+    uint32_t covg = pangraph_from_read_file(sample_fpath, pangraph, index, prgs,
+        opt.window_size, opt.kmer_size, opt.max_diff, opt.error_rate,
+        opt.min_cluster_size, opt.genome_size, opt.illumina, opt.clean,
+        opt.max_covg, opt.threads);
+
+    const auto pangraph_gfa { sample_outdir / "pandora.pangraph.gfa" };
+    BOOST_LOG_TRIVIAL(info) << "[Sample " << sample_name << "] "
+                            << "Writing pangenome::Graph to file " << pangraph_gfa;
+    write_pangraph_gfa(pangraph_gfa, pangraph);
+
+    if (pangraph->nodes.empty()) {
+        BOOST_LOG_TRIVIAL(warning)
+            << "[Sample " << sample_name << "] "
+            << "Found no LocalPRGs in the reads for sample " << sample_name;
+    }
+
+    BOOST_LOG_TRIVIAL(info) << "[Sample " << sample_name << "] "
+                            << "Updating local PRGs with hits...";
+    pangraph->add_hits_to_kmergraphs();
+
+    BOOST_LOG_TRIVIAL(info) << "[Sample " << sample_name << "] "
+                            << "Find PRG paths and write to files...";
+
+    // paralell region!
+    // shared variable - synced with critical(consensus_fq)
+    Fastaq consensus_fq(true, true);
+
+    // shared variable - synced with critical(candidate_regions)
+    CandidateRegions candidate_regions;
+
+    // shared variable - will denote which nodes we have to remove after the
+    // parallel loop synced with critical(nodes_to_remove)
+    std::vector<pangenome::NodePtr> nodes_to_remove;
+    nodes_to_remove.reserve(pangraph->nodes.size());
+
+    const uint16_t candidate_padding { static_cast<uint16_t>(
+        2 * opt.denovo_kmer_size) };
+    Discover discover { opt.min_candidate_covg, opt.min_candidate_len,
+        opt.max_candidate_len, candidate_padding, opt.merge_dist };
+
+    // transforms the pangraph->nodes from map to vector so that we can run it in
+    // parallel
+    // TODO: use OMP task instead?
+    std::vector<pangenome::NodePtr> pangraphNodesAsVector;
+    pangraphNodesAsVector.reserve(pangraph->nodes.size());
+    for (auto pan_id_to_node_mapping = pangraph->nodes.begin();
+         pan_id_to_node_mapping != pangraph->nodes.end();
+         ++pan_id_to_node_mapping) {
+        pangraphNodesAsVector.push_back(pan_id_to_node_mapping->second);
+    }
+
+#pragma omp parallel for num_threads(opt.threads) schedule(dynamic, 10)
+    for (uint32_t i = 0; i < pangraphNodesAsVector.size(); ++i) {
+        // add some progress
+        if (i && i % 100 == 0) {
+            BOOST_LOG_TRIVIAL(info)
+                << "[Sample " << sample_name << "] "
+                << ((double)i) / pangraphNodesAsVector.size() * 100 << "% done";
+        }
+
+        // get the node
+        const auto& pangraph_node = pangraphNodesAsVector[i];
+
+        // add consensus path to fastaq
+        std::vector<KmerNodePtr> kmp;
+        std::vector<LocalNodePtr> lmp;
+        prgs[pangraph_node->prg_id]->add_consensus_path_to_fastaq(consensus_fq,
+            pangraph_node, kmp, lmp, opt.window_size, opt.binomial, covg,
+            opt.max_num_kmers_to_avg, 0);
+
+        if (kmp.empty()) {
+            // mark the node as to remove
+#pragma omp critical(nodes_to_remove)
+            {
+                nodes_to_remove.push_back(pangraph_node);
+            }
+            continue;
+        }
+
+        if (opt.output_kg) {
+            pangraph_node->kmer_prg_with_coverage.save(
+                kmer_graph_dir / (pangraph_node->get_name() + ".kg.gfa"),
+                prgs[pangraph_node->prg_id]);
+        }
+
+        BOOST_LOG_TRIVIAL(info) << "[Sample " << sample_name << "] "
+                                << "Searching for regions with evidence of novel "
+                                   "variants...";
+        const string lmp_seq = prgs[pangraph_node->prg_id]->string_along_path(lmp);
+        const TmpPanNode pangraph_node_components { pangraph_node,
+            prgs[pangraph_node->prg_id], kmp, lmp, lmp_seq };
+        auto candidate_regions_for_pan_node {
+            discover.find_candidate_regions_for_pan_node(pangraph_node_components)
+        };
+
+#pragma omp critical(candidate_regions)
+        {
+            candidate_regions.insert(candidate_regions_for_pan_node.begin(),
+                candidate_regions_for_pan_node.end());
+        }
+    }
+
+    BOOST_LOG_TRIVIAL(info)
+        << "[Sample " << sample_name << "] "
+        << "Building read pileups for " << candidate_regions.size()
+        << " candidate de novo regions...";
+    // the pileup_construction_map function is intentionally left
+    // single threaded since it would require too much synchronization
+    const auto pileup_construction_map
+        = discover.pileup_construction_map(candidate_regions);
+
+    discover.load_candidate_region_pileups(
+        sample_fpath, candidate_regions, pileup_construction_map, opt.threads);
+
+    // remove the nodes marked as to be removed
+    for (const auto& node_to_remove : nodes_to_remove) {
+        pangraph->remove_node(node_to_remove);
+    }
+
+    consensus_fq.save(sample_outdir / "pandora.consensus.fq.gz");
+
+    if (pangraph->nodes.empty()) {
+        BOOST_LOG_TRIVIAL(error)
+            << "[Sample " << sample_name << "] "
+            << "All nodes which were found have been removed during cleaning. Is "
+               "your genome_size accurate?"
+            << " Genome size is assumed to be " << opt.genome_size
+            << " and can be updated with --genome_size";
+    }
+
+    DenovoDiscovery denovo { opt.denovo_kmer_size, opt.error_rate,
+        opt.max_num_candidate_paths, opt.max_insertion_size,
+        opt.min_covg_for_node_in_assembly_graph, opt.clean_dbg };
+
+    BOOST_LOG_TRIVIAL(info)
+        << "[Sample " << sample_name << "] "
+        << "Generating de novo variants as paths through their local graph...";
+    find_denovo_variants_multiprocess(candidate_regions, sample_name, sample_outdir,
+        denovo, opt.threads);
+
+    if (opt.output_mapped_read_fa) {
+        pangraph->save_mapped_read_strings(sample_fpath, sample_outdir);
+    }
+
+    BOOST_LOG_TRIVIAL(info) << "[Sample " << sample_name << "] "
+                            << "Done discovering!";
 }
 
 int pandora_discover(DiscoverOptions& opt)
@@ -429,71 +536,25 @@ int pandora_discover(DiscoverOptions& opt)
     BOOST_LOG_TRIVIAL(info) << "Loading read index file...";
     std::vector<std::pair<SampleIdText, SampleFpath>> samples
         = load_read_index(opt.reads_idx_file);
-    std::vector<std::string> sample_names;
-    for (const auto& sample_pair : samples) {
-        sample_names.push_back(sample_pair.first);
-    }
-
-#if ALLOW_FORK == 1
-    // adjust the nb of threads
-    uint32_t nb_of_samples = samples.size();
-    opt.threads = std::min(opt.threads, nb_of_samples);
 
     // for each sample, run pandora discover
-    // forking due to GATB
-    size_t child_id;
-    bool on_child;
-    for (child_id = 0; child_id < opt.threads; ++child_id) {
-        int child_process_id = fork();
-        bool error_creating_child_process = child_process_id == -1;
-        on_child = child_process_id == 0;
-
-        if (error_creating_child_process) {
-            fatal_error("Error creating child process.");
-        } else if (on_child) {
-            break;
-        } else {
-            BOOST_LOG_TRIVIAL(info) << "Child process id " << child_process_id
-                                    << " (child #" << child_id << ") created...";
-        }
+    for (const std::pair<SampleIdText, SampleFpath> &sample : samples) {
+        pandora_discover_core(sample, index, prgs, opt);
     }
 
-    if (on_child) {
-        pandora_discover_core(samples, index, prgs, opt, child_id);
-    } else {
-        // wait for all children to finish
-        for (child_id = 0; child_id < opt.threads; ++child_id) {
-            int child_pid = wait(NULL);
-            bool error_on_waiting_for_child = child_pid == -1;
-            if (error_on_waiting_for_child) {
-                fatal_error("Error waiting for child process.");
-            } else {
-                BOOST_LOG_TRIVIAL(info)
-                    << "Child process " << child_pid << " finished!";
-            }
-        }
-#else
-    // adjust the nb of threads
-    opt.threads = 1;
-    pandora_discover_core(samples, index, prgs, opt, 0);
-#endif
-        // concatenate all denovo files
-        std::vector<fs::path> denovo_paths_files;
-        for (uint32_t sample_id = 0; sample_id < samples.size(); sample_id++) {
-            const auto& sample = samples[sample_id];
-            const auto& sample_name = sample.first;
-            fs::path denovo_output_file = opt.outdir / sample_name / "denovo_paths.txt";
-            denovo_paths_files.push_back(denovo_output_file);
-        }
-        fs::path denovo_output_file = opt.outdir / "denovo_paths.txt";
-        concatenate_denovo_files(denovo_output_file, denovo_paths_files);
-        BOOST_LOG_TRIVIAL(info)
-            << "De novo variant paths written to " << denovo_output_file.string();
-        BOOST_LOG_TRIVIAL(info) << "All done!";
-
-#if ALLOW_FORK == 1
+    // concatenate all denovo files
+    std::vector<fs::path> denovo_paths_files;
+    for (uint32_t sample_id = 0; sample_id < samples.size(); sample_id++) {
+        const auto& sample = samples[sample_id];
+        const auto& sample_name = sample.first;
+        fs::path denovo_output_file = opt.outdir / sample_name / "denovo_paths.txt";
+        denovo_paths_files.push_back(denovo_output_file);
     }
-#endif
+    fs::path denovo_output_file = opt.outdir / "denovo_paths.txt";
+    concatenate_denovo_files(denovo_output_file, denovo_paths_files);
+    BOOST_LOG_TRIVIAL(info)
+        << "De novo variant paths written to " << denovo_output_file.string();
+    BOOST_LOG_TRIVIAL(info) << "All done!";
 
     return 0;
 }

--- a/src/denovo_discovery/discover_main.cpp
+++ b/src/denovo_discovery/discover_main.cpp
@@ -241,7 +241,7 @@ void find_denovo_variants_multiprocess(
     const fs::path &sample_outdir,
     const DenovoDiscovery &denovo,
     uint32_t threads) {
-    // transforms CandidateRegions into a vector of pointer to CandidateRegion so that
+    // transforms CandidateRegions into a vector of pointers to CandidateRegion so that
     // it is easier to multithread/multiprocess on it
     std::vector<CandidateRegion*> candidate_regions_as_vector;
     candidate_regions_as_vector.reserve(candidate_regions.size());
@@ -367,7 +367,7 @@ void pandora_discover_core(
     CandidateRegions candidate_regions;
 
     // shared variable - will denote which nodes we have to remove after the
-    // parallel loop synced with critical(nodes_to_remove)
+    // parallel loop. synced with critical(nodes_to_remove)
     std::vector<pangenome::NodePtr> nodes_to_remove;
     nodes_to_remove.reserve(pangraph->nodes.size());
 

--- a/test/denovo_discovery/candidate_region_test.cpp
+++ b/test/denovo_discovery/candidate_region_test.cpp
@@ -2179,5 +2179,91 @@ TEST_F(CandidateRegion___get_variants___Fixture, two_distant_MultiVariants)
     std::vector<std::string> expected { "5\tTATGTT\tCCC", "23\tGCC\tTTTTTTTTTT" };
     EXPECT_EQ(actual, expected);
 }
+
+class CandidateRegionWriteBuffer___merge___Fixture : public ::testing::Test {
+public:
+    CandidateRegionWriteBuffer buffer_1, buffer_1_copy;
+    CandidateRegionWriteBuffer___merge___Fixture() : buffer_1("sample_1"){
+        buffer_1.add_new_variant("locus_1", "ML_path_1", "locus_1_var_1");
+        buffer_1.add_new_variant("locus_2", "ML_path_2", "locus_2_var_1");
+        buffer_1.add_new_variant("locus_2", "ML_path_2", "locus_2_var_2");
+        buffer_1.add_new_variant("locus_3", "ML_path_3", "locus_3_var_1");
+        buffer_1.add_new_variant("locus_3", "ML_path_3", "locus_3_var_2");
+        buffer_1.add_new_variant("locus_3", "ML_path_3", "locus_3_var_3");
+        buffer_1_copy = buffer_1;
+    }
+};
+
+TEST_F(CandidateRegionWriteBuffer___merge___Fixture, different_samples___expects_FatalRuntimeError) {
+
+    CandidateRegionWriteBuffer buffer_2("sample_2");
+    ASSERT_EXCEPTION(buffer_1.merge(buffer_2), FatalRuntimeError,
+                     "Tried to merge two candidate regions buffers of different samples.");
+}
+
+TEST_F(CandidateRegionWriteBuffer___merge___Fixture, has_same_loci_but_different_ML_path___expects_FatalRuntimeError) {
+
+    CandidateRegionWriteBuffer buffer_2("sample_1");
+    buffer_2.add_new_variant("locus_1", "ML_path_1", "locus_1_var_1"); // same
+    buffer_2.add_new_variant("locus_2", "ML_path_2", "locus_2_var_1"); // same
+    buffer_2.add_new_variant("locus_3", "ML_path_3_diff", "locus_3_var_1"); // different
+    ASSERT_EXCEPTION(buffer_1.merge(buffer_2), FatalRuntimeError,
+                     "Tried to merge two candidate regions buffers, but they have "
+                     "different ML paths for a same locus.");
+}
+
+TEST_F(CandidateRegionWriteBuffer___merge___Fixture, merge_empty_buffer___no_changes_expected) {
+
+    CandidateRegionWriteBuffer buffer_2("sample_1");
+    buffer_1.merge(buffer_2);
+    EXPECT_EQ(buffer_1, buffer_1_copy);
+}
+
+TEST_F(CandidateRegionWriteBuffer___merge___Fixture, merge_equal_buffer___no_changes_expected) {
+    buffer_1.merge(buffer_1_copy);
+    EXPECT_EQ(buffer_1, buffer_1_copy);
+}
+
+TEST_F(CandidateRegionWriteBuffer___merge___Fixture, merge_buffer_with_new_loci) {
+    CandidateRegionWriteBuffer buffer_2("sample_1");
+    buffer_2.add_new_variant("locus_4", "ML_path_4", "locus_4_var_1");
+    buffer_2.add_new_variant("locus_5", "ML_path_5", "locus_5_var_1");
+    buffer_2.add_new_variant("locus_5", "ML_path_5", "locus_5_var_2");
+    buffer_1.merge(buffer_2);
+
+    CandidateRegionWriteBuffer expected(buffer_1_copy);
+    expected.add_new_variant("locus_4", "ML_path_4", "locus_4_var_1");
+    expected.add_new_variant("locus_5", "ML_path_5", "locus_5_var_1");
+    expected.add_new_variant("locus_5", "ML_path_5", "locus_5_var_2");
+
+    EXPECT_EQ(expected, buffer_1);
+}
+
+TEST_F(CandidateRegionWriteBuffer___merge___Fixture, merge_buffer_with_new_and_repeated_loci_new_and_repeated_vars) {
+    CandidateRegionWriteBuffer buffer_2("sample_1");
+
+    buffer_2.add_new_variant("locus_1", "ML_path_1", "locus_1_var_2"); // new
+    buffer_2.add_new_variant("locus_2", "ML_path_2", "locus_2_var_1"); //repeated
+    buffer_2.add_new_variant("locus_2", "ML_path_2", "locus_2_var_3"); // new
+    buffer_2.add_new_variant("locus_3", "ML_path_3", "locus_3_var_1"); // repeated
+    buffer_2.add_new_variant("locus_3", "ML_path_3", "locus_3_var_2"); // repeated
+    buffer_2.add_new_variant("locus_3", "ML_path_3", "locus_3_var_3"); // repeated
+    buffer_2.add_new_variant("locus_3", "ML_path_3", "locus_3_var_4"); // new
+    buffer_2.add_new_variant("locus_3", "ML_path_3", "locus_3_var_5"); // new
+    buffer_2.add_new_variant("locus_3", "ML_path_3", "locus_3_var_6"); // new
+    buffer_2.add_new_variant("locus_4", "ML_path_4", "locus_4_var_1"); // new loci and var
+    buffer_1.merge(buffer_2);
+
+    CandidateRegionWriteBuffer expected(buffer_1_copy);
+    expected.add_new_variant("locus_1", "ML_path_1", "locus_1_var_2");
+    expected.add_new_variant("locus_2", "ML_path_2", "locus_2_var_3");
+    expected.add_new_variant("locus_3", "ML_path_3", "locus_3_var_4");
+    expected.add_new_variant("locus_3", "ML_path_3", "locus_3_var_5");
+    expected.add_new_variant("locus_3", "ML_path_3", "locus_3_var_6");
+    expected.add_new_variant("locus_4", "ML_path_4", "locus_4_var_1");
+
+    EXPECT_EQ(expected, buffer_1);
+}
+
 ////////////////////////////////////////////////////////////////////////////////////////
 ////////////////////////////////////////////////////////////////////////////////////////

--- a/test/denovo_discovery/candidate_region_test.cpp
+++ b/test/denovo_discovery/candidate_region_test.cpp
@@ -2183,7 +2183,9 @@ TEST_F(CandidateRegion___get_variants___Fixture, two_distant_MultiVariants)
 class CandidateRegionWriteBuffer___merge___Fixture : public ::testing::Test {
 public:
     CandidateRegionWriteBuffer buffer_1, buffer_1_copy;
-    CandidateRegionWriteBuffer___merge___Fixture() : buffer_1("sample_1"){
+    CandidateRegionWriteBuffer___merge___Fixture()
+        : buffer_1("sample_1")
+    {
         buffer_1.add_new_variant("locus_1", "ML_path_1", "locus_1_var_1");
         buffer_1.add_new_variant("locus_2", "ML_path_2", "locus_2_var_1");
         buffer_1.add_new_variant("locus_2", "ML_path_2", "locus_2_var_2");
@@ -2194,37 +2196,46 @@ public:
     }
 };
 
-TEST_F(CandidateRegionWriteBuffer___merge___Fixture, different_samples___expects_FatalRuntimeError) {
+TEST_F(CandidateRegionWriteBuffer___merge___Fixture,
+    different_samples___expects_FatalRuntimeError)
+{
 
     CandidateRegionWriteBuffer buffer_2("sample_2");
     ASSERT_EXCEPTION(buffer_1.merge(buffer_2), FatalRuntimeError,
-                     "Tried to merge two candidate regions buffers of different samples.");
+        "Tried to merge two candidate regions buffers of different samples.");
 }
 
-TEST_F(CandidateRegionWriteBuffer___merge___Fixture, has_same_loci_but_different_ML_path___expects_FatalRuntimeError) {
+TEST_F(CandidateRegionWriteBuffer___merge___Fixture,
+    has_same_loci_but_different_ML_path___expects_FatalRuntimeError)
+{
 
     CandidateRegionWriteBuffer buffer_2("sample_1");
     buffer_2.add_new_variant("locus_1", "ML_path_1", "locus_1_var_1"); // same
     buffer_2.add_new_variant("locus_2", "ML_path_2", "locus_2_var_1"); // same
     buffer_2.add_new_variant("locus_3", "ML_path_3_diff", "locus_3_var_1"); // different
     ASSERT_EXCEPTION(buffer_1.merge(buffer_2), FatalRuntimeError,
-                     "Tried to merge two candidate regions buffers, but they have "
-                     "different ML paths for a same locus.");
+        "Tried to merge two candidate regions buffers, but they have "
+        "different ML paths for a same locus.");
 }
 
-TEST_F(CandidateRegionWriteBuffer___merge___Fixture, merge_empty_buffer___no_changes_expected) {
+TEST_F(CandidateRegionWriteBuffer___merge___Fixture,
+    merge_empty_buffer___no_changes_expected)
+{
 
     CandidateRegionWriteBuffer buffer_2("sample_1");
     buffer_1.merge(buffer_2);
     EXPECT_EQ(buffer_1, buffer_1_copy);
 }
 
-TEST_F(CandidateRegionWriteBuffer___merge___Fixture, merge_equal_buffer___no_changes_expected) {
+TEST_F(CandidateRegionWriteBuffer___merge___Fixture,
+    merge_equal_buffer___no_changes_expected)
+{
     buffer_1.merge(buffer_1_copy);
     EXPECT_EQ(buffer_1, buffer_1_copy);
 }
 
-TEST_F(CandidateRegionWriteBuffer___merge___Fixture, merge_buffer_with_new_loci) {
+TEST_F(CandidateRegionWriteBuffer___merge___Fixture, merge_buffer_with_new_loci)
+{
     CandidateRegionWriteBuffer buffer_2("sample_1");
     buffer_2.add_new_variant("locus_4", "ML_path_4", "locus_4_var_1");
     buffer_2.add_new_variant("locus_5", "ML_path_5", "locus_5_var_1");
@@ -2239,11 +2250,13 @@ TEST_F(CandidateRegionWriteBuffer___merge___Fixture, merge_buffer_with_new_loci)
     EXPECT_EQ(expected, buffer_1);
 }
 
-TEST_F(CandidateRegionWriteBuffer___merge___Fixture, merge_buffer_with_new_and_repeated_loci_new_and_repeated_vars) {
+TEST_F(CandidateRegionWriteBuffer___merge___Fixture,
+    merge_buffer_with_new_and_repeated_loci_new_and_repeated_vars)
+{
     CandidateRegionWriteBuffer buffer_2("sample_1");
 
     buffer_2.add_new_variant("locus_1", "ML_path_1", "locus_1_var_2"); // new
-    buffer_2.add_new_variant("locus_2", "ML_path_2", "locus_2_var_1"); //repeated
+    buffer_2.add_new_variant("locus_2", "ML_path_2", "locus_2_var_1"); // repeated
     buffer_2.add_new_variant("locus_2", "ML_path_2", "locus_2_var_3"); // new
     buffer_2.add_new_variant("locus_3", "ML_path_3", "locus_3_var_1"); // repeated
     buffer_2.add_new_variant("locus_3", "ML_path_3", "locus_3_var_2"); // repeated
@@ -2251,7 +2264,8 @@ TEST_F(CandidateRegionWriteBuffer___merge___Fixture, merge_buffer_with_new_and_r
     buffer_2.add_new_variant("locus_3", "ML_path_3", "locus_3_var_4"); // new
     buffer_2.add_new_variant("locus_3", "ML_path_3", "locus_3_var_5"); // new
     buffer_2.add_new_variant("locus_3", "ML_path_3", "locus_3_var_6"); // new
-    buffer_2.add_new_variant("locus_4", "ML_path_4", "locus_4_var_1"); // new loci and var
+    buffer_2.add_new_variant(
+        "locus_4", "ML_path_4", "locus_4_var_1"); // new loci and var
     buffer_1.merge(buffer_2);
 
     CandidateRegionWriteBuffer expected(buffer_1_copy);


### PR DESCRIPTION
## [0.9.0-rc2]

### Changed
- `pandora discover` now processes one sample at a time, but runs with several threads on the heavy tasks, i.e. when
mapping reads, finding candidate regions, and finding denovo variants. The result is that it now takes a lot less RAM to
run on multiple samples.

[0.9.0-rc2]: https://github.com/rmcolq/pandora/releases/tag/0.9.0-rc2