### PR TITLE
Fix to finding the longest path through PRGs

### DIFF
--- a/include/index.h
+++ b/include/index.h
@@ -39,7 +39,7 @@ protected:
 
     // required to map to PRGs without actually loading them
     std::vector<uint32_t> prg_lengths;
-    std::vector<uint32_t> prg_min_path_lengths;
+    std::vector<uint32_t> prg_max_path_lengths;
     std::shared_ptr<ZipFileReader> zip_file;
 
     // populated when loading an index - just valid for index consumption commands
@@ -59,17 +59,17 @@ protected:
         w(w), k(k), prg_names(std::move(prg_names)),
         prg_names_to_ids(this->prg_names.size()), prg_lengths(std::move(prg_lengths)),
         prgs(this->prg_names.size(), nullptr) {
-        prg_min_path_lengths.reserve(get_number_of_prgs());
+        prg_max_path_lengths.reserve(get_number_of_prgs());
         init_prg_names_to_ids();
     }
 
     // constructor to be used when LOADING an index from disk
     Index(const uint32_t w, const uint32_t k, std::vector<std::string> &&prg_names,
-        std::vector<uint32_t> &&prg_lengths, std::vector<uint32_t> &&prg_min_path_lengths,
+        std::vector<uint32_t> &&prg_lengths, std::vector<uint32_t> &&prg_max_path_lengths,
         const std::shared_ptr<ZipFileReader> &zip_file) :
         w(w), k(k), prg_names(std::move(prg_names)),
         prg_names_to_ids(this->prg_names.size()), prg_lengths(std::move(prg_lengths)),
-        prg_min_path_lengths(std::move(prg_min_path_lengths)), zip_file(zip_file),
+        prg_max_path_lengths(std::move(prg_max_path_lengths)), zip_file(zip_file),
         prgs(this->prg_names.size(), nullptr) {
         init_prg_names_to_ids();
     }
@@ -116,9 +116,9 @@ protected:
         save_values(index_archive, "_prg_lengths",
             prg_lengths.begin(), prg_lengths.end());
     }
