### PR TITLE
Make pandora instalable through conda

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -118,3 +118,5 @@ build_portable_executable
 pandora-linux-precompiled
 
 /cmake-build-release/
+/example/
+/archives/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -98,6 +98,7 @@ set(Gtest_LIBRARIES GTest::gtest GTest::gmock_main)
 ########################################################################################################################
 # INSTALL BOOST
 if(BIOCONDA)
+    ADD_DEFINITIONS(-DBOOST_LOG_DYN_LINK)
     set(Boost_USE_STATIC_LIBS OFF)
     find_package(Boost REQUIRED filesystem iostreams log log_setup system thread)
     include_directories(SYSTEM ${Boost_INCLUDE_DIRS})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -152,3 +152,5 @@ target_link_libraries(${PROJECT_NAME}
 
 enable_testing()
 add_subdirectory(test)
+
+install(TARGETS ${PROJECT_NAME} RUNTIME DESTINATION bin)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,11 +55,13 @@ else ()
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fopenmp")
 endif()
 
-# static C and C++ flags
-set(STATIC_C_CXX "-static-libgcc -static-libstdc++")
-
 # always link rt
 set(RT_LIBRARY "rt")
+
+if(NOT BIOCONDA)
+    # static C and C++ flags
+    set(STATIC_C_CXX "-static-libgcc -static-libstdc++")
+endif()
 
 ########################################################################################################################
 # EXTERNAL LIBS INSTALLATION
@@ -95,17 +97,16 @@ set(Gtest_LIBRARIES GTest::gtest GTest::gmock_main)
 
 ########################################################################################################################
 # INSTALL BOOST
-set(Boost_USE_STATIC_LIBS ON)
-
 if(BIOCONDA)
     find_package(Boost REQUIRED filesystem iostreams log log_setup system thread)
     include_directories(SYSTEM ${Boost_INCLUDE_DIRS})
+    set(Boost_USE_STATIC_LIBS OFF)
 else()
     hunter_add_package(Boost COMPONENTS filesystem iostreams log system thread)
     find_package(Boost CONFIG REQUIRED filesystem iostreams log log_setup system thread)
     set(Boost_LIBRARIES Boost::filesystem Boost::iostreams Boost::log Boost::log_setup Boost::system Boost::thread)
+    set(Boost_USE_STATIC_LIBS ON)
 endif()
-
 ########################################################################################################################
 ########################################################################################################################
 # END EXTERNAL LIBS INSTALLATION

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,7 @@
 cmake_minimum_required(VERSION 3.12)  # required by hunter ZLIB installation
 
 # include hunter
+option(HUNTER_STATUS_DEBUG "Hunter debug" ON)  # comment if does not want hunter debug on
 set(HUNTER_ROOT ${CMAKE_BINARY_DIR}/hunter)
 include("cmake/HunterGate.cmake")
 HunterGate(

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -98,14 +98,14 @@ set(Gtest_LIBRARIES GTest::gtest GTest::gmock_main)
 ########################################################################################################################
 # INSTALL BOOST
 if(BIOCONDA)
+    set(Boost_USE_STATIC_LIBS OFF)
     find_package(Boost REQUIRED filesystem iostreams log log_setup system thread)
     include_directories(SYSTEM ${Boost_INCLUDE_DIRS})
-    set(Boost_USE_STATIC_LIBS OFF)
 else()
+    set(Boost_USE_STATIC_LIBS ON)
     hunter_add_package(Boost COMPONENTS filesystem iostreams log system thread)
     find_package(Boost CONFIG REQUIRED filesystem iostreams log log_setup system thread)
     set(Boost_LIBRARIES Boost::filesystem Boost::iostreams Boost::log Boost::log_setup Boost::system Boost::thread)
-    set(Boost_USE_STATIC_LIBS ON)
 endif()
 ########################################################################################################################
 ########################################################################################################################

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -99,7 +99,7 @@ set(Boost_USE_STATIC_LIBS ON)
 
 if(BIOCONDA)
     find_package(Boost REQUIRED filesystem iostreams log log_setup system thread)
-    include_directories(${Boost_INCLUDE_DIRS})
+    include_directories(SYSTEM ${Boost_INCLUDE_DIRS})
 else()
     hunter_add_package(Boost COMPONENTS filesystem iostreams log system thread)
     find_package(Boost CONFIG REQUIRED filesystem iostreams log log_setup system thread)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -62,7 +62,6 @@ set(STATIC_C_CXX "-static-libgcc -static-libstdc++")
 ########################################################################################################################
 ########################################################################################################################
 # INSTALL ZLIB
-hunter_add_package(ZLIB)
 find_package(ZLIB 1.2.11 REQUIRED)
 set(ZLIB_LIBRARY ZLIB::ZLIB)
 ########################################################################################################################
@@ -91,7 +90,6 @@ set(Gtest_LIBRARIES GTest::gtest GTest::gmock_main)
 
 ########################################################################################################################
 # INSTALL BOOST
-hunter_add_package(Boost COMPONENTS filesystem iostreams log system thread)
 find_package(Boost CONFIG REQUIRED filesystem iostreams log system thread)
 set(BOOST_LIBRARIES Boost::filesystem Boost::iostreams Boost::log Boost::system Boost::thread)
 set(Boost_USE_STATIC_LIBS ON)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -99,6 +99,7 @@ set(Boost_USE_STATIC_LIBS ON)
 
 if(BIOCONDA)
     find_package(Boost REQUIRED filesystem iostreams log log_setup system thread)
+    include_directories(${Boost_INCLUDE_DIRS})
 else()
     hunter_add_package(Boost COMPONENTS filesystem iostreams log system thread)
     find_package(Boost CONFIG REQUIRED filesystem iostreams log log_setup system thread)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -97,17 +97,10 @@ set(Gtest_LIBRARIES GTest::gtest GTest::gmock_main)
 
 ########################################################################################################################
 # INSTALL BOOST
-if(BIOCONDA)
-    ADD_DEFINITIONS(-DBOOST_LOG_DYN_LINK)
-    set(Boost_USE_STATIC_LIBS OFF)
-    find_package(Boost REQUIRED filesystem iostreams log log_setup system thread)
-    include_directories(SYSTEM ${Boost_INCLUDE_DIRS})
-else()
-    set(Boost_USE_STATIC_LIBS ON)
-    hunter_add_package(Boost COMPONENTS filesystem iostreams log system thread)
-    find_package(Boost CONFIG REQUIRED filesystem iostreams log log_setup system thread)
-    set(Boost_LIBRARIES Boost::filesystem Boost::iostreams Boost::log Boost::log_setup Boost::system Boost::thread)
-endif()
+set(Boost_USE_STATIC_LIBS ON)
+hunter_add_package(Boost COMPONENTS filesystem iostreams log system thread)
+find_package(Boost CONFIG REQUIRED filesystem iostreams log log_setup system thread)
+set(Boost_LIBRARIES Boost::filesystem Boost::iostreams Boost::log Boost::log_setup Boost::system Boost::thread)
 ########################################################################################################################
 ########################################################################################################################
 # END EXTERNAL LIBS INSTALLATION

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.12)  # required by hunter ZLIB installation
 
 # include hunter
-option(HUNTER_STATUS_DEBUG "Hunter debug" ON)  # comment if does not want hunter debug on
+option(HUNTER_STATUS_DEBUG "Hunter debug" OFF)  # comment if does not want hunter debug on
 set(HUNTER_ROOT ${CMAKE_BINARY_DIR}/hunter)
 include("cmake/HunterGate.cmake")
 HunterGate(
@@ -58,11 +58,15 @@ endif()
 # static C and C++ flags
 set(STATIC_C_CXX "-static-libgcc -static-libstdc++")
 
+# always link rt
+set(RT_LIBRARY "rt")
+
 ########################################################################################################################
 # EXTERNAL LIBS INSTALLATION
 ########################################################################################################################
 ########################################################################################################################
 # INSTALL ZLIB
+hunter_add_package(ZLIB)
 find_package(ZLIB 1.2.11 REQUIRED)
 set(ZLIB_LIBRARY ZLIB::ZLIB)
 ########################################################################################################################
@@ -91,9 +95,16 @@ set(Gtest_LIBRARIES GTest::gtest GTest::gmock_main)
 
 ########################################################################################################################
 # INSTALL BOOST
-find_package(Boost CONFIG REQUIRED filesystem iostreams log system thread)
-set(BOOST_LIBRARIES Boost::filesystem Boost::iostreams Boost::log Boost::system Boost::thread)
 set(Boost_USE_STATIC_LIBS ON)
+
+if(BIOCONDA)
+    find_package(Boost REQUIRED filesystem iostreams log log_setup system thread)
+else()
+    hunter_add_package(Boost COMPONENTS filesystem iostreams log system thread)
+    find_package(Boost CONFIG REQUIRED filesystem iostreams log log_setup system thread)
+    set(Boost_LIBRARIES Boost::filesystem Boost::iostreams Boost::log Boost::log_setup Boost::system Boost::thread)
+endif()
+
 ########################################################################################################################
 ########################################################################################################################
 # END EXTERNAL LIBS INSTALLATION
@@ -135,11 +146,12 @@ add_dependencies(${PROJECT_NAME} gatb)
 
 target_link_libraries(${PROJECT_NAME}
         ${GATB_LIBS}
-        ${BOOST_LIBRARIES}
+        ${Boost_LIBRARIES}
         ${ZLIB_LIBRARY}
         ${CMAKE_DL_LIBS}
         ${STATIC_C_CXX}
         ${BACKWARD_LIBRARIES}
+        ${RT_LIBRARY}
 )
 
 enable_testing()

--- a/scripts/create_archives.sh
+++ b/scripts/create_archives.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+# run from project root: scripts/create_archives.sh
+# based on https://github.com/nzanepro/git-archive-submodules/blob/master/bin/git-archive-submodules.sh
+set -eu
+
+ARCHIVES_DIR="./archives"
+
+if [ -d "${ARCHIVES_DIR}" ]; then
+  echo "Please remove ${ARCHIVES_DIR} before proceeding."
+  exit 1
+fi
+
+TARMODULE=$(basename "$(git rev-parse --show-toplevel)")
+TARVERSION=$(git describe --tags --abbrev=0)
+TARPREFIX="${TARMODULE}-${TARVERSION}"
+
+echo "Creating tar archive..."
+mkdir -p archives
+git archive --prefix="${TARPREFIX}"/ -o archives/"${TARPREFIX}".tar "${TARVERSION}"
+git submodule foreach --recursive \
+  "git archive --prefix=${TARPREFIX}/\${displaypath}/ HEAD > ../../archives/tmp.tar && \
+  tar --concatenate --file=../../archives/${TARPREFIX}.tar ../../archives/tmp.tar" > /dev/null
+rm archives/tmp.tar
+
+echo "Compressing to tar.gz..."
+gzip -9 archives/"${TARPREFIX}".tar
+
+echo "Compressing to zip..."
+cd archives && tar xzf "${TARPREFIX}".tar.gz && \
+zip -r "${TARPREFIX}".zip "${TARPREFIX}" > /dev/null

--- a/scripts/create_archives.sh
+++ b/scripts/create_archives.sh
@@ -1,30 +1,54 @@
 #!/bin/bash
-# run from project root: scripts/create_archives.sh
+# run from project root: scripts/create_archives.sh <PANDORA_VERSION>
 # based on https://github.com/nzanepro/git-archive-submodules/blob/master/bin/git-archive-submodules.sh
 set -eu
 
-ARCHIVES_DIR="./archives"
+########################################################################################################################
+# argument parsing
+if [ "$#" -ne 1 ]; then
+    echo "Illegal number of parameters."
+    echo "Usage: $0 <PANDORA_VERSION>"
+    echo "Example: $0 0.8.0"
+    exit 1
+fi
+PANDORA_VERSION="$1"
+########################################################################################################################
 
+########################################################################################################################
+# configs
+PANDORA_URL="https://github.com/rmcolq/pandora"
+ARCHIVES_DIR="./archives"
+########################################################################################################################
+
+########################################################################################################################
+# main script
+ARCHIVES_DIR=$(realpath "${ARCHIVES_DIR}")
 if [ -d "${ARCHIVES_DIR}" ]; then
   echo "Please remove ${ARCHIVES_DIR} before proceeding."
   exit 1
 fi
 
-TARMODULE=$(basename "$(git rev-parse --show-toplevel)")
-TARVERSION=$(git describe --tags --abbrev=0)
-TARPREFIX="${TARMODULE}-${TARVERSION}"
+mkdir -p "${ARCHIVES_DIR}"
+cd "${ARCHIVES_DIR}"
+
+TARPREFIX="pandora-${PANDORA_VERSION}"
+echo "Cloning ${TARPREFIX}"
+git clone --recursive --depth=1 --single-branch --branch "${PANDORA_VERSION}" "${PANDORA_URL}" "${PANDORA_VERSION}"
 
 echo "Creating tar archive..."
-mkdir -p archives
-git archive --prefix="${TARPREFIX}"/ -o archives/"${TARPREFIX}".tar "${TARVERSION}"
+cd "${PANDORA_VERSION}"
+git archive --prefix="${TARPREFIX}"/ -o "${ARCHIVES_DIR}/${TARPREFIX}.tar" "${PANDORA_VERSION}"
 git submodule foreach --recursive \
-  "git archive --prefix=${TARPREFIX}/\${displaypath}/ HEAD > ../../archives/tmp.tar && \
-  tar --concatenate --file=../../archives/${TARPREFIX}.tar ../../archives/tmp.tar" > /dev/null
-rm archives/tmp.tar
+  "git archive --prefix=${TARPREFIX}/\${displaypath}/ HEAD > ${ARCHIVES_DIR}/tmp.tar && \
+  tar --concatenate --file=${ARCHIVES_DIR}/${TARPREFIX}.tar ${ARCHIVES_DIR}/tmp.tar" > /dev/null
+rm "${ARCHIVES_DIR}/tmp.tar"
 
 echo "Compressing to tar.gz..."
-gzip -9 archives/"${TARPREFIX}".tar
+gzip -9 "${ARCHIVES_DIR}/${TARPREFIX}.tar"
 
 echo "Compressing to zip..."
-cd archives && tar xzf "${TARPREFIX}".tar.gz && \
-zip -r "${TARPREFIX}".zip "${TARPREFIX}" > /dev/null
+cd "${ARCHIVES_DIR}" && tar xzf "${TARPREFIX}.tar.gz" && \
+zip -r "${TARPREFIX}.zip" "${TARPREFIX}" > /dev/null
+
+echo "All done!"
+########################################################################################################################

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -16,11 +16,12 @@ target_include_directories(${PROJECT_NAME}_test PUBLIC
 target_link_libraries(${PROJECT_NAME}_test
         ${Gtest_LIBRARIES}
         ${GATB_LIBS}
-        ${BOOST_LIBRARIES}
+        ${Boost_LIBRARIES}
         ${ZLIB_LIBRARY}
         ${CMAKE_DL_LIBS}
         ${STATIC_C_CXX}
         ${BACKWARD_LIBRARIES}
+        ${RT_LIBRARY}
         )
 
 add_test(NAME ${PROJECT_NAME}_test COMMAND ${PROJECT_NAME}_test)


### PR DESCRIPTION
* This PR includes a script, `scripts/create_archives.sh`, that will create `.tar.gz` and `.zip` packages of the `pandora` source code to be added to the releases. Differently from the source code packages automatically created by github, these packages actually include _all_ source code, including those from git submodules (it is weird why github does not include code from submodules directly. Several people call this actually a github bug, and an issue has been filled to github devs to fix this... but IIRC, the issue is still being fixed for a couple of years...);
* It also includes some few, but necessary, changes to the `CMake` files so that it is compilable in the conda build environment. The changes are very small, but it took a long time to find them... C++ tooling inside the conda container build env is something I really didn't appreciate... C++ tooling is already non trivial, and conda does not have the expected gcc/g++ toolsets in the default locations, which complicate things further. Anyway, the solution was actually **way** simpler than I expected, but I was unlucky to find it just after a couple of days playing with the conda build environment. Anyway, it is done now.
* Will convert this draft PR to a real PR once I finish doing the last checks, and check if the conda recipe is indeed correct (I can build it fine locally, unsure if can build it in their circle CI);