### PR TITLE
Handle ambiguous bases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ### Fixed
 
 - More robust TSV file parsing. Empty line no longer required at end [[#213][213]]
+- Handle ambiguous bases properly instead of skipping to next readonce we reach one [[#294][294]]
 
 ## [0.9.1]
 
@@ -134,5 +135,6 @@ their changes meticulously documented here.
 [234]: https://github.com/rmcolq/pandora/pull/234
 [249]: https://github.com/rmcolq/pandora/issues/249
 [265]: https://github.com/rmcolq/pandora/pull/265
+[294]: https://github.com/rmcolq/pandora/issues/294
 [v0.7.0]: https://github.com/rmcolq/pandora/releases/tag/v0.7.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ### Fixed
 
 - More robust TSV file parsing. Empty line no longer required at end [[#213][213]]
-- Handle ambiguous bases properly instead of skipping to next readonce we reach one [[#294][294]]
+- Handle ambiguous bases properly instead of skipping to next read once we reach one [[#294][294]]
 
 ## [0.9.1]
 

--- a/include/seq.h
+++ b/include/seq.h
@@ -11,9 +11,12 @@ class Seq {
 public:
     uint32_t id;
     std::string name;
-    std::vector<std::string> seq;
-    std::vector<size_t> offsets;
     std::set<Minimizer> sketch;
+
+    // the original sequence is split into several valid subsequences (composed of ACGT only)
+    std::vector<std::string> subseqs;  // these are the subsequences themselves
+    std::vector<size_t> offsets;  // these are the subsequences offsets on the original string
+
 
     Seq(uint32_t, const std::string&, const std::string&, uint32_t, uint32_t);
 

--- a/include/seq.h
+++ b/include/seq.h
@@ -25,7 +25,7 @@ public:
     void initialize(
         uint32_t, const std::string&, const std::string&, uint32_t, uint32_t);
 
-    bool add_letter_to_get_next_kmer(const char&, const uint64_t&, const uint64_t&,
+    void add_letter_to_get_next_kmer(const char&, const uint64_t&, const uint64_t&,
         uint32_t&, uint64_t (&)[2], uint64_t (&)[2]);
 
     void add_minimizing_kmers_to_sketch(const std::vector<Minimizer>&, const uint64_t&);

--- a/include/seq.h
+++ b/include/seq.h
@@ -11,7 +11,7 @@ class Seq {
 public:
     uint32_t id;
     std::string name;
-    std::string seq;
+    std::vector<std::string> seq;
     std::set<Minimizer> sketch;
 
     Seq(uint32_t, const std::string&, const std::string&, uint32_t, uint32_t);
@@ -31,6 +31,8 @@ public:
     void add_new_smallest_minimizer(std::vector<Minimizer>&, uint64_t&);
 
     void minimizer_sketch(const uint32_t w, const uint32_t k);
+
+    uint64_t length() const;
 
     friend std::ostream& operator<<(std::ostream& out, const Seq& data);
 };

--- a/include/seq.h
+++ b/include/seq.h
@@ -12,6 +12,7 @@ public:
     uint32_t id;
     std::string name;
     std::vector<std::string> seq;
+    std::vector<size_t> offsets;
     std::set<Minimizer> sketch;
 
     Seq(uint32_t, const std::string&, const std::string&, uint32_t, uint32_t);
@@ -30,11 +31,16 @@ public:
 
     void add_new_smallest_minimizer(std::vector<Minimizer>&, uint64_t&);
 
-    void minimizer_sketch(const uint32_t w, const uint32_t k);
-
     uint64_t length() const;
 
     friend std::ostream& operator<<(std::ostream& out, const Seq& data);
+
+    void minimizer_sketch(const uint32_t w, const uint32_t k);
+
+private:
+    void minimizer_sketch(const std::string &s, const size_t seq_offset,
+        const uint32_t w, const uint32_t k);
+
 };
 
 #endif

--- a/include/utils.h
+++ b/include/utils.h
@@ -8,6 +8,7 @@
 #include <cstdint>
 #include <string>
 #include <limits>
+#include <utility>
 #include <boost/filesystem/path.hpp>
 #include "minihits.h"
 #include "pangenome/ns.cpp"
@@ -131,6 +132,6 @@ std::vector<std::pair<SampleIdText, SampleFpath>> load_read_index(
 
 std::string remove_spaces_from_string(const std::string& str);
 
-std::vector<std::string> split_ambiguous(const std::string& s, uint8_t delim = 4);
+std::pair<std::vector<std::string>, std::vector<size_t>> split_ambiguous(const std::string& s, uint8_t delim = 4);
 
 #endif

--- a/include/utils.h
+++ b/include/utils.h
@@ -14,6 +14,7 @@
 #include <boost/log/trivial.hpp>
 #include <sstream>
 #include "fatal_error.h"
+#include "inthash.h"
 
 namespace fs = boost::filesystem;
 
@@ -129,5 +130,7 @@ std::vector<std::pair<SampleIdText, SampleFpath>> load_read_index(
     const fs::path& read_index_fpath);
 
 std::string remove_spaces_from_string(const std::string& str);
+
+std::vector<std::string> split_ambiguous(const std::string& s, uint8_t delim = 4);
 
 #endif

--- a/include/utils.h
+++ b/include/utils.h
@@ -132,6 +132,6 @@ std::vector<std::pair<SampleIdText, SampleFpath>> load_read_index(
 
 std::string remove_spaces_from_string(const std::string& str);
 
-std::pair<std::vector<std::string>, std::vector<size_t>> split_ambiguous(const std::string& s, uint8_t delim = 4);
+std::pair<std::vector<std::string>, std::vector<size_t>> split_ambiguous(const std::string& input_string, uint8_t delim = 4);
 
 #endif

--- a/src/seq.cpp
+++ b/src/seq.cpp
@@ -47,7 +47,7 @@ bool Seq::add_letter_to_get_next_kmer(const char& letter, const uint64_t& shift1
         buff++;
         return true;
     } else {
-        BOOST_LOG_TRIVIAL(debug)
+        BOOST_LOG_TRIVIAL(warning)
             << now() << "bad letter - found a non AGCT base in read so skipping read "
             << name;
         sketch.clear();

--- a/src/seq.cpp
+++ b/src/seq.cpp
@@ -15,7 +15,9 @@ Seq::Seq(uint32_t i, const std::string& n, const std::string& p, uint32_t w, uin
     : id(i)
     , name(n)
 {
-    seq = split_ambiguous(p);
+    auto seqs_and_offsets = split_ambiguous(p);
+    seq = seqs_and_offsets.first;
+    offsets = seqs_and_offsets.second;
     minimizer_sketch(w, k);
 }
 
@@ -26,7 +28,9 @@ void Seq::initialize(
 {
     id = i;
     name = n;
-    seq = split_ambiguous(p);
+    auto seqs_and_offsets = split_ambiguous(p);
+    seq = seqs_and_offsets.first;
+    offsets = seqs_and_offsets.second;
     sketch.clear();
     minimizer_sketch(w, k);
 }
@@ -95,7 +99,14 @@ void Seq::add_new_smallest_minimizer(vector<Minimizer>& window, uint64_t& smalle
     window.clear();
 }
 
-void Seq::minimizer_sketch(const uint32_t w, const uint32_t k)
+void Seq::minimizer_sketch(const uint32_t w, const uint32_t k) {
+    for (size_t i = 0; i < seq.size(); ++i) {
+        minimizer_sketch(seq[i], offsets[i], w, k);
+    }
+}
+
+void Seq::minimizer_sketch(const std::string &s, const size_t seq_offset,
+    const uint32_t w, const uint32_t k)
 {
     // initializations
     uint64_t shift1 = 2 * (k - 1), mask = (1ULL << 2 * k) - 1,
@@ -105,39 +116,37 @@ void Seq::minimizer_sketch(const uint32_t w, const uint32_t k)
     vector<Minimizer> window; // will store all k-mers as Minimizer in the window
     window.reserve(w);
 
-    for (auto &s : seq) {
-        const bool sequence_too_short_to_sketch = s.length() + 1 < w + k;
-        if (sequence_too_short_to_sketch)
-            continue;
+    const bool sequence_too_short_to_sketch = s.length() + 1 < w + k;
+    if (sequence_too_short_to_sketch)
+        return;
 
-        for (const char letter : s) {
-            const bool added = add_letter_to_get_next_kmer(letter, shift1, mask, buff,
-                kmer,
-                kh); // add the next base and remove the first one to get the next kmer
-            if (not added)
-                return;
+    for (const char letter : s) {
+        const bool added = add_letter_to_get_next_kmer(letter, shift1, mask, buff,
+            kmer,
+            kh); // add the next base and remove the first one to get the next kmer
+        if (not added)
+            return;
 
-            if (buff >= k) {
-                window.push_back(Minimizer(
-                    std::min(kh[0], kh[1]), buff - k, buff, (kh[0] <= kh[1])));
-            }
+        if (buff >= k) {
+            window.push_back(Minimizer(
+                std::min(kh[0], kh[1]), buff - k + seq_offset, buff + seq_offset, (kh[0] <= kh[1])));
+        }
 
-            if (window.size() == w) {
-                minimize_window(window,
-                    smallest); // finds the minimizer in the window, add the minimizer to the sketch set and erase everything until the minimizer
-            } else if (buff >= w + k
-                and window.back().canonical_kmer_hash <= smallest) {
-                add_new_smallest_minimizer(window,
-                    smallest); // add the last element of the window (a Minimizer) to the sketch, update the smallest and clear the window
-            }
+        if (window.size() == w) {
+            minimize_window(window,
+                smallest); // finds the minimizer in the window, add the minimizer to the sketch set and erase everything until the minimizer
+        } else if (buff >= w + k
+            and window.back().canonical_kmer_hash <= smallest) {
+            add_new_smallest_minimizer(window,
+                smallest); // add the last element of the window (a Minimizer) to the sketch, update the smallest and clear the window
+        }
 
-            const bool window_has_shortened = window.size() < w;
-            if (!window_has_shortened) {
-                fatal_error(
-                    "Error when sketching sequence: a minimizer should have been added "
-                    "and windows should have size < ",
-                    w, " (is ", window.size(), ")");
-            }
+        const bool window_has_shortened = window.size() < w;
+        if (!window_has_shortened) {
+            fatal_error(
+                "Error when sketching sequence: a minimizer should have been added "
+                "and windows should have size < ",
+                w, " (is ", window.size(), ")");
         }
     }
 }
@@ -151,7 +160,7 @@ std::ostream& operator<<(std::ostream& out, Seq const& data)
 uint64_t Seq::length() const
 {
     uint64_t l{0};
-    for (auto &s: seq) {
+    for (const auto &s: seq) {
         l += s.length();
     }
     return l;

--- a/src/seq.cpp
+++ b/src/seq.cpp
@@ -16,7 +16,7 @@ Seq::Seq(uint32_t i, const std::string& n, const std::string& p, uint32_t w, uin
     , name(n)
 {
     auto seqs_and_offsets = split_ambiguous(p);
-    seq = seqs_and_offsets.first;
+    subseqs = seqs_and_offsets.first;
     offsets = seqs_and_offsets.second;
     minimizer_sketch(w, k);
 }
@@ -29,7 +29,7 @@ void Seq::initialize(
     id = i;
     name = n;
     auto seqs_and_offsets = split_ambiguous(p);
-    seq = seqs_and_offsets.first;
+    subseqs = seqs_and_offsets.first;
     offsets = seqs_and_offsets.second;
     sketch.clear();
     minimizer_sketch(w, k);
@@ -100,8 +100,8 @@ void Seq::add_new_smallest_minimizer(vector<Minimizer>& window, uint64_t& smalle
 }
 
 void Seq::minimizer_sketch(const uint32_t w, const uint32_t k) {
-    for (size_t i = 0; i < seq.size(); ++i) {
-        minimizer_sketch(seq[i], offsets[i], w, k);
+    for (size_t i = 0; i < subseqs.size(); ++i) {
+        minimizer_sketch(subseqs[i], offsets[i], w, k);
     }
 }
 
@@ -160,7 +160,7 @@ std::ostream& operator<<(std::ostream& out, Seq const& data)
 uint64_t Seq::length() const
 {
     uint64_t l{0};
-    for (const auto &s: seq) {
+    for (const auto &s: subseqs) {
         l += s.length();
     }
     return l;

--- a/src/seq.cpp
+++ b/src/seq.cpp
@@ -97,18 +97,18 @@ void Seq::add_new_smallest_minimizer(vector<Minimizer>& window, uint64_t& smalle
 
 void Seq::minimizer_sketch(const uint32_t w, const uint32_t k)
 {
+    // initializations
+    uint64_t shift1 = 2 * (k - 1), mask = (1ULL << 2 * k) - 1,
+        smallest = std::numeric_limits<uint64_t>::max(), kmer[2] = { 0, 0 },
+        kh[2] = { 0, 0 };
+    uint32_t buff = 0;
+    vector<Minimizer> window; // will store all k-mers as Minimizer in the window
+    window.reserve(w);
+
     for (auto &s : seq) {
         const bool sequence_too_short_to_sketch = s.length() + 1 < w + k;
         if (sequence_too_short_to_sketch)
-            return;
-
-        // initializations
-        uint64_t shift1 = 2 * (k - 1), mask = (1ULL << 2 * k) - 1,
-                 smallest = std::numeric_limits<uint64_t>::max(), kmer[2] = { 0, 0 },
-                 kh[2] = { 0, 0 };
-        uint32_t buff = 0;
-        vector<Minimizer> window; // will store all k-mers as Minimizer in the window
-        window.reserve(w);
+            continue;
 
         for (const char letter : s) {
             const bool added = add_letter_to_get_next_kmer(letter, shift1, mask, buff,

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -635,29 +635,30 @@ std::string remove_spaces_from_string(const std::string& str)
     return to_return;
 }
 
-std::pair<std::vector<std::string>, std::vector<size_t>> split_ambiguous(const std::string& s, uint8_t delim)
+std::pair<std::vector<std::string>, std::vector<size_t>> split_ambiguous(const std::string& input_string, uint8_t delim)
 {
     std::vector<std::string> substrs;
     std::vector<size_t> offsets;
     auto start { 0 };
-    auto i { 0 };
-    auto l { 0 };
-    for (auto& ch : s) {
-        uint32_t c = nt4((uint8_t)ch);
-        if (c == delim) {
-            if (l > 0) {
-                substrs.emplace_back(s.substr(start, l));
+    auto current_index { 0 };
+    auto valid_substring_length { 0 };
+    for (const auto& base : input_string) {
+        const uint32_t coded_base = nt4(base);
+        const bool is_ambiguous = coded_base == delim;
+        if (is_ambiguous) {
+            if (valid_substring_length > 0) {
+                substrs.emplace_back(input_string.substr(start, valid_substring_length));
                 offsets.emplace_back(start);
             }
-            start = i + 1;
-            l = 0;
+            start = current_index + 1;
+            valid_substring_length = 0;
         } else {
-            ++l;
+            ++valid_substring_length;
         }
-        ++i;
+        ++current_index;
     }
-    if (l > 0) {
-        substrs.emplace_back(s.substr(start, l));
+    if (valid_substring_length > 0) {
+        substrs.emplace_back(input_string.substr(start, valid_substring_length));
         offsets.emplace_back(start);
     }
     return std::make_pair(substrs, offsets);

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -635,9 +635,10 @@ std::string remove_spaces_from_string(const std::string& str)
     return to_return;
 }
 
-std::vector<std::string> split_ambiguous(const std::string& s, uint8_t delim)
+std::pair<std::vector<std::string>, std::vector<size_t>> split_ambiguous(const std::string& s, uint8_t delim)
 {
-    std::vector<std::string> elems;
+    std::vector<std::string> substrs;
+    std::vector<size_t> offsets;
     auto start { 0 };
     auto i { 0 };
     auto l { 0 };
@@ -645,7 +646,8 @@ std::vector<std::string> split_ambiguous(const std::string& s, uint8_t delim)
         uint32_t c = nt4((uint8_t)ch);
         if (c == delim) {
             if (l > 0) {
-                elems.emplace_back(s.substr(start, l));
+                substrs.emplace_back(s.substr(start, l));
+                offsets.emplace_back(start);
             }
             start = i + 1;
             l = 0;
@@ -655,7 +657,8 @@ std::vector<std::string> split_ambiguous(const std::string& s, uint8_t delim)
         ++i;
     }
     if (l > 0) {
-        elems.emplace_back(s.substr(start, l));
+        substrs.emplace_back(s.substr(start, l));
+        offsets.emplace_back(start);
     }
-    return elems;
+    return std::make_pair(substrs, offsets);
 }

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -8,6 +8,7 @@
 #include <ctime>
 #include <algorithm>
 #include <boost/filesystem.hpp>
+#include <boost/algorithm/string/split.hpp>
 
 #include "utils.h"
 #include "seq.h"
@@ -635,30 +636,60 @@ std::string remove_spaces_from_string(const std::string& str)
     return to_return;
 }
 
+template<class UnaryPredicate >
+std::list<std::vector<uint32_t>> split_on_predicate(std::vector<uint32_t> &original, UnaryPredicate predicate) {
+    std::list<std::vector<uint32_t>> split;
+    boost::split(split, original, predicate, boost::algorithm::token_compress_on);
+    auto remove_index = std::remove_if(split.begin(), split.end(),
+        [](const std::vector<uint32_t> &hashed_substr) { return hashed_substr.empty(); } );
+    split.erase(remove_index, split.end());
+    return split;
+}
+
 std::pair<std::vector<std::string>, std::vector<size_t>> split_ambiguous(const std::string& s, uint8_t delim)
 {
-    std::vector<std::string> substrs;
-    std::vector<size_t> offsets;
-    auto start { 0 };
-    auto i { 0 };
-    auto l { 0 };
-    for (auto& ch : s) {
-        uint32_t c = nt4((uint8_t)ch);
-        if (c == delim) {
-            if (l > 0) {
-                substrs.emplace_back(s.substr(start, l));
-                offsets.emplace_back(start);
-            }
-            start = i + 1;
-            l = 0;
-        } else {
-            ++l;
-        }
-        ++i;
+    // encode the input string
+    std::vector<uint32_t> hashed_string(s.size());
+    std::transform(s.begin(), s.end(), hashed_string.begin(), nt4);
+
+    // get the runs of valid and ambiguous bases
+    std::list<std::vector<uint32_t>> valid_substrs = split_on_predicate(hashed_string,
+        [delim](uint8_t c){ return c == delim; });
+    std::list<std::vector<uint32_t>> ambiguous_substrs = split_on_predicate(hashed_string,
+        [delim](uint8_t c){ return c != delim; });
+
+    // edge case: no valid bases found
+    const bool no_valid_bases = valid_substrs.empty();
+    if (no_valid_bases) {
+        return std::make_pair(std::vector<std::string>(), std::vector<size_t>());
     }
-    if (l > 0) {
-        substrs.emplace_back(s.substr(start, l));
-        offsets.emplace_back(start);
+
+    // decode valid_substrs
+    std::vector<std::string> decoded_valid_substrs(valid_substrs.size());
+    auto decoded_valid_substrs_it = decoded_valid_substrs.begin();
+    for (auto valid_substrs_it = valid_substrs.begin(); valid_substrs_it != valid_substrs.end(); ++valid_substrs_it, ++decoded_valid_substrs_it) {
+        decoded_valid_substrs_it->append("*", valid_substrs_it->size());
+        std::transform(valid_substrs_it->begin(), valid_substrs_it->end(), decoded_valid_substrs_it->begin(),
+            [](const uint32_t coded_base) { return "ACGT"[coded_base]; });
     }
-    return std::make_pair(substrs, offsets);
+
+    // compute offsets
+    const bool first_run_is_ambiguous = hashed_string[0] == delim;
+    size_t first_offset = 0;
+    if (first_run_is_ambiguous) {
+        // edge case: sequence starts with ambiguous bases
+        first_offset = ambiguous_substrs.front().size();
+        ambiguous_substrs.pop_front();
+    }
+    std::vector<size_t> offsets{first_offset};
+
+    auto valid_substrs_it = valid_substrs.begin();
+    size_t previous_substr_len = valid_substrs_it->size();
+    for (++valid_substrs_it; valid_substrs_it != valid_substrs.end(); ++valid_substrs_it) {
+        offsets.push_back(offsets.back() + previous_substr_len + ambiguous_substrs.front().size());
+        ambiguous_substrs.pop_front();
+        previous_substr_len = valid_substrs_it->size();
+    }
+
+    return std::make_pair(decoded_valid_substrs, offsets);
 }

--- a/test/seq_test.cpp
+++ b/test/seq_test.cpp
@@ -12,7 +12,8 @@ TEST(SeqTest, create)
     Seq s1(0, "0", "AGCTAATGCGTT", 11, 3);
     EXPECT_EQ((uint)0, s1.id);
     EXPECT_EQ("0", s1.name);
-    EXPECT_EQ("AGCTAATGCGTT", s1.seq);
+    const std::vector<std::string> expected_seq{"AGCTAATGCGTT"};
+    EXPECT_EQ(expected_seq, s1.seq);
 }
 
 TEST(SeqTest, initialize)
@@ -21,7 +22,8 @@ TEST(SeqTest, initialize)
     s1.initialize(1, "new", "AGCTAATGCATA", 9, 3);
     EXPECT_EQ((uint)1, s1.id);
     EXPECT_EQ("new", s1.name);
-    EXPECT_EQ("AGCTAATGCATA", s1.seq);
+    const std::vector<std::string> expected_seq{"AGCTAATGCATA"};
+    EXPECT_EQ(expected_seq, s1.seq);
 }
 
 TEST(SeqTest, sketchShortReads)

--- a/test/seq_test.cpp
+++ b/test/seq_test.cpp
@@ -1,8 +1,7 @@
 #include "gtest/gtest.h"
 #include "seq.h"
-#include "minimizer.h"
 #include "interval.h"
-#include <stdint.h>
+#include <cstdint>
 #include <iostream>
 
 using namespace std;
@@ -12,7 +11,7 @@ TEST(SeqTest, create)
     Seq s1(0, "0", "AGCTAATGCGTT", 11, 3);
     EXPECT_EQ((uint)0, s1.id);
     EXPECT_EQ("0", s1.name);
-    const std::vector<std::string> expected_seq{"AGCTAATGCGTT"};
+    const std::vector<std::string> expected_seq { "AGCTAATGCGTT" };
     EXPECT_EQ(expected_seq, s1.seq);
 }
 
@@ -22,7 +21,7 @@ TEST(SeqTest, initialize)
     s1.initialize(1, "new", "AGCTAATGCATA", 9, 3);
     EXPECT_EQ((uint)1, s1.id);
     EXPECT_EQ("new", s1.name);
-    const std::vector<std::string> expected_seq{"AGCTAATGCATA"};
+    const std::vector<std::string> expected_seq { "AGCTAATGCATA" };
     EXPECT_EQ(expected_seq, s1.seq);
 }
 
@@ -97,15 +96,39 @@ TEST(SeqTest, sketchIncludesEveryLetter)
     }
 }
 
+TEST(SeqTest, lengthNoAmbiguous)
+{
+    const std::string s { "AGCTAATGCGTT" };
+    const Seq seq(0, "0", s, 3, 3);
+
+    EXPECT_EQ(seq.length(), s.length());
+}
+
+TEST(SeqTest, lengthOneAmbiguous)
+{
+    const std::string s { "AGCTAATGNGTT" };
+    const Seq seq(0, "0", s, 3, 3);
+
+    EXPECT_EQ(seq.length(), s.length() - 1);
+}
+
+TEST(SeqTest, lengthTwoAmbiguous)
+{
+    const std::string s { "AWGCTAATGNGTT" };
+    const Seq seq(0, "0", s, 3, 3);
+
+    EXPECT_EQ(seq.length(), s.length() - 2);
+}
+
 TEST(SeqTest, sketchSkipsAmbiguousBaseAtStart)
 {
     const string seq = "NGCTAATGTGTT";
-    const auto w{1};
-    const auto k{3};
+    const auto w { 1 };
+    const auto k { 3 };
     Seq s1(0, "0", seq, w, k);
 
-    set<int> pos_exclude{0};
-    set<int> pos_include{};
+    set<int> pos_exclude { 0 };
+    set<int> pos_include {};
     for (auto it = s1.sketch.begin(); it != s1.sketch.end(); ++it) {
         for (uint32_t j = (*it).pos_of_kmer_in_read.start;
              j < (*it).pos_of_kmer_in_read.get_end(); ++j) {
@@ -113,5 +136,5 @@ TEST(SeqTest, sketchSkipsAmbiguousBaseAtStart)
             pos_include.insert(j);
         }
     }
-    EXPECT_EQ(pos_include.size(), seq.length()-1);
+    EXPECT_EQ(pos_include.size(), seq.length() - 1);
 }

--- a/test/seq_test.cpp
+++ b/test/seq_test.cpp
@@ -94,3 +94,22 @@ TEST(SeqTest, sketchIncludesEveryLetter)
         EXPECT_EQ((pos_inc.find(i) != pos_inc.end()), true);
     }
 }
+
+TEST(SeqTest, sketchSkipsAmbiguousBaseAtStart)
+{
+    const string seq = "NGCTAATGTGTT";
+    const auto w{1};
+    const auto k{3};
+    Seq s1(0, "0", seq, w, k);
+
+    set<int> pos_exclude{0};
+    set<int> pos_include{};
+    for (auto it = s1.sketch.begin(); it != s1.sketch.end(); ++it) {
+        for (uint32_t j = (*it).pos_of_kmer_in_read.start;
+             j < (*it).pos_of_kmer_in_read.get_end(); ++j) {
+            EXPECT_TRUE(pos_exclude.find(j) == pos_exclude.end()) << (*it);
+            pos_include.insert(j);
+        }
+    }
+    EXPECT_EQ(pos_include.size(), seq.length()-1);
+}

--- a/test/seq_test.cpp
+++ b/test/seq_test.cpp
@@ -13,7 +13,7 @@ TEST(SeqTest, create)
     EXPECT_EQ((uint)0, s1.id);
     EXPECT_EQ("0", s1.name);
     const std::vector<std::string> expected_seq { "AGCTAATGCGTT" };
-    EXPECT_EQ(expected_seq, s1.seq);
+    EXPECT_EQ(expected_seq, s1.subseqs);
 }
 
 TEST(SeqTest, initialize)
@@ -23,7 +23,7 @@ TEST(SeqTest, initialize)
     EXPECT_EQ((uint)1, s1.id);
     EXPECT_EQ("new", s1.name);
     const std::vector<std::string> expected_seq { "AGCTAATGCATA" };
-    EXPECT_EQ(expected_seq, s1.seq);
+    EXPECT_EQ(expected_seq, s1.subseqs);
 }
 
 TEST(SeqTest, sketchShortReads)

--- a/test/seq_test.cpp
+++ b/test/seq_test.cpp
@@ -96,6 +96,25 @@ TEST(SeqTest, sketchIncludesEveryLetter)
     }
 }
 
+TEST(SeqTest, sketchSkipsAmbiguousBaseAtStart)
+{
+    const string seq = "NGCTAATGTGTT";
+    const auto w { 1 };
+    const auto k { 3 };
+    Seq s1(0, "0", seq, w, k);
+
+    set<int> pos_exclude { 0 };
+    set<int> pos_include {};
+    for (auto it = s1.sketch.begin(); it != s1.sketch.end(); ++it) {
+        for (uint32_t j = (*it).pos_of_kmer_in_read.start;
+             j < (*it).pos_of_kmer_in_read.get_end(); ++j) {
+            EXPECT_TRUE(pos_exclude.find(j) == pos_exclude.end()) << (*it);
+            pos_include.insert(j);
+        }
+    }
+    EXPECT_EQ(pos_include.size(), seq.length() - 1);
+}
+
 TEST(SeqTest, lengthNoAmbiguous)
 {
     const std::string s { "AGCTAATGCGTT" };
@@ -120,21 +139,3 @@ TEST(SeqTest, lengthTwoAmbiguous)
     EXPECT_EQ(seq.length(), s.length() - 2);
 }
 
-TEST(SeqTest, sketchSkipsAmbiguousBaseAtStart)
-{
-    const string seq = "NGCTAATGTGTT";
-    const auto w { 1 };
-    const auto k { 3 };
-    Seq s1(0, "0", seq, w, k);
-
-    set<int> pos_exclude { 0 };
-    set<int> pos_include {};
-    for (auto it = s1.sketch.begin(); it != s1.sketch.end(); ++it) {
-        for (uint32_t j = (*it).pos_of_kmer_in_read.start;
-             j < (*it).pos_of_kmer_in_read.get_end(); ++j) {
-            EXPECT_TRUE(pos_exclude.find(j) == pos_exclude.end()) << (*it);
-            pos_include.insert(j);
-        }
-    }
-    EXPECT_EQ(pos_include.size(), seq.length() - 1);
-}

--- a/test/seq_test.cpp
+++ b/test/seq_test.cpp
@@ -115,6 +115,80 @@ TEST(SeqTest, sketchSkipsAmbiguousBaseAtStart)
     EXPECT_EQ(pos_include.size(), seq.length() - 1);
 }
 
+TEST(SeqTest, sketchSkipsAmbiguousBaseAtEnd)
+{
+    const string seq = "GCTAATGTGTTN";
+    const auto w { 1 };
+    const auto k { 3 };
+    Seq s1(0, "0", seq, w, k);
+
+    set<int> pos_exclude { 11 };
+    set<int> pos_include {};
+    for (auto it = s1.sketch.begin(); it != s1.sketch.end(); ++it) {
+        for (uint32_t j = (*it).pos_of_kmer_in_read.start;
+             j < (*it).pos_of_kmer_in_read.get_end(); ++j) {
+            EXPECT_TRUE(pos_exclude.find(j) == pos_exclude.end()) << (*it);
+            pos_include.insert(j);
+        }
+    }
+    EXPECT_EQ(pos_include.size(), seq.length() - 1);
+}
+
+TEST(SeqTest, sketchSkipsAmbiguousBaseInMiddle)
+{
+    const string seq = "GCTAATNGTGTT";
+    const auto w { 1 };
+    const auto k { 3 };
+    Seq s1(0, "0", seq, w, k);
+
+    set<int> pos_exclude { 6 };
+    set<int> pos_include {};
+    for (auto it = s1.sketch.begin(); it != s1.sketch.end(); ++it) {
+        for (uint32_t j = (*it).pos_of_kmer_in_read.start;
+             j < (*it).pos_of_kmer_in_read.get_end(); ++j) {
+            EXPECT_TRUE(pos_exclude.find(j) == pos_exclude.end()) << (*it);
+            pos_include.insert(j);
+        }
+    }
+    EXPECT_EQ(pos_include.size(), seq.length() - 1);
+}
+
+TEST(SeqTest, sketchSkipsAmbiguousBaseTwoInMiddle)
+{
+    const string seq = "GCTANATNGTGTT";
+    const auto w { 1 };
+    const auto k { 3 };
+    Seq s1(0, "0", seq, w, k);
+
+    set<int> pos_exclude { 4, 5, 6, 7 };
+    set<int> pos_include {};
+    for (auto it = s1.sketch.begin(); it != s1.sketch.end(); ++it) {
+        for (uint32_t j = (*it).pos_of_kmer_in_read.start;
+             j < (*it).pos_of_kmer_in_read.get_end(); ++j) {
+            EXPECT_TRUE(pos_exclude.find(j) == pos_exclude.end()) << (*it);
+            pos_include.insert(j);
+        }
+    }
+    EXPECT_EQ(pos_include.size(), seq.length() - 4);
+}
+
+TEST(SeqTest, sketchSkipsAmbiguousNoStretchesOfK)
+{
+    const string seq = "GCNTANATNGTWGTNT";
+    const auto w { 1 };
+    const auto k { 3 };
+    Seq s1(0, "0", seq, w, k);
+
+    set<int> pos_include {};
+    for (auto it = s1.sketch.begin(); it != s1.sketch.end(); ++it) {
+        for (uint32_t j = (*it).pos_of_kmer_in_read.start;
+             j < (*it).pos_of_kmer_in_read.get_end(); ++j) {
+            pos_include.insert(j);
+        }
+    }
+    EXPECT_TRUE(pos_include.empty());
+}
+
 TEST(SeqTest, lengthNoAmbiguous)
 {
     const std::string s { "AGCTAATGCGTT" };
@@ -138,4 +212,3 @@ TEST(SeqTest, lengthTwoAmbiguous)
 
     EXPECT_EQ(seq.length(), s.length() - 2);
 }
-

--- a/test/utils_test.cpp
+++ b/test/utils_test.cpp
@@ -1206,13 +1206,13 @@ TEST(load_read_index, read_index_has_three_samples)
 
 TEST(load_read_index, read_index_has_three_samples_and_no_empty_line_at_end)
 {
-    std::vector<std::pair<SampleIdText, SampleFpath>> actual
-            = load_read_index(fs::path("../../test/test_cases/sample_read_index_no_empty_line_at_end.tsv"));
+    std::vector<std::pair<SampleIdText, SampleFpath>> actual = load_read_index(
+        fs::path("../../test/test_cases/sample_read_index_no_empty_line_at_end.tsv"));
     std::vector<std::pair<SampleIdText, SampleFpath>> expected { {
-                                                                         std::make_pair("sample_1", "reads_1.fastq"),
-                                                                         std::make_pair("sample_2", "reads_2.fastq"),
-                                                                         std::make_pair("sample_3", "reads_3.fastq"),
-                                                                 } };
+        std::make_pair("sample_1", "reads_1.fastq"),
+        std::make_pair("sample_2", "reads_2.fastq"),
+        std::make_pair("sample_3", "reads_3.fastq"),
+    } };
 
     EXPECT_EQ(actual, expected);
 }
@@ -1232,7 +1232,127 @@ TEST(load_read_index, read_index_has_three_samples_and_two_are_repeated)
 
 TEST(load_read_index, read_index_has_missing_column)
 {
-    ASSERT_EXCEPTION(load_read_index(fs::path("../../test/test_cases/malformatted_read_index.tsv")),
-                     FatalRuntimeError, "Malformatted read index file entry for sample_3");
+    ASSERT_EXCEPTION(
+        load_read_index(fs::path("../../test/test_cases/malformatted_read_index.tsv")),
+        FatalRuntimeError, "Malformatted read index file entry for sample_3");
 }
 
+TEST(splitAmbiguous, noAmbiguous)
+{
+    const std::string s("ACGT");
+
+    const auto actual(split_ambiguous(s));
+    const std::vector<std::string> expected { s };
+
+    EXPECT_EQ(actual, expected);
+}
+
+TEST(splitAmbiguous, emptySequence)
+{
+    const std::string s("");
+
+    const auto actual(split_ambiguous(s));
+    const std::vector<std::string> expected;
+
+    EXPECT_EQ(actual, expected);
+}
+
+TEST(splitAmbiguous, allAmbiguous)
+{
+    const std::string s("NXDW");
+
+    const auto actual(split_ambiguous(s));
+    const std::vector<std::string> expected;
+
+    EXPECT_EQ(actual, expected);
+}
+
+TEST(splitAmbiguous, firstLetterIsAmbiguous)
+{
+    const std::string s("NACGT");
+
+    const auto actual(split_ambiguous(s));
+    const std::vector<std::string> expected { "ACGT" };
+
+    EXPECT_EQ(actual, expected);
+}
+
+TEST(splitAmbiguous, firstTwoLettersAreAmbiguous)
+{
+    const std::string s("NWACGT");
+
+    const auto actual(split_ambiguous(s));
+    const std::vector<std::string> expected { "ACGT" };
+
+    EXPECT_EQ(actual, expected);
+}
+
+TEST(splitAmbiguous, lastLetterIsAmbiguous)
+{
+    const std::string s("ACGTN");
+
+    const auto actual(split_ambiguous(s));
+    const std::vector<std::string> expected { "ACGT" };
+
+    EXPECT_EQ(actual, expected);
+}
+
+TEST(splitAmbiguous, lastTwoLettersAreAmbiguous)
+{
+    const std::string s("ACGTNW");
+
+    const auto actual(split_ambiguous(s));
+    const std::vector<std::string> expected { "ACGT" };
+
+    EXPECT_EQ(actual, expected);
+}
+
+TEST(splitAmbiguous, ambiguousBaseInMiddle)
+{
+    const std::string s("ACNGT");
+
+    const auto actual(split_ambiguous(s));
+    const std::vector<std::string> expected { "AC", "GT" };
+
+    EXPECT_EQ(actual, expected);
+}
+
+TEST(splitAmbiguous, ambiguousBaseOffCentre)
+{
+    const std::string s("AWCGT");
+
+    const auto actual(split_ambiguous(s));
+    const std::vector<std::string> expected { "A", "CGT" };
+
+    EXPECT_EQ(actual, expected);
+}
+
+TEST(splitAmbiguous, twoAmbiguousInMiddle)
+{
+    const std::string s("AWXCGT");
+
+    const auto actual(split_ambiguous(s));
+    const std::vector<std::string> expected { "A", "CGT" };
+
+    EXPECT_EQ(actual, expected);
+}
+
+TEST(splitAmbiguous, twoAmbiguousSpacedOut)
+{
+    const std::string s("AWCNGT");
+
+    const auto actual(split_ambiguous(s));
+    const std::vector<std::string> expected { "A", "C", "GT" };
+
+    EXPECT_EQ(actual, expected);
+}
+
+TEST(splitAmbiguous, twoAmbiguousSpacedOutRuns)
+{
+    const std::string s("AWXCNXGT");
+
+    const auto actual(split_ambiguous(s));
+    const std::vector<std::string> expected { "A", "C", "GT" };
+
+    EXPECT_EQ(actual, expected);
+}

--- a/test/utils_test.cpp
+++ b/test/utils_test.cpp
@@ -1242,7 +1242,10 @@ TEST(splitAmbiguous, noAmbiguous)
     const std::string s("ACGT");
 
     const auto actual(split_ambiguous(s));
-    const std::vector<std::string> expected { s };
+
+    const std::vector<std::string> expected_substrs { s };
+    const std::vector<std::size_t> expected_offsets { 0 };
+    const auto expected = make_pair(expected_substrs, expected_offsets);
 
     EXPECT_EQ(actual, expected);
 }
@@ -1252,7 +1255,11 @@ TEST(splitAmbiguous, emptySequence)
     const std::string s("");
 
     const auto actual(split_ambiguous(s));
-    const std::vector<std::string> expected;
+
+    const std::vector<std::string> expected_substrs;
+    const std::vector<std::size_t> expected_offsets;
+    const auto expected = make_pair(expected_substrs, expected_offsets);
+
 
     EXPECT_EQ(actual, expected);
 }
@@ -1262,7 +1269,11 @@ TEST(splitAmbiguous, allAmbiguous)
     const std::string s("NXDW");
 
     const auto actual(split_ambiguous(s));
-    const std::vector<std::string> expected;
+
+    const std::vector<std::string> expected_substrs;
+    const std::vector<std::size_t> expected_offsets;
+    const auto expected = make_pair(expected_substrs, expected_offsets);
+
 
     EXPECT_EQ(actual, expected);
 }
@@ -1272,7 +1283,10 @@ TEST(splitAmbiguous, firstLetterIsAmbiguous)
     const std::string s("NACGT");
 
     const auto actual(split_ambiguous(s));
-    const std::vector<std::string> expected { "ACGT" };
+
+    const std::vector<std::string> expected_substrs { "ACGT" };
+    const std::vector<std::size_t> expected_offsets { 1 };
+    const auto expected = make_pair(expected_substrs, expected_offsets);
 
     EXPECT_EQ(actual, expected);
 }
@@ -1282,7 +1296,10 @@ TEST(splitAmbiguous, firstTwoLettersAreAmbiguous)
     const std::string s("NWACGT");
 
     const auto actual(split_ambiguous(s));
-    const std::vector<std::string> expected { "ACGT" };
+
+    const std::vector<std::string> expected_substrs { "ACGT" };
+    const std::vector<std::size_t> expected_offsets { 2 };
+    const auto expected = make_pair(expected_substrs, expected_offsets);
 
     EXPECT_EQ(actual, expected);
 }
@@ -1292,7 +1309,10 @@ TEST(splitAmbiguous, lastLetterIsAmbiguous)
     const std::string s("ACGTN");
 
     const auto actual(split_ambiguous(s));
-    const std::vector<std::string> expected { "ACGT" };
+
+    const std::vector<std::string> expected_substrs { "ACGT" };
+    const std::vector<std::size_t> expected_offsets { 0 };
+    const auto expected = make_pair(expected_substrs, expected_offsets);
 
     EXPECT_EQ(actual, expected);
 }
@@ -1302,7 +1322,10 @@ TEST(splitAmbiguous, lastTwoLettersAreAmbiguous)
     const std::string s("ACGTNW");
 
     const auto actual(split_ambiguous(s));
-    const std::vector<std::string> expected { "ACGT" };
+
+    const std::vector<std::string> expected_substrs { "ACGT" };
+    const std::vector<std::size_t> expected_offsets { 0 };
+    const auto expected = make_pair(expected_substrs, expected_offsets);
 
     EXPECT_EQ(actual, expected);
 }
@@ -1312,7 +1335,10 @@ TEST(splitAmbiguous, ambiguousBaseInMiddle)
     const std::string s("ACNGT");
 
     const auto actual(split_ambiguous(s));
-    const std::vector<std::string> expected { "AC", "GT" };
+
+    const std::vector<std::string> expected_substrs { "AC", "GT" };
+    const std::vector<std::size_t> expected_offsets { 0, 3 };
+    const auto expected = make_pair(expected_substrs, expected_offsets);
 
     EXPECT_EQ(actual, expected);
 }
@@ -1322,7 +1348,10 @@ TEST(splitAmbiguous, ambiguousBaseOffCentre)
     const std::string s("AWCGT");
 
     const auto actual(split_ambiguous(s));
-    const std::vector<std::string> expected { "A", "CGT" };
+
+    const std::vector<std::string> expected_substrs { "A", "CGT" };
+    const std::vector<std::size_t> expected_offsets { 0, 2 };
+    const auto expected = make_pair(expected_substrs, expected_offsets);
 
     EXPECT_EQ(actual, expected);
 }
@@ -1332,7 +1361,10 @@ TEST(splitAmbiguous, twoAmbiguousInMiddle)
     const std::string s("AWXCGT");
 
     const auto actual(split_ambiguous(s));
-    const std::vector<std::string> expected { "A", "CGT" };
+
+    const std::vector<std::string> expected_substrs { "A", "CGT" };
+    const std::vector<std::size_t> expected_offsets { 0, 3 };
+    const auto expected = make_pair(expected_substrs, expected_offsets);
 
     EXPECT_EQ(actual, expected);
 }
@@ -1342,7 +1374,10 @@ TEST(splitAmbiguous, twoAmbiguousSpacedOut)
     const std::string s("AWCNGT");
 
     const auto actual(split_ambiguous(s));
-    const std::vector<std::string> expected { "A", "C", "GT" };
+
+    const std::vector<std::string> expected_substrs { "A", "C", "GT" };
+    const std::vector<std::size_t> expected_offsets { 0, 2, 4 };
+    const auto expected = make_pair(expected_substrs, expected_offsets);
 
     EXPECT_EQ(actual, expected);
 }
@@ -1352,7 +1387,11 @@ TEST(splitAmbiguous, twoAmbiguousSpacedOutRuns)
     const std::string s("AWXCNXGT");
 
     const auto actual(split_ambiguous(s));
-    const std::vector<std::string> expected { "A", "C", "GT" };
+
+    const std::vector<std::string> expected_substrs { "A", "C", "GT" };
+    const std::vector<std::size_t> expected_offsets { 0, 3, 6 };
+    const auto expected = make_pair(expected_substrs, expected_offsets);
+
 
     EXPECT_EQ(actual, expected);
 }


### PR DESCRIPTION
This PR closes #294. I also brings `master` up to date with `dev`.

The methodology here is that we split a `Seq`'s internal sequence into a vector of strings that don't contain ambiguous bases - i.e., splitting the original sequence on ambiguous bases.