-    inline void save_prg_min_path_lengths(ZipFileWriter &index_archive) const {
-        save_values(index_archive, "_prg_min_path_lengths",
-            prg_min_path_lengths.begin(), prg_min_path_lengths.end());
+    inline void save_prg_max_path_lengths(ZipFileWriter &index_archive) const {
+        save_values(index_archive, "_prg_max_path_lengths",
+            prg_max_path_lengths.begin(), prg_max_path_lengths.end());
     }
     inline void save_metadata(ZipFileWriter &index_archive) const {
         std::vector<uint32_t> metadata{w, k};
@@ -213,11 +213,11 @@ public:
         return prg_lengths[id];
     }
 
-    inline const std::vector<uint32_t> & get_prg_min_path_lengths() const {
-        return prg_min_path_lengths;
+    inline const std::vector<uint32_t> & get_prg_max_path_lengths() const {
+        return prg_max_path_lengths;
     }
-    inline uint32_t get_prg_min_path_lengths_given_id(size_t id) const {
-        return prg_min_path_lengths[id];
+    inline uint32_t get_prg_max_path_lengths_given_id(size_t id) const {
+        return prg_max_path_lengths[id];
     }
 
     inline std::vector<std::shared_ptr<LocalPRG>> get_loaded_prgs() const {

--- a/include/kmergraph.h
+++ b/include/kmergraph.h
@@ -59,7 +59,7 @@ public:
 
     void discover_k();
 
-    uint32_t min_path_length() const;
+    uint32_t max_path_length() const;
 
     // get the KmerGraph as gfa
     std::string to_gfa(const std::shared_ptr<LocalPRG> localprg = nullptr) const;

--- a/include/kmergraph.h
+++ b/include/kmergraph.h
@@ -32,7 +32,6 @@ private:
     uint32_t k;
 
 public:
-    uint32_t shortest_path_length;
     std::vector<KmerNodePtr> nodes;
     std::set<KmerNodePtr, pCompKmerNode>
         sorted_nodes; // representing ordering of the nodes compatible with dp
@@ -60,7 +59,7 @@ public:
 
     void discover_k();
 
-    uint32_t min_path_length();
+    uint32_t min_path_length() const;
 
     // get the KmerGraph as gfa
     std::string to_gfa(const std::shared_ptr<LocalPRG> localprg = nullptr) const;

--- a/include/zip_file.h
+++ b/include/zip_file.h
@@ -120,8 +120,8 @@ public:
     inline std::vector<uint32_t> read_prg_lengths() {
         return read_int_values("_prg_lengths");
     }
-    inline std::vector<uint32_t> read_prg_min_path_lengths() {
-        return read_int_values("_prg_min_path_lengths");
+    inline std::vector<uint32_t> read_prg_max_path_lengths() {
+        return read_int_values("_prg_max_path_lengths");
     }
     ////////////////////////////////////////////////////////////////////////////////////
 

--- a/src/kmergraph.cpp
+++ b/src/kmergraph.cpp
@@ -420,28 +420,24 @@ void KmerGraph::load(std::stringstream &gfa_stream)
     }
 }
 
-uint32_t KmerGraph::min_path_length() const
+uint32_t KmerGraph::max_path_length() const
 {
     std::vector<KmerNodePtr> sorted_nodes(
         this->sorted_nodes.begin(), this->sorted_nodes.end());
 
-    // length of shortest path from node i to end of graph
-    std::vector<uint32_t> id_to_len(sorted_nodes.size(), 0);
+    std::vector<uint32_t> id_to_max_len(sorted_nodes.size(), 0);
     for (uint32_t j = sorted_nodes.size() - 1; j != 0; --j) {
         auto& current_node = sorted_nodes[j-1];
-        auto& current_node_len = id_to_len[current_node->id];
+        auto& current_node_len = id_to_max_len[current_node->id];
         for (auto& weak_out_node : current_node->out_nodes) {
             auto out_node = weak_out_node.lock();
-            auto out_node_len = id_to_len[out_node->id];
-            bool found_longer_path = out_node_len + 1 > current_node_len;
-            if (found_longer_path) {
-                current_node_len = out_node_len + 1;
-            }
+            const auto out_node_len = id_to_max_len[out_node->id];
+            current_node_len = std::max(current_node_len, out_node_len + 1);
         }
     }
 
-    uint32_t shortest_path_length = id_to_len[0];
-    return shortest_path_length;
+    uint32_t max_path_length = id_to_max_len[0];
+    return max_path_length;
 }
 
 bool KmerGraph::operator==(const KmerGraph& other_graph) const

--- a/src/kmergraph.cpp
+++ b/src/kmergraph.cpp
@@ -13,14 +13,12 @@ using namespace prg;
 
 KmerGraph::KmerGraph()
 {
-    shortest_path_length = 0;
     k = 0; // nb the kmer size is determined by the first non-null node added
 }
 
 // copy constructor
 KmerGraph::KmerGraph(const KmerGraph& other)
 {
-    shortest_path_length = other.shortest_path_length;
     k = other.k;
     KmerNodePtr n;
 
@@ -55,7 +53,6 @@ KmerGraph& KmerGraph::operator=(const KmerGraph& other)
     nodes.reserve(other.nodes.size());
 
     // shallow copy no pointers
-    shortest_path_length = other.shortest_path_length;
     k = other.k;
     KmerNodePtr n;
 
@@ -80,7 +77,6 @@ void KmerGraph::clear()
 {
     nodes.clear();
     sorted_nodes.clear();
-    shortest_path_length = 0;
     k = 0;
 }
 
@@ -424,27 +420,28 @@ void KmerGraph::load(std::stringstream &gfa_stream)
     }
 }
 
-uint32_t KmerGraph::min_path_length()
+uint32_t KmerGraph::min_path_length() const
 {
-    // TODO: FIX THIS INNEFICIENCY I INTRODUCED
     std::vector<KmerNodePtr> sorted_nodes(
         this->sorted_nodes.begin(), this->sorted_nodes.end());
 
-    if (shortest_path_length > 0) {
-        return shortest_path_length;
-    }
-
-    std::vector<uint32_t> len(
-        sorted_nodes.size(), 0); // length of shortest path from node i to end of graph
+    // length of shortest path from node i to end of graph
+    std::vector<uint32_t> id_to_len(sorted_nodes.size(), 0);
     for (uint32_t j = sorted_nodes.size() - 1; j != 0; --j) {
-        for (uint32_t i = 0; i != sorted_nodes[j - 1]->out_nodes.size(); ++i) {
-            if (len[sorted_nodes[j - 1]->out_nodes[i].lock()->id] + 1 > len[j - 1]) {
-                len[j - 1] = len[sorted_nodes[j - 1]->out_nodes[i].lock()->id] + 1;
+        auto& current_node = sorted_nodes[j-1];
+        auto& current_node_len = id_to_len[current_node->id];
+        for (auto& weak_out_node : current_node->out_nodes) {
+            auto out_node = weak_out_node.lock();
+            auto out_node_len = id_to_len[out_node->id];
+            bool found_longer_path = out_node_len + 1 > current_node_len;
+            if (found_longer_path) {
+                current_node_len = out_node_len + 1;
             }
         }
     }
-    shortest_path_length = len[0];
-    return len[0];
+
+    uint32_t shortest_path_length = id_to_len[0];
+    return shortest_path_length;
 }
 
 bool KmerGraph::operator==(const KmerGraph& other_graph) const

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -635,7 +635,7 @@ uint32_t pangraph_from_read_file(const SampleData& sample,
                 // infer the clusters of hits
                 MinimizerHitClusters clusters_of_hits =
                     get_minimizer_hit_clusters(sample_name, sequence,
-                        index.get_prg_min_path_lengths(), index.get_prg_names(),
+                        index.get_prg_max_path_lengths(), index.get_prg_names(),
                         minimizer_hits, max_diff,
                         fraction_kmers_required_for_cluster, cluster_def_file,
                         cluster_filter_file, min_cluster_size,


### PR DESCRIPTION
## Summary 

@Danderson123 found a strange issue that was happening in `pandora`. Basically he had a long MSA, created a PRG from it, and when indexing, `pandora` was saying the longest path through that gene had 7 minimising kmers (well the story is not exactly this, but after some debugging, we found out this was the issue). The longest path through that gene actually has 241 minimising kmers. There was a big bug when calculating the maximum path through a gene, mostly affecting cases when reads are longer than genes, i.e. ONT reads. This PR is a tentative fix to this, but I'd like to run this on some real data to measure the effect of this fix.

## Preliminary

`KmerGraph::min_path_length()` had a semantic and an implementation bug. The semantic bug is that this method actually retrieves the length of the max path in the kmer DAG instead of the min path. This is fixed in this PR, and from this point on I will refer to this method as `KmerGraph::max_path_length()`. The implementation bug is that when computing the length of the max path, we use a length vector that is indexed in two different ways, e.g. one is using the index of the kmers sorted by their PRG paths, e.g.:
```
len[j - 1]
```
and the other is using the Kmer node id, which is the index of the kmers sorted topologically, e.g.:
```
len[sorted_nodes[j - 1]->out_nodes[i].lock()->id]
```

Although these indexes somehow overlap, i.e. the order of the kmer nodes sorted by PRG paths and topologically are similar, they are not identical, and in non-trivial PRGs there can be significant differences. Just the fact of accessing a data structure with two different set of indexes is already problematic.

## Solution

We are now just using a single way to access this length vector (the index of the kmers sorted topologically)

## Misc

This PR also contains some refactors to `KmerGraph::max_path_length()`.

## TODO

Need to test the effect of this fix. It definitely affects our ONT results, but I am not sure if it is a small or large effect. I will be testing on the 4-way. It would be really helpful if @mbhall88 could test this on the DrPRG evaluation and @Danderson123 on the Amira evaluation. Please note that this version of `pandora` has changes from the several previous PRs incorporated, and you might need to tweak some parameters in order to not have some genes filtered out. Notably, when running map/discover/compare `--genome-size` need to be tweaked to the expected genome size of your samples. Also, by default, all genes with mean kmer coverage < 3 will be removed (change this with `--min-abs-gene-coverage`), all genes with mean kmer coverage < 5% of the sample coverage will be removed (change this with `--min-rel-gene-coverage`) and all genes with mean kmer coverage > 100x of the sample coverage will be removed (change this with `--max-rel-gene-coverage`). This is a notable change from previous versions of `pandora`, especially for small datasets, where these values were hard-coded, different, and were just triggered if the sample coverage was >= 20x (i.e. if you had a toy dataset, these filters wouldn't trigger whereas now they do). Also please do use the `--debugging-files` flag so that we can debug the run later if required.

I am assuming you will run this in codon, so I will soon give you a path to an executable in codon that you can use