### PR TITLE
Misc improvements before index optimisation PR

### DIFF
--- a/include/compare_main.h
+++ b/include/compare_main.h
@@ -35,6 +35,7 @@ struct CompareOptions {
     fs::path vcf_refs_file;
     uint8_t verbosity { 0 };
     float error_rate { 0.11 };
+    uint32_t rng_seed { 0 };
     uint32_t genome_size { 5000000 };
     uint32_t max_diff { 250 };
     bool output_vcf { false };

--- a/include/denovo_discovery/discover_main.h
+++ b/include/denovo_discovery/discover_main.h
@@ -22,6 +22,7 @@ struct DiscoverOptions {
     uint32_t threads { 1 };
     uint8_t verbosity { 0 };
     float error_rate { 0.11 };
+    uint32_t rng_seed { 0 };
     uint32_t genome_size { 5000000 };
     uint32_t max_diff { 250 };
     bool output_kg { false };

--- a/include/denovo_discovery/discover_main.h
+++ b/include/denovo_discovery/discover_main.h
@@ -26,7 +26,6 @@ struct DiscoverOptions {
     uint32_t max_diff { 250 };
     bool output_kg { false };
     bool illumina { false };
-    bool clean { false };
     bool binomial { false };
     bool do_not_auto_update_params { false };
     uint32_t max_covg { 600 };

--- a/include/kmergraphwithcoverage.h
+++ b/include/kmergraphwithcoverage.h
@@ -152,8 +152,6 @@ public:
 
     void save_covg_dist(const std::string&);
 
-    std::vector<std::vector<KmerNodePtr>> get_random_paths(uint32_t);
-
     float prob_path(const std::vector<KmerNodePtr>& kpath, const uint32_t& sample_id,
         const std::string& prob_model);
 

--- a/include/localPRG.h
+++ b/include/localPRG.h
@@ -121,7 +121,8 @@ public:
         npath.push_back(prg.nodes.at(0));
         while (not npath.back()->outNodes.empty()) {
             uint32_t random_number = rng();
-            npath.push_back(npath.back()->outNodes[random_number]);
+            size_t random_neighbour = random_number % npath.back()->outNodes.size();
+            npath.push_back(npath.back()->outNodes[random_neighbour]);
         }
         return string_along_path(npath);
     }

--- a/include/localPRG.h
+++ b/include/localPRG.h
@@ -115,7 +115,16 @@ public:
     std::vector<LocalNodePtr> find_alt_path(const std::vector<LocalNodePtr>&,
         const uint32_t, const std::string&, const std::string&) const;
 
-    std::string random_path();
+    template<typename RNG>
+    std::string random_path(RNG &&rng) {
+        std::vector<LocalNodePtr> npath;
+        npath.push_back(prg.nodes.at(0));
+        while (not npath.back()->outNodes.empty()) {
+            uint32_t random_number = rng();
+            npath.push_back(npath.back()->outNodes[random_number]);
+        }
+        return string_along_path(npath);
+    }
 
     // TODO: I really feel like these methods are not responsability of a LocalPRG
     // TODO: many of them should be in VCF class, or in the KmerGraphWithCoverage or

--- a/include/map_main.h
+++ b/include/map_main.h
@@ -35,6 +35,7 @@ struct MapOptions {
     fs::path vcf_refs_file;
     uint8_t verbosity { 0 };
     float error_rate { 0.11 };
+    uint32_t rng_seed { 0 };
     uint32_t genome_size { 5000000 };
     uint32_t max_diff { 250 };
     bool output_kg { false };

--- a/include/map_main.h
+++ b/include/map_main.h
@@ -40,7 +40,6 @@ struct MapOptions {
     bool output_kg { false };
     bool output_vcf { false };
     bool illumina { false };
-    bool clean { false };
     bool binomial { false };
     bool do_not_auto_update_params { false };
     uint32_t max_covg { 300 };

--- a/include/minihit_clusters.h
+++ b/include/minihit_clusters.h
@@ -18,26 +18,21 @@
  * Querying can only happen after insertions are finalised.
  */
 class MinimizerHitClusters {
-private:
-    bool insertion_phase;
-    std::vector<MinimizerHits> clusters;
-    std::mt19937 rng;  // TODO: make shuffling deterministic?
-
-    inline void check_if_can_insert() const {
-        if (!insertion_phase) {
-            fatal_error("Tried to insert a cluster in a MinimizerHitClusters when insertion phase was finished");
-        }
-    }
-
-    inline void check_if_can_query() const {
-        if (insertion_phase) {
-            fatal_error("Tried to query a MinimizerHitClusters when insertion phase was not finished");
-        }
-    }
-
 public:
-    MinimizerHitClusters() : insertion_phase(true), clusters(), rng(std::random_device()()){}
-    ~MinimizerHitClusters() = default;
+    explicit MinimizerHitClusters(const uint32_t rng_seed) : insertion_phase(true), clusters(){
+        if (bool deterministic_run = rng_seed > 0; deterministic_run) {
+            rng = std::mt19937(rng_seed);
+        } else{
+            rng = std::mt19937(std::random_device()());
+        }
+    }
+    ~MinimizerHitClusters() = default;  // Note: this is not virtual as there is no need to
+
+    // enable copy/move
+    MinimizerHitClusters(const MinimizerHitClusters &) = default;  // copy constructor
+    MinimizerHitClusters& operator=(const MinimizerHitClusters &) = default; // copy assignment operator
+    MinimizerHitClusters(MinimizerHitClusters &&) = default; // move constructor
+    MinimizerHitClusters& operator=(MinimizerHitClusters &&) = default; // move assignment operator
 
     inline void insert(const MinimizerHits& cluster) {
         check_if_can_insert();
@@ -80,6 +75,23 @@ public:
     inline auto end () {
         check_if_can_query();
         return clusters.end();
+    }
+
+private:
+    bool insertion_phase;
+    std::vector<MinimizerHits> clusters;
+    std::mt19937 rng;
+
+    inline void check_if_can_insert() const {
+        if (!insertion_phase) {
+            fatal_error("Tried to insert a cluster in a MinimizerHitClusters when insertion phase was finished");
+        }
+    }
+
+    inline void check_if_can_query() const {
+        if (insertion_phase) {
+            fatal_error("Tried to query a MinimizerHitClusters when insertion phase was not finished");
+        }
     }
 };
 

--- a/include/utils.h
+++ b/include/utils.h
@@ -49,15 +49,6 @@ template <typename T> struct spointer_values_equal {
     bool operator()(const std::shared_ptr<T> other) const { return *to_find == *other; }
 };
 
-// pointer less comparator, from
-// https://stackoverflow.com/questions/41375232/is-there-an-stl-comparator-for-stdset-or-stdmap-with-shared-ptr-keys-that
-struct ptr_less {
-    template <typename T> bool operator()(T lhs, T rhs) const
-    {
-        return std::less<decltype(*lhs)>()(*lhs, *rhs);
-    }
-};
-
 // utility functions
 std::string now();
 
@@ -150,11 +141,7 @@ std::vector<SampleData> load_read_index(const fs::path& read_index_fpath);
 // Returns filepath
 std::pair<int, std::string> build_memfd(const std::string &data);
 
-std::string exec(const char* cmd);
-
 void build_file(const std::string &filepath, const std::string &data);
-
-bool tool_exists(const std::string &command);
 
 void concatenate_text_files(
     const fs::path& output_filename, const std::vector<fs::path>& input_filenames,
@@ -166,9 +153,6 @@ inline void to_upper(std::string &str) {
     std::transform(str.begin(), str.end(), str.begin(), ::toupper);
 }
 
-int random_int();
 std::pair<std::vector<std::string>, std::vector<size_t>> split_ambiguous(const std::string& input_string, uint8_t delim = 4);
-
-uintmax_t get_number_of_bytes_in_file(const fs::path &file);
 
 #endif

--- a/include/utils.h
+++ b/include/utils.h
@@ -116,9 +116,8 @@ uint32_t pangraph_from_read_file(const SampleData& sample,
     std::shared_ptr<pangenome::Graph> pangraph, Index &index,
     const int max_diff, const float& e_rate,
     const fs::path& sample_outdir, const uint32_t min_cluster_size = 10,
-    const uint32_t genome_size = 5000000, const bool illumina = false, const bool clean = false,
-    const uint32_t max_covg = 300, uint32_t threads = 1,
-    const bool keep_extra_debugging_files = false);
+    const uint32_t genome_size = 5000000, const uint32_t max_covg = 300,
+    uint32_t threads = 1, const bool keep_extra_debugging_files = false);
 
 void infer_most_likely_prg_path_for_pannode(
     const std::vector<std::shared_ptr<LocalPRG>>&, PanNode*, uint32_t, float);

--- a/include/utils.h
+++ b/include/utils.h
@@ -98,7 +98,7 @@ MinimizerHitClusters get_minimizer_hit_clusters(
     const std::vector<std::string> &prg_names,
     std::shared_ptr<MinimizerHits> minimizer_hits,
     std::shared_ptr<pangenome::Graph> pangraph, const int max_diff,
-    const uint32_t& genome_size, const float& fraction_kmers_required_for_cluster,
+    const float& fraction_kmers_required_for_cluster,
     ClusterDefFile &cluster_def_file,
     ClusterFilterFile &cluster_filter_file,
     const uint32_t min_cluster_size,

--- a/include/utils.h
+++ b/include/utils.h
@@ -91,7 +91,8 @@ MinimizerHitClusters filter_clusters(
     const Seq &seq,
     const MinimizerHitClusters& clusters_of_hits,
     const std::vector<std::string> &prg_names,
-    ClusterFilterFile& cluster_filter_file
+    ClusterFilterFile& cluster_filter_file,
+    const uint32_t rng_seed = 0
 );
 
 void add_clusters_to_pangraph(
@@ -110,14 +111,16 @@ MinimizerHitClusters get_minimizer_hit_clusters(
     ClusterDefFile &cluster_def_file,
     ClusterFilterFile &cluster_filter_file,
     const uint32_t min_cluster_size,
-    const uint32_t expected_number_kmers_in_read_sketch = std::numeric_limits<uint32_t>::max());
+    const uint32_t expected_number_kmers_in_read_sketch,
+    const uint32_t rng_seed);
 
 uint32_t pangraph_from_read_file(const SampleData& sample,
     std::shared_ptr<pangenome::Graph> pangraph, Index &index,
     const int max_diff, const float& e_rate,
     const fs::path& sample_outdir, const uint32_t min_cluster_size = 10,
     const uint32_t genome_size = 5000000, const uint32_t max_covg = 300,
-    uint32_t threads = 1, const bool keep_extra_debugging_files = false);
+    uint32_t threads = 1, const bool keep_extra_debugging_files = false,
+    const uint32_t rng_seed = 0);
 
 void infer_most_likely_prg_path_for_pannode(
     const std::vector<std::shared_ptr<LocalPRG>>&, PanNode*, uint32_t, float);

--- a/src/compare_main.cpp
+++ b/src/compare_main.cpp
@@ -80,11 +80,6 @@ void setup_compare_subcommand(CLI::App& app)
         ->group("Preset");
 
     compare_subcmd
-        ->add_flag(
-            "--clean", opt->clean, "Add a step to clean and detangle the pangraph")
-        ->group("Filtering");
-
-    compare_subcmd
         ->add_flag("--bin", opt->binomial,
             "Use binomial model for kmer coverages [default: negative binomial]")
         ->group("Parameter Estimation");
@@ -287,8 +282,8 @@ int pandora_compare(CompareOptions& opt)
                                 << sample_fpath << " (this will take a while)";
         uint32_t covg = pangraph_from_read_file(sample, pangraph_sample, index,
             opt.max_diff, opt.error_rate, sample_outdir,
-            opt.min_cluster_size, opt.genome_size, opt.illumina, opt.clean,
-            opt.max_covg, opt.threads, opt.keep_extra_debugging_files);
+            opt.min_cluster_size, opt.genome_size, opt.max_covg, opt.threads,
+            opt.keep_extra_debugging_files);
 
         if (pangraph_sample->nodes.empty()) {
             BOOST_LOG_TRIVIAL(warning)

--- a/src/compare_main.cpp
+++ b/src/compare_main.cpp
@@ -70,6 +70,17 @@ void setup_compare_subcommand(CLI::App& app)
         ->group("Mapping");
 
     compare_subcmd
+        ->add_option(
+            "-r,--rng-seed", opt->rng_seed, "RNG seed, an int>0 to force deterministic "
+                                            "mapping when multiple optimal mappings are"
+                                            "possible. To be avoided except in "
+                                            "debugging/investigation scenarios. A value "
+                                            "of 0 will be interpreted as no seed given "
+                                            "and mapping will not be deterministic.")
+        ->capture_default_str()
+        ->group("Mapping");
+
+    compare_subcmd
         ->add_flag("--loci-vcf", opt->output_vcf, "Save a VCF file for each found loci")
         ->group("Input/Output");
 
@@ -283,7 +294,7 @@ int pandora_compare(CompareOptions& opt)
         uint32_t covg = pangraph_from_read_file(sample, pangraph_sample, index,
             opt.max_diff, opt.error_rate, sample_outdir,
             opt.min_cluster_size, opt.genome_size, opt.max_covg, opt.threads,
-            opt.keep_extra_debugging_files);
+            opt.keep_extra_debugging_files, opt.rng_seed);
 
         if (pangraph_sample->nodes.empty()) {
             BOOST_LOG_TRIVIAL(warning)

--- a/src/compare_main.cpp
+++ b/src/compare_main.cpp
@@ -70,17 +70,6 @@ void setup_compare_subcommand(CLI::App& app)
         ->group("Mapping");
 
     compare_subcmd
-        ->add_option(
-            "-r,--rng-seed", opt->rng_seed, "RNG seed, an int>0 to force deterministic "
-                                            "mapping when multiple optimal mappings are"
-                                            "possible. To be avoided except in "
-                                            "debugging/investigation scenarios. A value "
-                                            "of 0 will be interpreted as no seed given "
-                                            "and mapping will not be deterministic.")
-        ->capture_default_str()
-        ->group("Mapping");
-
-    compare_subcmd
         ->add_flag("--loci-vcf", opt->output_vcf, "Save a VCF file for each found loci")
         ->group("Input/Output");
 
@@ -221,6 +210,17 @@ void setup_compare_subcommand(CLI::App& app)
         ->add_flag("-K,--debugging-files", opt->keep_extra_debugging_files,
             "Keep extra debugging files. Warning: this might "
             "create thousands of files.")
+        ->group("Debugging");
+
+    compare_subcmd
+        ->add_option(
+            "-r,--rng-seed", opt->rng_seed, "RNG seed, an int>0 to force deterministic "
+                                            "mapping when multiple optimal mappings are "
+                                            "possible. To be avoided except in "
+                                            "debugging/investigation scenarios. A value "
+                                            "of 0 will be interpreted as no seed given "
+                                            "and mapping will not be deterministic.")
+        ->capture_default_str()
         ->group("Debugging");
 
     compare_subcmd->add_flag(

--- a/src/denovo_discovery/discover_main.cpp
+++ b/src/denovo_discovery/discover_main.cpp
@@ -67,6 +67,17 @@ void setup_discover_subcommand(CLI::App& app)
         ->group("Mapping");
 
     discover_subcmd
+        ->add_option(
+            "-r,--rng-seed", opt->rng_seed, "RNG seed, an int>0 to force deterministic "
+                                            "mapping when multiple optimal mappings are"
+                                            "possible. To be avoided except in "
+                                            "debugging/investigation scenarios. A value "
+                                            "of 0 will be interpreted as no seed given "
+                                            "and mapping will not be deterministic.")
+        ->capture_default_str()
+        ->group("Mapping");
+
+    discover_subcmd
         ->add_flag("--kg", opt->output_kg,
             "Save kmer graphs with forward and reverse coverage annotations for found "
             "loci")
@@ -190,7 +201,7 @@ void pandora_discover_core(const SampleData& sample, Index &index, DiscoverOptio
     uint32_t covg
         = pangraph_from_read_file(sample, pangraph, index, opt.max_diff, opt.error_rate, sample_outdir,
         opt.min_cluster_size, opt.genome_size, opt.max_covg,
-        opt.threads, opt.keep_extra_debugging_files);
+        opt.threads, opt.keep_extra_debugging_files, opt.rng_seed);
 
     if (pangraph->nodes.empty()) {
         BOOST_LOG_TRIVIAL(warning)

--- a/src/denovo_discovery/discover_main.cpp
+++ b/src/denovo_discovery/discover_main.cpp
@@ -79,11 +79,6 @@ void setup_discover_subcommand(CLI::App& app)
         ->group("Preset");
 
     discover_subcmd
-        ->add_flag(
-            "--clean", opt->clean, "Add a step to clean and detangle the pangraph")
-        ->group("Filtering");
-
-    discover_subcmd
         ->add_flag("--bin", opt->binomial,
             "Use binomial model for kmer coverages [default: negative binomial]")
         ->group("Parameter Estimation");
@@ -194,7 +189,7 @@ void pandora_discover_core(const SampleData& sample, Index &index, DiscoverOptio
     auto pangraph = std::make_shared<pangenome::Graph>();
     uint32_t covg
         = pangraph_from_read_file(sample, pangraph, index, opt.max_diff, opt.error_rate, sample_outdir,
-        opt.min_cluster_size, opt.genome_size, opt.illumina, opt.clean, opt.max_covg,
+        opt.min_cluster_size, opt.genome_size, opt.max_covg,
         opt.threads, opt.keep_extra_debugging_files);
 
     if (pangraph->nodes.empty()) {

--- a/src/denovo_discovery/discover_main.cpp
+++ b/src/denovo_discovery/discover_main.cpp
@@ -67,17 +67,6 @@ void setup_discover_subcommand(CLI::App& app)
         ->group("Mapping");
 
     discover_subcmd
-        ->add_option(
-            "-r,--rng-seed", opt->rng_seed, "RNG seed, an int>0 to force deterministic "
-                                            "mapping when multiple optimal mappings are"
-                                            "possible. To be avoided except in "
-                                            "debugging/investigation scenarios. A value "
-                                            "of 0 will be interpreted as no seed given "
-                                            "and mapping will not be deterministic.")
-        ->capture_default_str()
-        ->group("Mapping");
-
-    discover_subcmd
         ->add_flag("--kg", opt->output_kg,
             "Save kmer graphs with forward and reverse coverage annotations for found "
             "loci")
@@ -174,6 +163,17 @@ void setup_discover_subcommand(CLI::App& app)
 
     discover_subcmd->add_flag(
         "-v", opt->verbosity, "Verbosity of logging. Repeat for increased verbosity");
+
+    discover_subcmd
+        ->add_option(
+            "-r,--rng-seed", opt->rng_seed, "RNG seed, an int>0 to force deterministic "
+                                            "mapping when multiple optimal mappings are "
+                                            "possible. To be avoided except in "
+                                            "debugging/investigation scenarios. A value "
+                                            "of 0 will be interpreted as no seed given "
+                                            "and mapping will not be deterministic.")
+        ->capture_default_str()
+        ->group("Debugging");
 
     // Set the function that will be called when this subcommand is issued.
     discover_subcmd->callback([opt]() { pandora_discover(*opt); });

--- a/src/kmergraphwithcoverage.cpp
+++ b/src/kmergraphwithcoverage.cpp
@@ -1,6 +1,5 @@
 #include <sstream>
 #include <limits>
-#include <cstdlib> /* srand, rand */
 #include <cmath>
 
 #include <boost/math/distributions/negative_binomial.hpp>
@@ -327,38 +326,6 @@ float KmerGraphWithCoverage::find_max_path(std::vector<KmerNodePtr>& maxpath,
     return prob_path(maxpath, sample_id, prob_model);
 }
 
-std::vector<std::vector<KmerNodePtr>> KmerGraphWithCoverage::get_random_paths(
-    uint32_t num_paths)
-{
-    // find a random path through kmergraph picking ~uniformly from the outnodes at each
-    // point
-    std::vector<std::vector<KmerNodePtr>> rpaths;
-    std::vector<KmerNodePtr> rpath;
-    uint32_t i;
-
-    time_t now;
-    now = time(nullptr);
-    srand((unsigned int)now);
-
-    if (!kmer_prg->nodes.empty()) {
-        for (uint32_t j = 0; j != num_paths; ++j) {
-            i = rand() % kmer_prg->nodes[0]->out_nodes.size();
-            rpath.push_back(kmer_prg->nodes[0]->out_nodes[i].lock());
-            while (rpath.back() != kmer_prg->nodes[kmer_prg->nodes.size() - 1]) {
-                if (rpath.back()->out_nodes.size() == 1) {
-                    rpath.push_back(rpath.back()->out_nodes[0].lock());
-                } else {
-                    i = rand() % rpath.back()->out_nodes.size();
-                    rpath.push_back(rpath.back()->out_nodes[i].lock());
-                }
-            }
-            rpath.pop_back();
-            rpaths.push_back(rpath);
-            rpath.clear();
-        }
-    }
-    return rpaths;
-}
 
 float KmerGraphWithCoverage::prob_path(const std::vector<KmerNodePtr>& kpath,
     const uint32_t& sample_id, const std::string& prob_model)

--- a/src/localPRG.cpp
+++ b/src/localPRG.cpp
@@ -1835,17 +1835,6 @@ void LocalPRG::add_variants_to_vcf(VCF& master_vcf, pangenome::NodePtr pnode,
     }
 }
 
-std::string LocalPRG::random_path()
-{
-    std::vector<LocalNodePtr> npath;
-    npath.push_back(prg.nodes.at(0));
-    while (not npath.back()->outNodes.empty()) {
-        uint32_t random_number = rand() % npath.back()->outNodes.size();
-        npath.push_back(npath.back()->outNodes[random_number]);
-    }
-    return string_along_path(npath);
-}
-
 bool operator!=(
     const std::vector<KmerNodePtr>& lhs, const std::vector<KmerNodePtr>& rhs)
 {

--- a/src/map_main.cpp
+++ b/src/map_main.cpp
@@ -69,17 +69,6 @@ void setup_map_subcommand(CLI::App& app)
         ->group("Mapping");
 
     map_subcmd
-        ->add_option(
-            "-r,--rng-seed", opt->rng_seed, "RNG seed, an int>0 to force deterministic "
-                                            "mapping when multiple optimal mappings are"
-                                            "possible. To be avoided except in "
-                                            "debugging/investigation scenarios. A value "
-                                            "of 0 will be interpreted as no seed given "
-                                            "and mapping will not be deterministic.")
-        ->capture_default_str()
-        ->group("Mapping");
-
-    map_subcmd
         ->add_flag("--kg", opt->output_kg,
             "Save kmer graphs with forward and reverse coverage annotations for found "
             "loci")
@@ -229,6 +218,17 @@ void setup_map_subcommand(CLI::App& app)
         ->add_flag("-K,--debugging-files", opt->keep_extra_debugging_files,
             "Keep extra debugging files. Warning: this might "
             "create thousands of files.")
+        ->group("Debugging");
+
+    map_subcmd
+        ->add_option(
+            "-r,--rng-seed", opt->rng_seed, "RNG seed, an int>0 to force deterministic "
+                                            "mapping when multiple optimal mappings are "
+                                            "possible. To be avoided except in "
+                                            "debugging/investigation scenarios. A value "
+                                            "of 0 will be interpreted as no seed given "
+                                            "and mapping will not be deterministic.")
+        ->capture_default_str()
         ->group("Debugging");
 
     map_subcmd->add_flag(

--- a/src/map_main.cpp
+++ b/src/map_main.cpp
@@ -69,6 +69,17 @@ void setup_map_subcommand(CLI::App& app)
         ->group("Mapping");
 
     map_subcmd
+        ->add_option(
+            "-r,--rng-seed", opt->rng_seed, "RNG seed, an int>0 to force deterministic "
+                                            "mapping when multiple optimal mappings are"
+                                            "possible. To be avoided except in "
+                                            "debugging/investigation scenarios. A value "
+                                            "of 0 will be interpreted as no seed given "
+                                            "and mapping will not be deterministic.")
+        ->capture_default_str()
+        ->group("Mapping");
+
+    map_subcmd
         ->add_flag("--kg", opt->output_kg,
             "Save kmer graphs with forward and reverse coverage annotations for found "
             "loci")
@@ -279,7 +290,7 @@ int pandora_map(MapOptions& opt)
     uint32_t covg
         = pangraph_from_read_file(sample, pangraph, index, opt.max_diff, opt.error_rate,
             opt.outdir, opt.min_cluster_size, opt.genome_size, opt.max_covg,
-        opt.threads, opt.keep_extra_debugging_files);
+        opt.threads, opt.keep_extra_debugging_files, opt.rng_seed);
 
     if (pangraph->nodes.empty()) {
         BOOST_LOG_TRIVIAL(info) << "Found none of the LocalPRGs in the reads.";

--- a/src/map_main.cpp
+++ b/src/map_main.cpp
@@ -85,11 +85,6 @@ void setup_map_subcommand(CLI::App& app)
         ->group("Preset");
 
     map_subcmd
-        ->add_flag(
-            "--clean", opt->clean, "Add a step to clean and detangle the pangraph")
-        ->group("Filtering");
-
-    map_subcmd
         ->add_flag("--bin", opt->binomial,
             "Use binomial model for kmer coverages [default: negative binomial]")
         ->group("Parameter Estimation");
@@ -283,7 +278,7 @@ int pandora_map(MapOptions& opt)
     auto pangraph = std::make_shared<pangenome::Graph>();
     uint32_t covg
         = pangraph_from_read_file(sample, pangraph, index, opt.max_diff, opt.error_rate,
-            opt.outdir, opt.min_cluster_size, opt.genome_size, opt.illumina, opt.clean, opt.max_covg,
+            opt.outdir, opt.min_cluster_size, opt.genome_size, opt.max_covg,
         opt.threads, opt.keep_extra_debugging_files);
 
     if (pangraph->nodes.empty()) {

--- a/src/random_main.cpp
+++ b/src/random_main.cpp
@@ -1,5 +1,6 @@
 #include "random_main.h"
 #include "cli_helpers.h"
+#include <random>
 
 void setup_random_subcommand(CLI::App& app)
 {
@@ -45,12 +46,14 @@ int pandora_random_path(RandomOptions const& opt)
     BOOST_LOG_TRIVIAL(info) << "Index loaded successfully!";
 
     Fastaq fa(opt.compress, false);
+    std::random_device random_dev;
+    std::mt19937 rng(random_dev());
 
     for (const auto& prg_ptr : index.get_loaded_prgs()) {
         std::unordered_set<std::string> random_paths;
         auto skip = 0;
         while (random_paths.size() < opt.num_paths and skip < 10) {
-            auto spath = prg_ptr->random_path();
+            auto spath = prg_ptr->random_path(rng);
             if (random_paths.find(spath) != random_paths.end()) {
                 skip += 1;
             } else {

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -458,6 +458,9 @@ void add_clusters_to_pangraph(
     Index &index, uint32_t sample_id)
 {
     BOOST_LOG_TRIVIAL(trace) << "Add clusters to PanGraph";
+    if (minimizer_hit_clusters.empty()) {
+        return;
+    }
 
     for (const auto &cluster : minimizer_hit_clusters) {
         // each cluster here defines a mapping, so we know which prgs mapped
@@ -645,14 +648,12 @@ uint32_t pangraph_from_read_file(const SampleData& sample,
                 const std::string sam_record = filtered_mappings.get_sam_record_from_hit_cluster(
                     sequence, clusters_of_hits);
 
-                if (!clusters_of_hits.empty()) {
 #pragma omp critical(pangraph)
-                    {
-                        add_clusters_to_pangraph(clusters_of_hits, pangraph, index, 0);
-                        filtered_mappings.write_sam_record(sam_record);
-                        if (!paf_file.is_fake_file) {
-                            paf_file.write_clusters(sequence, clusters_of_hits);
-                        }
+                {
+                    add_clusters_to_pangraph(clusters_of_hits, pangraph, index, 0);
+                    filtered_mappings.write_sam_record(sam_record);
+                    if (!paf_file.is_fake_file) {
+                        paf_file.write_clusters(sequence, clusters_of_hits);
                     }
                 }
             }

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -24,15 +24,10 @@
 #include <fcntl.h>
 #include <stdlib.h>
 #include <unistd.h>
-#include <string.h>
 #include <cstdio>
 #include <stdexcept>
 #include <string>
 #include <array>
-#include <random>
-
-#include <cstdio>
-#include <sys/wait.h>
 
 std::string now()
 {
@@ -294,10 +289,11 @@ MinimizerHitClusters filter_clusters(
     const Seq &seq,
     const MinimizerHitClusters& clusters_of_hits,
     const std::vector<std::string> &prg_names,
-    ClusterFilterFile& cluster_filter_file)
+    ClusterFilterFile& cluster_filter_file,
+    const uint32_t rng_seed)
 {
     const std::string tag = "[Sample: " + sample_name + ", read index: " + to_string(seq.id) + "]: ";
-    MinimizerHitClusters filtered_clusters_of_hits;
+    MinimizerHitClusters filtered_clusters_of_hits(rng_seed);
 
     // Next order clusters, choose between those that overlap by too much
     BOOST_LOG_TRIVIAL(trace) << tag << "Filter the " << clusters_of_hits.size()
@@ -492,10 +488,11 @@ MinimizerHitClusters get_minimizer_hit_clusters(
     ClusterDefFile &cluster_def_file,
     ClusterFilterFile &cluster_filter_file,
     const uint32_t min_cluster_size,
-    const uint32_t expected_number_kmers_in_read_sketch)
+    const uint32_t expected_number_kmers_in_read_sketch,
+    const uint32_t rng_seed)
 {
     const std::string tag = "[Sample: " + sample_name + ", read index: " + to_string(seq.id) + "]: ";
-    MinimizerHitClusters minimizer_hit_clusters;
+    MinimizerHitClusters minimizer_hit_clusters(rng_seed);
 
     if (minimizer_hits->empty()) {
         minimizer_hit_clusters.finalise_insertions();
@@ -521,8 +518,8 @@ uint32_t pangraph_from_read_file(const SampleData& sample,
     std::shared_ptr<pangenome::Graph> pangraph, Index &index,
     const int max_diff, const float& e_rate,
     const fs::path& sample_outdir, const uint32_t min_cluster_size,
-    const uint32_t genome_size, const bool illumina, const bool clean,
-    const uint32_t max_covg, uint32_t threads, const bool keep_extra_debugging_files)
+    const uint32_t genome_size, const uint32_t max_covg, uint32_t threads,
+    const bool keep_extra_debugging_files, const uint32_t rng_seed)
 {
     // constant variables
     const SampleIdText sample_name = sample.first;
@@ -643,7 +640,8 @@ uint32_t pangraph_from_read_file(const SampleData& sample,
                         index.get_prg_min_path_lengths(), index.get_prg_names(),
                         minimizer_hits, pangraph, max_diff, genome_size,
                         fraction_kmers_required_for_cluster, cluster_def_file,
-                        cluster_filter_file, min_cluster_size, expected_number_kmers_in_read_sketch);
+                        cluster_filter_file, min_cluster_size,
+                        expected_number_kmers_in_read_sketch, rng_seed);
 
                 const std::string sam_record = filtered_mappings.get_sam_record_from_hit_cluster(
                     sequence, clusters_of_hits);
@@ -695,23 +693,6 @@ void open_file_for_appending(const std::string& file_path, std::ofstream& stream
     if (!stream.is_open()) {
         fatal_error("Error opening file ", file_path);
     }
-}
-
-// read all strings in the readsFile file and return them as a vector of strings
-std::vector<std::string> get_vector_of_strings_from_file(const std::string& file_path)
-{
-    std::vector<std::string> lines;
-    std::string line;
-
-    std::ifstream in_file;
-    open_file_for_reading(file_path, in_file);
-    while (getline(in_file, line)) {
-        if (line.size() > 0)
-            lines.push_back(line);
-    }
-    in_file.close();
-
-    return lines;
 }
 
 uint32_t strtogs(const char* str)
@@ -799,32 +780,11 @@ std::pair<int, std::string> build_memfd(const std::string &data) {
     return std::make_pair(fd, ss_filepath.str());
 }
 
-// From https://stackoverflow.com/a/478960/5264075
-// Exec a command and returns stdout
-std::string exec(const char* cmd) {
-    BOOST_LOG_TRIVIAL(debug) << "Running " << cmd;
-    std::array<char, 4096> buffer;
-    std::string result;
-    std::unique_ptr<FILE, decltype(&pclose)> pipe(popen(cmd, "r"), pclose);
-    if (!pipe) {
-        throw std::runtime_error("popen() failed!");
-    }
-    while (fgets(buffer.data(), buffer.size(), pipe.get()) != nullptr) {
-        result += buffer.data();
-    }
-    return result;
-}
-
 void build_file(const std::string &filepath, const std::string &data) {
     std::ofstream output_file;
     open_file_for_writing(filepath, output_file);
     output_file.write(data.c_str(), data.size());
     output_file.close();
-}
-
-bool tool_exists(const std::string &command) {
-    int ret = std::system(command.c_str());
-    return WEXITSTATUS(ret) == 0;
 }
 
 void concatenate_text_files(
@@ -859,14 +819,6 @@ std::string reverse_complement(const std::string& forward)
     }
     reverse[len] = '\0';
     return reverse;
-}
-
-int random_int()
-{
-    static std::random_device dev;
-    static std::mt19937 rng(dev());
-    static std::uniform_int_distribution<std::mt19937::result_type> dist;
-    return dist(rng);
 }
 
 std::pair<std::vector<std::string>, std::vector<size_t>> split_ambiguous(const std::string& input_string, uint8_t delim)

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -484,7 +484,7 @@ MinimizerHitClusters get_minimizer_hit_clusters(
     const std::vector<std::string> &prg_names,
     std::shared_ptr<MinimizerHits> minimizer_hits,
     std::shared_ptr<pangenome::Graph> pangraph, const int max_diff,
-    const uint32_t& genome_size, const float& fraction_kmers_required_for_cluster,
+    const float& fraction_kmers_required_for_cluster,
     ClusterDefFile &cluster_def_file,
     ClusterFilterFile &cluster_filter_file,
     const uint32_t min_cluster_size,
@@ -638,7 +638,7 @@ uint32_t pangraph_from_read_file(const SampleData& sample,
                 MinimizerHitClusters clusters_of_hits =
                     get_minimizer_hit_clusters(sample_name, sequence,
                         index.get_prg_min_path_lengths(), index.get_prg_names(),
-                        minimizer_hits, pangraph, max_diff, genome_size,
+                        minimizer_hits, pangraph, max_diff,
                         fraction_kmers_required_for_cluster, cluster_def_file,
                         cluster_filter_file, min_cluster_size,
                         expected_number_kmers_in_read_sketch, rng_seed);


### PR DESCRIPTION
This PR contains several misc small fixes:
1. Fixes a segfault bug with getting the wrong pangraph node, introduced in the previous PR;
2. Fixes a minor bug that caused unmapped reads to be suppressed in the file SAM;
3. Removes the `--clean` command line option, redundant now that gene-DBGs code were removed;
4. Adds CLI option `--rng-seed` to make multimapping deterministic, if required;
5. A handful of clean ups of unused code;